### PR TITLE
Fix open match logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Open Match](site/static/images/logo-with-name.png)
+![Open Match](https://github.com/googleforgames/open-match-docs/blob/master/site/static/images/logo-with-name.png)
 
 [![GoDoc](https://godoc.org/open-match.dev/open-match?status.svg)](https://godoc.org/open-match.dev/open-match)
 [![Go Report Card](https://goreportcard.com/badge/open-match.dev/open-match)](https://goreportcard.com/report/open-match.dev/open-match)


### PR DESCRIPTION
Open match logo points to a broken `/site/static` link. This commit change the link to [https://github.com/googleforgames/open-match-docs/blob/master/site/static/images/logo-with-name.png](https://github.com/googleforgames/open-match-docs/blob/master/site/static/images/logo-with-name.png)