### PR TITLE
Fix a bug in redis connect

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/fsnotify/fsnotify v1.4.7
 	github.com/gogo/protobuf v1.2.1
 	github.com/golang/protobuf v1.3.1
-	github.com/gomodule/redigo v1.7.0
+	github.com/gomodule/redigo v1.7.1-0.20190322064113-39e2c31b7ca3
 	github.com/grpc-ecosystem/grpc-gateway v1.8.5
 	github.com/openzipkin/zipkin-go v0.1.6
 	github.com/pkg/errors v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -74,8 +74,8 @@ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
-github.com/gomodule/redigo v1.7.0 h1:ZKld1VOtsGhAe37E7wMxEDgAlGM5dvFY+DiOhSkhP9Y=
-github.com/gomodule/redigo v1.7.0/go.mod h1:B4C85qUVwatsJoIUNIfCRsp7qO0iAmpGFZ4EELWSbC4=
+github.com/gomodule/redigo v1.7.1-0.20190322064113-39e2c31b7ca3 h1:6amM4HsNPOvMLVc2ZnyqrjeQ92YAVWn7T4WBKK87inY=
+github.com/gomodule/redigo v1.7.1-0.20190322064113-39e2c31b7ca3/go.mod h1:B4C85qUVwatsJoIUNIfCRsp7qO0iAmpGFZ4EELWSbC4=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=

--- a/internal/statestore/redis.go
+++ b/internal/statestore/redis.go
@@ -68,10 +68,8 @@ func newRedis(cfg config.View) Service {
 		MaxIdle:     cfg.GetInt("redis.pool.maxIdle"),
 		MaxActive:   cfg.GetInt("redis.pool.maxActive"),
 		IdleTimeout: cfg.GetDuration("redis.pool.idleTimeout"),
-		DialContext: func(ctx context.Context) (redis.Conn, error) {
-			if ctx.Err() != nil {
-				return nil, ctx.Err()
-			}
+		Wait:        true,
+		Dial: func() (redis.Conn, error) {
 			return redis.DialURL(redisURL)
 		},
 	}
@@ -79,10 +77,8 @@ func newRedis(cfg config.View) Service {
 		MaxIdle:     1,
 		MaxActive:   2,
 		IdleTimeout: cfg.GetDuration("redis.pool.healthCheckTimeout"),
-		DialContext: func(ctx context.Context) (redis.Conn, error) {
-			if ctx.Err() != nil {
-				return nil, ctx.Err()
-			}
+		Wait:        true,
+		Dial: func() (redis.Conn, error) {
 			return redis.DialURL(redisURL, redis.DialConnectTimeout(cfg.GetDuration("redis.pool.healthCheckTimeout")), redis.DialReadTimeout(cfg.GetDuration("redis.pool.healthCheckTimeout")))
 		},
 	}

--- a/internal/statestore/redis.go
+++ b/internal/statestore/redis.go
@@ -68,13 +68,21 @@ func newRedis(cfg config.View) Service {
 		MaxIdle:     cfg.GetInt("redis.pool.maxIdle"),
 		MaxActive:   cfg.GetInt("redis.pool.maxActive"),
 		IdleTimeout: cfg.GetDuration("redis.pool.idleTimeout"),
-		Dial:        func() (redis.Conn, error) { return redis.DialURL(redisURL) },
+		DialContext: func(ctx context.Context) (redis.Conn, error) {
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+			return redis.DialURL(redisURL)
+		},
 	}
 	healthCheckPool := &redis.Pool{
 		MaxIdle:     1,
 		MaxActive:   2,
 		IdleTimeout: cfg.GetDuration("redis.pool.healthCheckTimeout"),
-		Dial: func() (redis.Conn, error) {
+		DialContext: func(ctx context.Context) (redis.Conn, error) {
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
 			return redis.DialURL(redisURL, redis.DialConnectTimeout(cfg.GetDuration("redis.pool.healthCheckTimeout")), redis.DialReadTimeout(cfg.GetDuration("redis.pool.healthCheckTimeout")))
 		},
 	}

--- a/internal/statestore/redis_test.go
+++ b/internal/statestore/redis_test.go
@@ -34,7 +34,8 @@ import (
 
 func TestStatestoreSetup(t *testing.T) {
 	assert := assert.New(t)
-	cfg := createRedis(t)
+	cfg, closer := createRedis(t)
+	defer closer()
 	service := New(cfg)
 	assert.NotNil(service)
 	defer service.Close()
@@ -43,7 +44,8 @@ func TestStatestoreSetup(t *testing.T) {
 func TestTicketLifecycle(t *testing.T) {
 	// Create State Store
 	assert := assert.New(t)
-	cfg := createRedis(t)
+	cfg, closer := createRedis(t)
+	defer closer()
 	service := New(cfg)
 	assert.NotNil(service)
 	defer service.Close()
@@ -98,7 +100,8 @@ func TestTicketLifecycle(t *testing.T) {
 func TestTicketIndexing(t *testing.T) {
 	// Create State Store
 	assert := assert.New(t)
-	cfg := createRedis(t)
+	cfg, closer := createRedis(t)
+	defer closer()
 	service := New(cfg)
 	assert.NotNil(service)
 	defer service.Close()
@@ -168,7 +171,8 @@ func TestTicketIndexing(t *testing.T) {
 func TestGetAssignmentBeforeSet(t *testing.T) {
 	// Create State Store
 	assert := assert.New(t)
-	cfg := createRedis(t)
+	cfg, closer := createRedis(t)
+	defer closer()
 	service := New(cfg)
 	assert.NotNil(service)
 	defer service.Close()
@@ -187,7 +191,8 @@ func TestGetAssignmentBeforeSet(t *testing.T) {
 func TestUpdateAssignmentFatal(t *testing.T) {
 	// Create State Store
 	assert := assert.New(t)
-	cfg := createRedis(t)
+	cfg, closer := createRedis(t)
+	defer closer()
 	service := New(cfg)
 	assert.NotNil(service)
 	defer service.Close()
@@ -211,7 +216,8 @@ func TestUpdateAssignmentFatal(t *testing.T) {
 func TestGetAssignmentNormal(t *testing.T) {
 	// Create State Store
 	assert := assert.New(t)
-	cfg := createRedis(t)
+	cfg, closer := createRedis(t)
+	defer closer()
 	service := New(cfg)
 	assert.NotNil(service)
 	defer service.Close()
@@ -250,7 +256,8 @@ func TestGetAssignmentNormal(t *testing.T) {
 func TestUpdateAssignmentNormal(t *testing.T) {
 	// Create State Store
 	assert := assert.New(t)
-	cfg := createRedis(t)
+	cfg, closer := createRedis(t)
+	defer closer()
 	service := New(cfg)
 	assert.NotNil(service)
 	defer service.Close()
@@ -283,7 +290,9 @@ func TestUpdateAssignmentNormal(t *testing.T) {
 
 func TestConnect(t *testing.T) {
 	assert := assert.New(t)
-	store := newRedis(createRedis(t))
+	cfg, closer := createRedis(t)
+	defer closer()
+	store := New(cfg)
 	defer store.Close()
 
 	rb, ok := store.(*redisBackend)
@@ -296,7 +305,7 @@ func TestConnect(t *testing.T) {
 	assert.Nil(conn)
 }
 
-func createRedis(t *testing.T) config.View {
+func createRedis(t *testing.T) (config.View, func()) {
 	cfg := viper.New()
 	mredis, err := miniredis.Run()
 	if err != nil {
@@ -317,5 +326,5 @@ func createRedis(t *testing.T) config.View {
 	cfg.Set("backoff.maxElapsedTime", 100*time.Millisecond)
 	cfg.Set("playerIndices", []string{"testindex1", "testindex2"})
 
-	return cfg
+	return cfg, func() {mredis.Close()}
 }

--- a/internal/statestore/redis_test.go
+++ b/internal/statestore/redis_test.go
@@ -281,6 +281,21 @@ func TestUpdateAssignmentNormal(t *testing.T) {
 
 }
 
+func TestConnect(t *testing.T) {
+	assert := assert.New(t)
+	store := newRedis(createRedis(t))
+	defer store.Close()
+
+	rb, ok := store.(*redisBackend)
+	assert.True(ok)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	conn, err := rb.connect(ctx)
+	assert.NotNil(err)
+	assert.Nil(conn)
+}
+
 func createRedis(t *testing.T) config.View {
 	cfg := viper.New()
 	mredis, err := miniredis.Run()


### PR DESCRIPTION
The original implementation is not sensitive to the context, and will return a connection even if a cancelled context is passed into the `redisBackend.connect` function. This requires updating the `redigo` module to the bleeding edge and this `DialContext` instead of calling `Dial`.

This commit also adds a the resource closer to the statestore tests in `statestore/redis_test.go`