### PR TITLE
Fix Swagger UI errors.

### DIFF
--- a/cmd/swaggerui/Dockerfile
+++ b/cmd/swaggerui/Dockerfile
@@ -19,7 +19,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo .
 COPY api/*.json /go/src/open-match.dev/open-match/third_party/swaggerui/api/
 
 # We need to change the location of the frontend.swagger.json so that we point to this server.
-RUN sed -i 's/url:.*/url: \"api\/frontend.swagger.json\",/g' /go/src/open-match.dev/open-match/third_party/swaggerui/index.html
+RUN sed -i 's|url:.*|url: "/api/frontend.swagger.json",|g' /go/src/open-match.dev/open-match/third_party/swaggerui/index.html
 
 FROM gcr.io/distroless/static
 COPY --from=builder /go/src/open-match.dev/open-match/cmd/swaggerui/swaggerui .


### PR DESCRIPTION
Add slash in URL to prevent double appendage in Chrome.