### PR TITLE
Prepare CI for Cluster E2E Testing

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -52,10 +52,10 @@ steps:
   args: ['--destination=gcr.io/$PROJECT_ID/open-match-build', '--cache=true', '--cache-ttl=48h', '--dockerfile=Dockerfile.ci', '.']
   waitFor: ['-']
 
-# - id: 'Test: Markdown'
-#   name: 'gcr.io/$PROJECT_ID/open-match-build'
-#   args: ['make', 'md-test']
-#   waitFor: ['Docker Image: open-match-build']
+- id: 'Test: Markdown'
+  name: 'gcr.io/$PROJECT_ID/open-match-build'
+  args: ['make', 'md-test']
+  waitFor: ['Docker Image: open-match-build']
 
 - id: 'Build: Clean'
   name: 'gcr.io/$PROJECT_ID/open-match-build'
@@ -120,7 +120,7 @@ steps:
 
 - id: 'Deploy: Deployment Configs'
   name: 'gcr.io/$PROJECT_ID/open-match-build'
-  args: ['make', '_GCB_POST_SUBMIT=${_GCB_POST_SUBMIT}', '_GCB_LATEST_VERSION=${_GCB_LATEST_VERSION}', VERSION_SUFFIX=$SHORT_SHA', 'BRANCH_NAME=$BRANCH_NAME', 'ci-deploy-artifacts']
+  args: ['make', '_GCB_POST_SUBMIT=${_GCB_POST_SUBMIT}', '_GCB_LATEST_VERSION=${_GCB_LATEST_VERSION}', 'VERSION_SUFFIX=${SHORT_SHA}', 'BRANCH_NAME=${BRANCH_NAME}', 'ci-deploy-artifacts']
   waitFor: ['Lint: Format, Vet, Charts', 'Build: Binaries']
   volumes:
   - name: 'go-vol'
@@ -128,7 +128,7 @@ steps:
 
 - id: 'Test: Delete Old Clusters'
   name: 'gcr.io/$PROJECT_ID/open-match-build'
-  args: ['make', 'ci-reap-clusters']
+  args: ['make', 'GCP_PROJECT_ID=${PROJECT_ID}', 'ci-reap-clusters']
   waitFor: ['Build: Install Toolchain']
 
 artifacts:
@@ -141,6 +141,9 @@ artifacts:
             - cmd/evaluator/evaluator
             - cmd/minimatch/minimatch
             - cmd/swaggerui/swaggerui
+            - examples/functions/golang/soloduel/soloduel
+            - tools/certgen/certgen
+            - tools/reaper/reaper
             - install/yaml/install.yaml
             - install/yaml/install-demo.yaml
             - install/yaml/01-redis-chart.yaml
@@ -148,7 +151,6 @@ artifacts:
             - install/yaml/03-prometheus-chart.yaml
             - install/yaml/04-grafana-chart.yaml
             - install/yaml/05-jaeger-chart.yaml
-            - examples/functions/golang/soloduel/soloduel
 images:
 - 'gcr.io/$PROJECT_ID/openmatch-backend:${_OM_VERSION}-${SHORT_SHA}'
 - 'gcr.io/$PROJECT_ID/openmatch-frontend:${_OM_VERSION}-${SHORT_SHA}'
@@ -158,6 +160,7 @@ images:
 - 'gcr.io/$PROJECT_ID/openmatch-demo:${_OM_VERSION}-${SHORT_SHA}'
 - 'gcr.io/$PROJECT_ID/openmatch-mmf-go-soloduel:${_OM_VERSION}-${SHORT_SHA}'
 - 'gcr.io/$PROJECT_ID/openmatch-swaggerui:${_OM_VERSION}-${SHORT_SHA}'
+- 'gcr.io/$PROJECT_ID/openmatch-reaper:${_OM_VERSION}-${SHORT_SHA}'
 substitutions:
     _OM_VERSION: "0.0.0-dev"
     _GCB_POST_SUBMIT: "0"

--- a/examples/functions/golang/pool/matchfunction_test.go
+++ b/examples/functions/golang/pool/matchfunction_test.go
@@ -28,8 +28,8 @@ func TestMakeMatches(t *testing.T) {
 	assert := assert.New(t)
 
 	poolNameToTickets := map[string][]*pb.Ticket{
-		"pool1": []*pb.Ticket{{Id: "1"}, {Id: "2"}},
-		"pool2": []*pb.Ticket{{Id: "3"}, {Id: "4"}},
+		"pool1": {{Id: "1"}, {Id: "2"}},
+		"pool2": {{Id: "3"}, {Id: "4"}},
 	}
 
 	p := &mmfHarness.MatchFunctionParams{
@@ -56,12 +56,12 @@ func TestMakeMatches(t *testing.T) {
 		MatchProfile:  p.ProfileName,
 		MatchFunction: matchName,
 		Ticket:        []*pb.Ticket{{Id: "1"}, {Id: "2"}},
-		Roster:        []*pb.Roster{&pb.Roster{Name: "pool1", TicketId: []string{"1", "2"}}},
+		Roster:        []*pb.Roster{{Name: "pool1", TicketId: []string{"1", "2"}}},
 	})
 	assert.Contains(actual, &pb.Match{
 		MatchProfile:  p.ProfileName,
 		MatchFunction: matchName,
 		Ticket:        []*pb.Ticket{{Id: "3"}, {Id: "4"}},
-		Roster:        []*pb.Roster{&pb.Roster{Name: "pool2", TicketId: []string{"3", "4"}}},
+		Roster:        []*pb.Roster{{Name: "pool2", TicketId: []string{"3", "4"}}},
 	})
 }

--- a/examples/functions/golang/soloduel/matchfunction_test.go
+++ b/examples/functions/golang/soloduel/matchfunction_test.go
@@ -28,8 +28,8 @@ func TestMakeMatchesDeduplicate(t *testing.T) {
 	assert := assert.New(t)
 
 	poolNameToTickets := map[string][]*pb.Ticket{
-		"pool1": []*pb.Ticket{{Id: "1"}},
-		"pool2": []*pb.Ticket{{Id: "1"}},
+		"pool1": {{Id: "1"}},
+		"pool2": {{Id: "1"}},
 	}
 
 	p := &mmfHarness.MatchFunctionParams{
@@ -47,9 +47,9 @@ func TestMakeMatches(t *testing.T) {
 	assert := assert.New(t)
 
 	poolNameToTickets := map[string][]*pb.Ticket{
-		"pool1": []*pb.Ticket{{Id: "1"}, {Id: "2"}, {Id: "3"}},
-		"pool2": []*pb.Ticket{{Id: "4"}},
-		"pool3": []*pb.Ticket{{Id: "5"}, {Id: "6"}, {Id: "7"}},
+		"pool1": {{Id: "1"}, {Id: "2"}, {Id: "3"}},
+		"pool2": {{Id: "4"}},
+		"pool3": {{Id: "5"}, {Id: "6"}, {Id: "7"}},
 	}
 
 	p := &mmfHarness.MatchFunctionParams{

--- a/internal/app/backend/backend_service_test.go
+++ b/internal/app/backend/backend_service_test.go
@@ -193,7 +193,7 @@ func TestDoFetchMatchesFilterChannel(t *testing.T) {
 		{
 			description: "test the filter can return an error when one of the mmfResult contains an error",
 			preAction: func(mmfChan chan mmfResult, cancel context.CancelFunc) {
-				mmfChan <- mmfResult{matches: []*pb.Match{&pb.Match{MatchId: "1"}}, err: nil}
+				mmfChan <- mmfResult{matches: []*pb.Match{{MatchId: "1"}}, err: nil}
 				mmfChan <- mmfResult{matches: nil, err: errors.New("some error")}
 			},
 			shouldMatches: nil,

--- a/internal/filter/filter_test.go
+++ b/internal/filter/filter_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestFilter(t *testing.T) {
 	tickets := []*pb.Ticket{
-		&pb.Ticket{
+		{
 			Id: "good",
 			Properties: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
@@ -38,7 +38,7 @@ func TestFilter(t *testing.T) {
 			},
 		},
 
-		&pb.Ticket{
+		{
 			Id: "first_bad",
 			Properties: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
@@ -48,7 +48,7 @@ func TestFilter(t *testing.T) {
 			},
 		},
 
-		&pb.Ticket{
+		{
 			Id: "second_bad",
 			Properties: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
@@ -58,7 +58,7 @@ func TestFilter(t *testing.T) {
 			},
 		},
 
-		&pb.Ticket{
+		{
 			Id: "both_bad",
 			Properties: &structpb.Struct{
 				Fields: map[string]*structpb.Value{

--- a/internal/statestore/redis_test.go
+++ b/internal/statestore/redis_test.go
@@ -326,5 +326,5 @@ func createRedis(t *testing.T) (config.View, func()) {
 	cfg.Set("backoff.maxElapsedTime", 100*time.Millisecond)
 	cfg.Set("playerIndices", []string{"testindex1", "testindex2"})
 
-	return cfg, func() {mredis.Close()}
+	return cfg, func() { mredis.Close() }
 }

--- a/tools/reaper/Dockerfile
+++ b/tools/reaper/Dockerfile
@@ -1,0 +1,55 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM open-match-base-build as builder
+
+WORKDIR /go/src/open-match.dev/open-match/tools/reaper/
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo .
+
+FROM gcr.io/distroless/static
+COPY --from=builder /go/src/open-match.dev/open-match/tools/reaper/reaper .
+
+ENTRYPOINT ["/reaper"]
+
+# Docker Image Arguments
+ARG BUILD_DATE
+ARG VCS_REF
+ARG BUILD_VERSION
+ARG IMAGE_TITLE="Open Match Cluster Reaper"
+
+# Standardized Docker Image Labels
+# https://github.com/opencontainers/image-spec/blob/master/annotations.md
+LABEL \
+    org.opencontainers.image.created="${BUILD_TIME}" \
+    org.opencontainers.image.authors="Google LLC <open-match-discuss@googlegroups.com>" \
+    org.opencontainers.image.url="https://open-match.dev/" \
+    org.opencontainers.image.documentation="https://open-match.dev/site/docs/" \
+    org.opencontainers.image.source="https://github.com/googleforgames/open-match" \
+    org.opencontainers.image.version="${BUILD_VERSION}" \
+    org.opencontainers.image.revision="1" \
+    org.opencontainers.image.vendor="Google LLC" \
+    org.opencontainers.image.licenses="Apache-2.0" \
+    org.opencontainers.image.ref.name="" \
+    org.opencontainers.image.title="${IMAGE_TITLE}" \
+    org.opencontainers.image.description="Flexible, extensible, and scalable video game matchmaking." \
+    org.label-schema.schema-version="1.0" \
+    org.label-schema.build-date=$BUILD_DATE \
+    org.label-schema.url="http://open-match.dev/" \
+    org.label-schema.vcs-url="https://github.com/googleforgames/open-match" \
+    org.label-schema.version=$BUILD_VERSION \
+    org.label-schema.vcs-ref=$VCS_REF \
+    org.label-schema.vendor="Google LLC" \
+    org.label-schema.name="${IMAGE_TITLE}" \
+    org.label-schema.description="Flexible, extensible, and scalable video game matchmaking." \
+    org.label-schema.usage="https://open-match.dev/site/docs/"

--- a/tools/reaper/reaper.go
+++ b/tools/reaper/reaper.go
@@ -17,9 +17,13 @@ package main
 
 import (
 	"flag"
-	"time"
-
+	"fmt"
+	"log"
+	"net"
 	reaperInternal "open-match.dev/open-match/tools/reaper/internal"
+	"os"
+	"strconv"
+	"time"
 )
 
 var (
@@ -27,14 +31,45 @@ var (
 	ageFlag       = flag.Duration("age", time.Hour*1, "Age of a cluster before it's a candidate for deletion.")
 	labelFlag     = flag.String("label", "open-match-ci", "Required label that must be on the cluster for it to be considered for reaping.")
 	locationFlag  = flag.String("location", "us-west1-a", "Location of the cluster")
+	portFlag      = flag.Int("port", 0, "HTTP Port to serve from.")
 )
 
 func main() {
 	flag.Parse()
-	reaperInternal.ReapCluster(&reaperInternal.Params{
+	port := 0
+	portStr := os.Getenv("PORT")
+	if portStr != "" {
+		var err error
+		port, err = strconv.Atoi(portStr)
+		if err != nil {
+			log.Printf("Not serving via $PORT variable, %s, because it's not an integer, %s.", portStr, err)
+		}
+	} else {
+		port = *portFlag
+	}
+	if port > 0 {
+		addr := fmt.Sprintf(":%d", port)
+		conn, err := net.Listen("tcp", addr)
+		if err != nil {
+			log.Fatalf("cannot serve on %d, %s", port, err)
+		}
+		if err := reaperInternal.Serve(conn, flagToParams()); err != nil {
+			log.Fatal(err)
+		}
+	} else {
+		if resp, err := reaperInternal.ReapCluster(flagToParams()); err != nil {
+			log.Fatal(err)
+		} else {
+			log.Print(resp)
+		}
+	}
+}
+
+func flagToParams() *reaperInternal.Params {
+	return &reaperInternal.Params{
 		Age:       *ageFlag,
 		Label:     *labelFlag,
 		ProjectID: *projectIDFlag,
 		Location:  *locationFlag,
-	})
+	}
 }


### PR DESCRIPTION
* Added a serving mode for Cluster Reaper
* Add a docker image for the cluster reaper.
* Updated Makefile to use `$(GCLOUD)` instead of `gcloud` for control over verbosity.
* Post submit builds will generate images with the `:canary` label instead of `:dev`.
* Re-enable markdown tests.

For the cluster reaper the plan will be to create a Cloud Run deployment that serves it and a Cloud Scheduler job that tickles it every minute to delete orphaned clusters.