### PR TITLE
Add frontend corner test cases

### DIFF
--- a/internal/app/frontend/frontend_service.go
+++ b/internal/app/frontend/frontend_service.go
@@ -46,7 +46,7 @@ var (
 // Indexing a Ticket adds the it to the pool of Tickets considered for matchmaking.
 func (s *frontendService) CreateTicket(ctx context.Context, req *pb.CreateTicketRequest) (*pb.CreateTicketResponse, error) {
 	// Perform input validation.
-	if req.Ticket == nil {
+	if req.Ticket == nil || req.Ticket.Properties == nil {
 		logger.Error("invalid argument - ticket cannot be nil")
 		return nil, status.Errorf(codes.InvalidArgument, "ticket cannot be nil")
 	}

--- a/internal/app/frontend/frontend_service.go
+++ b/internal/app/frontend/frontend_service.go
@@ -46,7 +46,7 @@ var (
 // Indexing a Ticket adds the it to the pool of Tickets considered for matchmaking.
 func (s *frontendService) CreateTicket(ctx context.Context, req *pb.CreateTicketRequest) (*pb.CreateTicketResponse, error) {
 	// Perform input validation.
-	if req.Ticket == nil || req.Ticket.Properties == nil {
+	if req.GetTicket() == nil {
 		logger.Error("invalid argument - ticket cannot be nil")
 		return nil, status.Errorf(codes.InvalidArgument, "ticket cannot be nil")
 	}

--- a/internal/statestore/redis.go
+++ b/internal/statestore/redis.go
@@ -275,7 +275,7 @@ func (rb *redisBackend) IndexTicket(ctx context.Context, ticket *pb.Ticket) erro
 		// Alternatives for populating this information in proto fields are being considered.
 		// Also, we need to add Ticket creation time to either the ticket or index.
 		// Meta characters bein specified in JSON property keys is currently not supported.
-		v, ok := ticket.Properties.Fields[attribute]
+		v, ok := ticket.GetProperties().GetFields()[attribute]
 
 		// If this attribute wasn't provided, continue to the next attribute to index.
 		if !ok {


### PR DESCRIPTION
I also modified the sanity check in frontend_service.go to make sure the implementation won't panic if receiving a ticket with ticket.Properties == nil