### PR TITLE
Fix helm deletion error

### DIFF
--- a/install/helm/open-match/values.yaml
+++ b/install/helm/open-match/values.yaml
@@ -330,6 +330,7 @@ prometheus:
               target_label: kubernetes_pod_name
 
 grafana:
+  enabled: true
   persistence:
     enabled: true
   server:


### PR DESCRIPTION
Resolves #217. `.Values.grafana.enabled` is not set so what being passed to helm from `templates/grafana-dashboards.yaml` is empty, which turns into a deletion error since this template does not have a valid object to be deleted. 