### PR TITLE
Update the behavior of backend.FetchMatches

### DIFF
--- a/internal/app/backend/backend_service.go
+++ b/internal/app/backend/backend_service.go
@@ -133,7 +133,7 @@ func (s *backendService) FetchMatches(req *pb.FetchMatchesRequest, stream pb.Bac
 		}
 	}(resultChan)
 
-	proposals := make(*pb.Match)
+	proposals := []*pb.Match{}
 
 	// Query if mmf encounters any errors in any of the profiles
 	for result := range resultChan {
@@ -157,7 +157,7 @@ func (s *backendService) FetchMatches(req *pb.FetchMatchesRequest, stream pb.Bac
 	}
 
 	for _, proposal := range proposals {
-		err = stream.Send(&pb.FetchMatchesResponse{Match: match})
+		err = stream.Send(&pb.FetchMatchesResponse{Match: proposal})
 		if err != nil {
 			logger.WithError(err).Error("failed to stream back the response")
 			return err

--- a/internal/app/backend/backend_service.go
+++ b/internal/app/backend/backend_service.go
@@ -60,6 +60,8 @@ var (
 // specified MatchProfiles. Each MatchFunction execution returns a set of
 // proposals which are then evaluated to generate results. FetchMatches method
 // streams these results back to the caller.
+// FetchMatches returns nil unless the context is canceled. FetchMatches moves to the next response candidate if it encounters
+// any internal execution failures.
 func (s *backendService) FetchMatches(req *pb.FetchMatchesRequest, stream pb.Backend_FetchMatchesServer) error {
 	// Validate that the function configuration and match profiles are provided.
 	if req.Config == nil {


### PR DESCRIPTION
Per discussion, `backend.FetchMatches` returns safely unless the context is canceled. FetchMatches moves to the next response candidate if it encounters any internal issues