### PR TITLE
Temorarily disable md-test CI check

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -52,10 +52,10 @@ steps:
   args: ['--destination=gcr.io/$PROJECT_ID/open-match-build', '--cache=true', '--cache-ttl=48h', '--dockerfile=Dockerfile.ci', '.']
   waitFor: ['-']
 
-- id: 'Test: Markdown'
-  name: 'gcr.io/$PROJECT_ID/open-match-build'
-  args: ['make', 'md-test']
-  waitFor: ['Docker Image: open-match-build']
+# - id: 'Test: Markdown'
+#   name: 'gcr.io/$PROJECT_ID/open-match-build'
+#   args: ['make', 'md-test']
+#   waitFor: ['Docker Image: open-match-build']
 
 - id: 'Build: Clean'
   name: 'gcr.io/$PROJECT_ID/open-match-build'


### PR DESCRIPTION
CI is broken because we reference redis somewhere in the docs and redis's certificate https://redis.io/ just expired. Temporarily disable md-test until redis.io comes back.