### PR TITLE
Refactor backend.getClient methods for synchronizer's implementation

### DIFF
--- a/internal/app/backend/backend_service_test.go
+++ b/internal/app/backend/backend_service_test.go
@@ -218,36 +218,6 @@ func TestDoFetchMatchesFilterChannel(t *testing.T) {
 	}
 }
 
-func TestGetHTTPClient(t *testing.T) {
-	assert := assert.New(t)
-	cache := &sync.Map{}
-	client, url, err := getHTTPClient(viper.New(), cache, &pb.FunctionConfig_Rest{Rest: &pb.RestFunctionConfig{Host: "om-test", Port: int32(50321)}})
-	assert.Nil(err)
-	assert.NotNil(client)
-	assert.NotNil(url)
-	cachedClient, url, err := getHTTPClient(viper.New(), cache, &pb.FunctionConfig_Rest{Rest: &pb.RestFunctionConfig{Host: "om-test", Port: int32(50321)}})
-	assert.Nil(err)
-	assert.NotNil(client)
-	assert.NotNil(url)
-
-	// Test caching by comparing pointer value
-	assert.EqualValues(client, cachedClient)
-}
-
-func TestGetGRPCClient(t *testing.T) {
-	assert := assert.New(t)
-	cache := &sync.Map{}
-	client, err := getGRPCClient(viper.New(), cache, &pb.FunctionConfig_Grpc{Grpc: &pb.GrpcFunctionConfig{Host: "om-test", Port: int32(50321)}})
-	assert.Nil(err)
-	assert.NotNil(client)
-	cachedClient, err := getGRPCClient(viper.New(), cache, &pb.FunctionConfig_Grpc{Grpc: &pb.GrpcFunctionConfig{Host: "om-test", Port: int32(50321)}})
-	assert.Nil(err)
-	assert.NotNil(client)
-
-	// Test caching by comparing pointer value
-	assert.EqualValues(client, cachedClient)
-}
-
 func TestDoAssignTickets(t *testing.T) {
 	fakeTickets := []*pb.Ticket{
 		{

--- a/internal/rpc/clients.go
+++ b/internal/rpc/clients.go
@@ -73,10 +73,8 @@ func GRPCClientFromConfig(cfg config.View, prefix string) (*grpc.ClientConn, err
 }
 
 // GRPCClientFromEndpoint creates a gRPC client connection from endpoint.
-func GRPCClientFromEndpoint(cfg config.View, hostname string, port int) (*grpc.ClientConn, error) {
+func GRPCClientFromEndpoint(cfg config.View, address string) (*grpc.ClientConn, error) {
 	// TODO: investigate if it is possible to keep a cache of the certpool and transport credentials
-	address := fmt.Sprintf("%s:%d", hostname, port)
-
 	grpcOptions := []grpc.DialOption{}
 
 	if cfg.GetBool("tls.enabled") {
@@ -153,9 +151,8 @@ func HTTPClientFromConfig(cfg config.View, prefix string) (*http.Client, string,
 }
 
 // HTTPClientFromEndpoint creates a HTTP client from from endpoint.
-func HTTPClientFromEndpoint(cfg config.View, hostname string, port int) (*http.Client, string, error) {
+func HTTPClientFromEndpoint(cfg config.View, address string) (*http.Client, string, error) {
 	// TODO: investigate if it is possible to keep a cache of the certpool and transport credentials
-	address := fmt.Sprintf("%s:%d", hostname, port)
 	// TODO: Make client Timeout configurable
 	httpClient := &http.Client{Timeout: time.Second * 3}
 	var baseURL string

--- a/internal/util/cache/client.go
+++ b/internal/util/cache/client.go
@@ -1,0 +1,64 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"net/http"
+	"sync"
+
+	"google.golang.org/grpc"
+	"open-match.dev/open-match/internal/config"
+	"open-match.dev/open-match/internal/rpc"
+)
+
+type grpcData struct {
+	conn *grpc.ClientConn
+}
+
+type httpData struct {
+	client  *http.Client
+	baseURL string
+}
+
+// GetHTTPClientFromCache get a httpclient and base url from a sync map and write to the map if the address is first seen.
+func GetHTTPClientFromCache(cfg config.View, mmfClients *sync.Map, addr string) (*http.Client, string, error) {
+	val, exists := mmfClients.Load(addr)
+	data, ok := val.(httpData)
+	if !ok || !exists {
+		client, baseURL, err := rpc.HTTPClientFromEndpoint(cfg, addr)
+		if err != nil {
+			return nil, "", err
+		}
+		data = httpData{client, baseURL}
+		mmfClients.Store(addr, data)
+	}
+	return data.client, data.baseURL, nil
+}
+
+// GetGRPCClientFromCache get a grpc client connection from a sync map and write to the mao if the address is first seen.
+func GetGRPCClientFromCache(cfg config.View, mmfClients *sync.Map, addr string) (*grpc.ClientConn, error) {
+	val, exists := mmfClients.Load(addr)
+	data, ok := val.(grpcData)
+	if !ok || !exists {
+		conn, err := rpc.GRPCClientFromEndpoint(cfg, addr)
+		if err != nil {
+			return nil, err
+		}
+		data = grpcData{conn}
+		mmfClients.Store(addr, data)
+	}
+
+	return data.conn, nil
+}

--- a/internal/util/cache/client_test.go
+++ b/internal/util/cache/client_test.go
@@ -1,0 +1,54 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetGRPCClientFromCache(t *testing.T) {
+	assert := assert.New(t)
+	cache := &sync.Map{}
+	client, err := GetGRPCClientFromCache(viper.New(), cache, "om-test:50321")
+	assert.Nil(err)
+	assert.NotNil(client)
+	cachedConn, err := GetGRPCClientFromCache(viper.New(), cache, "om-test:50321")
+	assert.Nil(err)
+	assert.NotNil(cachedConn)
+
+	// Test caching by comparing pointer value
+	assert.EqualValues(client, cachedConn)
+}
+
+func TestGetHTTPClientFromCache(t *testing.T) {
+	assert := assert.New(t)
+	cache := &sync.Map{}
+	client, baseURL, err := GetHTTPClientFromCache(viper.New(), cache, "om-test:50321")
+	assert.NotEqual("", baseURL)
+	assert.Nil(err)
+	assert.NotNil(client)
+	cachedClient, baseURL, err := GetHTTPClientFromCache(viper.New(), cache, "om-test:50321")
+	assert.NotEqual("", baseURL)
+	assert.Nil(err)
+	assert.NotNil(cachedClient)
+
+	// Test caching by comparing pointer value
+	assert.EqualValues(client, cachedClient)
+
+}


### PR DESCRIPTION
Our backend and synchronizer service both need to talk to an external service hosted by users to work properly. This commit refactor `backend.getHTTPClient` and `backend.getGRPCClient` helpers with cache functionality for synchronizer's implementation. @sawagh Let me know if it looks good to you.