### PR TITLE
Update golangci version and enable it in presubmit check

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -198,6 +198,7 @@ issues:
     - path: _test\.go
       linters:
         - errcheck
+        - bodyclose
     # The following are allowed global variable patterns.
     # Generally it's ok to have constants or variables that effectively act as constants such as a static logger or flag values.
     # The filters below specify the source code pattern that's allowed when declaring a global

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ NODEJS_VERSION = 10.15.3
 SKAFFOLD_VERSION = latest
 MINIKUBE_VERSION = latest
 HTMLTEST_VERSION = 0.10.3
-GOLANGCI_VERSION = 1.16.0
+GOLANGCI_VERSION = 1.17.1
 KIND_VERSION = 0.3.0
 SWAGGERUI_VERSION = 3.22.2
 
@@ -681,7 +681,7 @@ vet:
 golangci: build/toolchain/bin/golangci-lint$(EXE_EXTENSION)
 	build/toolchain/bin/golangci-lint$(EXE_EXTENSION) run --config=.golangci.yaml
 
-lint: fmt vet lint-chart
+lint: golangci lint-chart
 
 all: service-binaries example-binaries tools-binaries
 

--- a/internal/rpc/clients_test.go
+++ b/internal/rpc/clients_test.go
@@ -118,7 +118,11 @@ func runHTTPClientTests(assert *assert.Assertions, cfg config.View, rpcParams *S
 	httpResp, err := httpClient.Do(httpReq)
 	assert.Nil(err)
 	assert.NotNil(httpResp)
-	defer httpResp.Body.Close()
+	defer func() {
+		if httpResp != nil {
+			httpResp.Body.Close()
+		}
+	}()
 
 	body, err := ioutil.ReadAll(httpResp.Body)
 	assert.Nil(err)

--- a/internal/rpc/clients_test.go
+++ b/internal/rpc/clients_test.go
@@ -118,6 +118,7 @@ func runHTTPClientTests(assert *assert.Assertions, cfg config.View, rpcParams *S
 	httpResp, err := httpClient.Do(httpReq)
 	assert.Nil(err)
 	assert.NotNil(httpResp)
+	defer httpResp.Body.Close()
 
 	body, err := ioutil.ReadAll(httpResp.Body)
 	assert.Nil(err)

--- a/internal/rpc/server_test.go
+++ b/internal/rpc/server_test.go
@@ -95,8 +95,11 @@ func runGrpcWithProxyTests(assert *assert.Assertions, s grpcServerWithProxy, con
 	httpResp, err := httpClient.Do(httpReq)
 	assert.Nil(err)
 	assert.NotNil(httpResp)
-	defer httpResp.Body.Close()
-
+	defer func() {
+		if httpResp != nil {
+			httpResp.Body.Close()
+		}
+	}()
 	body, err := ioutil.ReadAll(httpResp.Body)
 	assert.Nil(err)
 	assert.Equal(200, httpResp.StatusCode)
@@ -108,7 +111,11 @@ func runGrpcWithProxyTests(assert *assert.Assertions, s grpcServerWithProxy, con
 	httpResp, err = httpClient.Do(httpReq)
 	assert.Nil(err)
 	assert.NotNil(httpResp)
-	defer httpResp.Body.Close()
+	defer func() {
+		if httpResp != nil {
+			httpResp.Body.Close()
+		}
+	}()
 	body, err = ioutil.ReadAll(httpResp.Body)
 	assert.Nil(err)
 	assert.Equal(200, httpResp.StatusCode)

--- a/internal/rpc/server_test.go
+++ b/internal/rpc/server_test.go
@@ -95,11 +95,7 @@ func runGrpcWithProxyTests(assert *assert.Assertions, s grpcServerWithProxy, con
 	httpResp, err := httpClient.Do(httpReq)
 	assert.Nil(err)
 	assert.NotNil(httpResp)
-	defer func() {
-		if httpResp != nil {
-			httpResp.Body.Close()
-		}
-	}()
+	defer httpResp.Body.Close()
 
 	body, err := ioutil.ReadAll(httpResp.Body)
 	assert.Nil(err)
@@ -112,6 +108,7 @@ func runGrpcWithProxyTests(assert *assert.Assertions, s grpcServerWithProxy, con
 	httpResp, err = httpClient.Do(httpReq)
 	assert.Nil(err)
 	assert.NotNil(httpResp)
+	defer httpResp.Body.Close()
 	body, err = ioutil.ReadAll(httpResp.Body)
 	assert.Nil(err)
 	assert.Equal(200, httpResp.StatusCode)


### PR DESCRIPTION
Golangci 1.17.1 resolves its original segfault issue. It includes gofmt and govet so I use to replace these two presubmit checks.

This commit disable the `bodyclose` plugin when running golangci against the test files as it only accepts closing the http body with specific pattern.