### PR TITLE
Fix CI: Switch to a Supported GKE Version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -609,7 +609,7 @@ get-kind-kubeconfig: build/toolchain/bin/kind$(EXE_EXTENSION)
 delete-kind-cluster: build/toolchain/bin/kind$(EXE_EXTENSION) build/toolchain/bin/kubectl$(EXE_EXTENSION)
 	-$(KIND) delete cluster
 
-create-gke-cluster: GKE_VERSION = 1.13.6-gke.6 # gcloud beta container get-server-config --zone us-central1-a
+create-gke-cluster: GKE_VERSION = 1.13.6 # gcloud beta container get-server-config --zone us-central1-a
 create-gke-cluster: GKE_CLUSTER_SHAPE_FLAGS = --machine-type n1-standard-4 --enable-autoscaling --min-nodes 1 --num-nodes 2 --max-nodes 10 --disk-size 50
 create-gke-cluster: GKE_FUTURE_COMPAT_FLAGS = --no-enable-basic-auth --no-issue-client-certificate --enable-ip-alias --metadata disable-legacy-endpoints=true --enable-autoupgrade
 create-gke-cluster: build/toolchain/bin/kubectl$(EXE_EXTENSION) gcloud


### PR DESCRIPTION
It turns out that 1.13.6.gke.6 which is a very new version is no longer supported. Scaling back the version number to just 1.13.6 since that should still exist.

```
ERROR: (gcloud.beta.container.clusters.create) ResponseError: code=400, message=Master version "1.13.6-gke.6" is unsupported.
```