### PR TITLE
Codify Open Match Continuous Integration as a Terraform template and migrate CI collisions. (#576)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,7 +103,6 @@ tmp/
 
 # Terraform context
 .terraform
-*.tfstate
 *.tfstate.backup
 
 # Credential Files

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -15,7 +15,7 @@
 FROM debian
 
 RUN apt-get update
-RUN apt-get install -y -qq git make python3 virtualenv curl sudo unzip apt-transport-https ca-certificates curl software-properties-common gnupg2
+RUN apt-get install -y -qq git make python3 virtualenv curl sudo unzip apt-transport-https ca-certificates curl software-properties-common gnupg2 bc
 
 # Docker
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | sudo apt-key add -

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,8 @@ BUILD_DATE = $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 YEAR_MONTH = $(shell date -u +'%Y%m')
 YEAR_MONTH_DAY = $(shell date -u +'%Y%m%d')
 MAJOR_MINOR_VERSION = $(shell echo $(BASE_VERSION) | cut -d '.' -f1).$(shell echo $(BASE_VERSION) | cut -d '.' -f2)
-
+NANOS = $(shell date -u +'%N')
+NANOS_MODULO_60 = $(shell echo $(NANOS)%60 | bc)
 PROTOC_VERSION = 3.8.0
 HELM_VERSION = 2.14.1
 HUGO_VERSION = 0.55.6
@@ -144,7 +145,7 @@ OPEN_MATCH_CI_LABEL = open-match-ci
 ifdef ALLOW_BUILD_WITH_SUDO
 	GCLOUD = gcloud --quiet --no-user-output-enabled
 	GKE_CLUSTER_NAME = om-cluster-$(SHORT_SHA)
-	GKE_CLUSTER_FLAGS = --labels open-match-ci=1 --node-labels=open-match-ci=1
+	GKE_CLUSTER_FLAGS = --labels open-match-ci=1 --node-labels=open-match-ci=1 --network=projects/$(GCP_PROJECT_ID)/global/networks/open-match-ci --subnetwork=projects/$(GCP_PROJECT_ID)/regions/$(GCP_REGION)/subnetworks/ci-$(GCP_REGION)-$(NANOS_MODULO_60)
 endif
 
 # If the version is 0.0* then the service name is "development" as in development.open-match.dev.

--- a/install/terraform/open-match-build/README.md
+++ b/install/terraform/open-match-build/README.md
@@ -11,6 +11,24 @@ a migration or emergency.
 If you're making changes to these files you must check in the .tfstate file as
 well as comment the reason why you're enabling a feature or making a change.
 
+## Update Infrastructure
+
+To apply your changes run the following commands:
+
+```bash
+# Get the Terraform tool we use.
+make build/toolchain/bin/terraform
+alias terraform=$PWD/build/toolchain/bin/terraform
+cd install/terraform/open-match-build/
+# Initialize Terraform and download the state of the project.
+terraform init
+terraform state pull
+# Preview the changes.
+terraform plan
+# Update the project, may be destructive!
+terraform apply
+```
+
 ## Security Warning
 For security purposes, only open-match-build administrators have the
 authorization to make changes to this file.

--- a/install/terraform/open-match-build/open-match-build.tf
+++ b/install/terraform/open-match-build/open-match-build.tf
@@ -1,0 +1,142 @@
+# Copyright 2019 Google LLC All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "gcp_project_id" {
+  description = "GCP Project ID"
+  default = "open-match-build"
+}
+
+variable "gcp_region" {
+  description = "Location where resources in GCP will be located."
+  default = "us-west1"
+}
+
+variable "gcp_zone" {
+  description = "Location where resources in GCP will be located."
+  default = "us-west1-b"
+}
+
+variable "vpc_flow_logs" {
+  description = "Enables VPC network flow logs for debugging."
+  default = "false"
+}
+
+provider "null" {
+}
+
+provider "google" {
+  version = ">=0.0.0"
+  project = "${var.gcp_project_id}"
+  region = "${var.gcp_region}"
+}
+
+provider "google-beta" {
+  version = ">=0.0.0"
+  project = "${var.gcp_project_id}"
+  region = "${var.gcp_region}"
+}
+
+# Create a manual-mode GCP regionalized network for CI.
+# We'll create GKE clusters outside of the "default" auto-mode network so that we can have many subnets.
+resource "google_compute_network" "ci_network" {
+  name = "open-match-ci"
+  description = "VPC Network for Continuous Integration runs."
+  auto_create_subnetworks = false
+  routing_mode = "REGIONAL"
+}
+
+# We create 60 subnetworks so that each GKE cluster we create in CI can run on it's own subnet.
+# This is to workaround a bug in GKE where it cannot tolerate creating 2 clusters on the same subnet at the same time.
+resource "google_compute_subnetwork" "ci_subnet" {
+  count = 60
+  name          = "ci-${var.gcp_region}-${count.index}"
+  ip_cidr_range = "10.0.${count.index}.0/24"
+  region        = "${var.gcp_region}"
+  network       = "${google_compute_network.ci_network.self_link}"
+  enable_flow_logs = "${var.vpc_flow_logs}"
+  description = "Subnetwork for continuous integration build that runs on the :${count.index} second."
+  private_ip_google_access = true
+}
+
+# The cluster reaper is a tool that scans for orphaned GKE clusters created by CI and deletes them.
+# The reaper runs as this service account.
+resource "google_service_account" "cluster_reaper" {
+  project     = "${var.gcp_project_id}"
+  account_id   = "cluster-reaper"
+  display_name = "cluster-reaper"
+  # Description is not supported yet.
+  #description = "Deletes orphaned GKE clusters."
+}
+
+# This role defines all the permissions that the cluster reaper has.
+# It mainly needs to list and delete GKE cluster but it also runs in Cloud Run so it needs invoker permissions.
+resource "google_project_iam_custom_role" "cluster_reaper_role" {
+  provider = "google-beta"
+  project     = "${var.gcp_project_id}"
+  role_id     = "continuousintegration.reaper"
+  title       = "Open Match CI Cluster Reaper"
+  description = "Role to authorize the cluster reaper to delete GKE clusters and invoke itself through Cloud Scheduler."
+  permissions = [
+    "container.clusters.delete",
+    "container.clusters.get",
+    "container.clusters.list",
+    "container.operations.get",
+    "container.operations.list",
+    "resourcemanager.projects.get",
+    # Not supported yet.
+    #"run.routes.invoke",
+  ]
+  stage = "BETA"
+}
+
+# This binds the role to the service account so the cluster reaper can do its thing.
+resource "google_project_iam_binding" "cluster_reaper_role_binding" {
+  project = "${google_project_iam_custom_role.cluster_reaper_role.project}"
+  role    = "projects/${google_project_iam_custom_role.cluster_reaper_role.project}/roles/${google_project_iam_custom_role.cluster_reaper_role.role_id}"
+  members = [
+    "serviceAccount:${google_service_account.cluster_reaper.email}"
+  ]
+  depends_on = ["null_resource.after_service_account_creation"]
+}
+
+# TODO: Remove once run.routes.invoke can be added to custom roles.
+resource "google_project_iam_binding" "cluster_reaper_role_binding_for_cloud_run_invoker" {
+  provider = "google-beta"
+  project = "${google_project_iam_custom_role.cluster_reaper_role.project}"
+  role    = "roles/run.invoker"
+  members = [
+    "serviceAccount:${google_service_account.cluster_reaper.email}"
+  ]
+  depends_on = ["null_resource.after_service_account_creation"]
+}
+
+# https://www.terraform.io/docs/providers/google/r/google_service_account.html
+# It's recommended to delay creation of the role binding by a few seconds after the service account
+# because the service account creation is eventually consistent.
+resource "null_resource" "before_service_account_creation" {
+    depends_on = ["google_service_account.cluster_reaper"]
+}
+
+resource "null_resource" "delay_after_service_account_creation" {
+  provisioner "local-exec" {
+    command = "sleep 30"
+  }
+  triggers = {
+    "before" = "${null_resource.before_service_account_creation.id}"
+  }
+}
+
+resource "null_resource" "after_service_account_creation" {
+  depends_on = ["null_resource.delay_after_service_account_creation"]
+}

--- a/install/terraform/open-match-build/terraform.tfstate
+++ b/install/terraform/open-match-build/terraform.tfstate
@@ -1,0 +1,1702 @@
+{
+  "version": 4,
+  "terraform_version": "0.12.2",
+  "serial": 254,
+  "lineage": "8cf91df2-b3d7-2b87-3cb9-6e8f06e359f2",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "google_compute_network",
+      "name": "ci_network",
+      "provider": "provider.google",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "auto_create_subnetworks": false,
+            "delete_default_routes_on_create": false,
+            "description": "VPC Network for Continuous Integration runs.",
+            "gateway_ipv4": "",
+            "id": "open-match-ci",
+            "ipv4_range": "",
+            "name": "open-match-ci",
+            "project": "open-match-build",
+            "routing_mode": "REGIONAL",
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjoyNDAwMDAwMDAwMDAsImRlbGV0ZSI6MjQwMDAwMDAwMDAwLCJ1cGRhdGUiOjI0MDAwMDAwMDAwMH19"
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "google_compute_subnetwork",
+      "name": "ci_subnet",
+      "each": "list",
+      "provider": "provider.google",
+      "instances": [
+        {
+          "index_key": 0,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:01:50.731-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :0 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "gE-LOSj_6vk=",
+            "gateway_address": "10.0.0.1",
+            "id": "us-west1/ci-us-west1-0",
+            "ip_cidr_range": "10.0.0.0/24",
+            "name": "ci-us-west1-0",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-0",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 1,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:01:34.917-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :1 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "jfGBm7N_cEo=",
+            "gateway_address": "10.0.1.1",
+            "id": "us-west1/ci-us-west1-1",
+            "ip_cidr_range": "10.0.1.0/24",
+            "name": "ci-us-west1-1",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-1",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 2,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:00:27.109-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :2 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "jpvlqFeHUK4=",
+            "gateway_address": "10.0.2.1",
+            "id": "us-west1/ci-us-west1-2",
+            "ip_cidr_range": "10.0.2.0/24",
+            "name": "ci-us-west1-2",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-2",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 3,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:00:53.339-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :3 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "FNQL3b2MC9w=",
+            "gateway_address": "10.0.3.1",
+            "id": "us-west1/ci-us-west1-3",
+            "ip_cidr_range": "10.0.3.0/24",
+            "name": "ci-us-west1-3",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-3",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 4,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:01:35.192-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :4 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "8mZuE586w2o=",
+            "gateway_address": "10.0.4.1",
+            "id": "us-west1/ci-us-west1-4",
+            "ip_cidr_range": "10.0.4.0/24",
+            "name": "ci-us-west1-4",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-4",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 5,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:00:27.501-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :5 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "vv-TKBVNq-U=",
+            "gateway_address": "10.0.5.1",
+            "id": "us-west1/ci-us-west1-5",
+            "ip_cidr_range": "10.0.5.0/24",
+            "name": "ci-us-west1-5",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-5",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 6,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:00:47.805-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :6 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "KNi3Ml7ywrY=",
+            "gateway_address": "10.0.6.1",
+            "id": "us-west1/ci-us-west1-6",
+            "ip_cidr_range": "10.0.6.0/24",
+            "name": "ci-us-west1-6",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-6",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 7,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:01:45.014-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :7 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "iOYrFdo1yj0=",
+            "gateway_address": "10.0.7.1",
+            "id": "us-west1/ci-us-west1-7",
+            "ip_cidr_range": "10.0.7.0/24",
+            "name": "ci-us-west1-7",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-7",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 8,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:01:56.941-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :8 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "S9mdHR6LWa4=",
+            "gateway_address": "10.0.8.1",
+            "id": "us-west1/ci-us-west1-8",
+            "ip_cidr_range": "10.0.8.0/24",
+            "name": "ci-us-west1-8",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-8",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 9,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:00:17.335-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :9 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "LX3QyIWhiRs=",
+            "gateway_address": "10.0.9.1",
+            "id": "us-west1/ci-us-west1-9",
+            "ip_cidr_range": "10.0.9.0/24",
+            "name": "ci-us-west1-9",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-9",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 10,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:01:50.713-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :10 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "HxwEf9F44Ko=",
+            "gateway_address": "10.0.10.1",
+            "id": "us-west1/ci-us-west1-10",
+            "ip_cidr_range": "10.0.10.0/24",
+            "name": "ci-us-west1-10",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-10",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 11,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:00:37.514-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :11 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "y3jP5FrZTK8=",
+            "gateway_address": "10.0.11.1",
+            "id": "us-west1/ci-us-west1-11",
+            "ip_cidr_range": "10.0.11.0/24",
+            "name": "ci-us-west1-11",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-11",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 12,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:00:32.236-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :12 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "J7ADQHEk8U8=",
+            "gateway_address": "10.0.12.1",
+            "id": "us-west1/ci-us-west1-12",
+            "ip_cidr_range": "10.0.12.0/24",
+            "name": "ci-us-west1-12",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-12",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 13,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:02:16.638-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :13 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "FLeXPZW9fPk=",
+            "gateway_address": "10.0.13.1",
+            "id": "us-west1/ci-us-west1-13",
+            "ip_cidr_range": "10.0.13.0/24",
+            "name": "ci-us-west1-13",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-13",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 14,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:00:48.843-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :14 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "H9md_b90LHU=",
+            "gateway_address": "10.0.14.1",
+            "id": "us-west1/ci-us-west1-14",
+            "ip_cidr_range": "10.0.14.0/24",
+            "name": "ci-us-west1-14",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-14",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 15,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:01:35.138-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :15 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "XPXNlpKLQGI=",
+            "gateway_address": "10.0.15.1",
+            "id": "us-west1/ci-us-west1-15",
+            "ip_cidr_range": "10.0.15.0/24",
+            "name": "ci-us-west1-15",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-15",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 16,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:02:00.644-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :16 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "koU3otU4BIE=",
+            "gateway_address": "10.0.16.1",
+            "id": "us-west1/ci-us-west1-16",
+            "ip_cidr_range": "10.0.16.0/24",
+            "name": "ci-us-west1-16",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-16",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 17,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:00:22.825-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :17 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "aDmOhMg41ng=",
+            "gateway_address": "10.0.17.1",
+            "id": "us-west1/ci-us-west1-17",
+            "ip_cidr_range": "10.0.17.0/24",
+            "name": "ci-us-west1-17",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-17",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 18,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:02:00.945-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :18 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "D368ZICqFOs=",
+            "gateway_address": "10.0.18.1",
+            "id": "us-west1/ci-us-west1-18",
+            "ip_cidr_range": "10.0.18.0/24",
+            "name": "ci-us-west1-18",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-18",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 19,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:01:19.241-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :19 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "zXmM8yvlzEU=",
+            "gateway_address": "10.0.19.1",
+            "id": "us-west1/ci-us-west1-19",
+            "ip_cidr_range": "10.0.19.0/24",
+            "name": "ci-us-west1-19",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-19",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 20,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:00:27.521-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :20 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "_m0GshmwKeU=",
+            "gateway_address": "10.0.20.1",
+            "id": "us-west1/ci-us-west1-20",
+            "ip_cidr_range": "10.0.20.0/24",
+            "name": "ci-us-west1-20",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-20",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 21,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:01:30.529-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :21 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "T1ouHbjN5t8=",
+            "gateway_address": "10.0.21.1",
+            "id": "us-west1/ci-us-west1-21",
+            "ip_cidr_range": "10.0.21.0/24",
+            "name": "ci-us-west1-21",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-21",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 22,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:01:03.438-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :22 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "DO4Ttk-VdVs=",
+            "gateway_address": "10.0.22.1",
+            "id": "us-west1/ci-us-west1-22",
+            "ip_cidr_range": "10.0.22.0/24",
+            "name": "ci-us-west1-22",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-22",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 23,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:02:16.464-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :23 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "I5vn5nf2qto=",
+            "gateway_address": "10.0.23.1",
+            "id": "us-west1/ci-us-west1-23",
+            "ip_cidr_range": "10.0.23.0/24",
+            "name": "ci-us-west1-23",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-23",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 24,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:01:03.429-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :24 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "X6A2voDPDR4=",
+            "gateway_address": "10.0.24.1",
+            "id": "us-west1/ci-us-west1-24",
+            "ip_cidr_range": "10.0.24.0/24",
+            "name": "ci-us-west1-24",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-24",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 25,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:01:34.941-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :25 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "dDt0cEg-uGk=",
+            "gateway_address": "10.0.25.1",
+            "id": "us-west1/ci-us-west1-25",
+            "ip_cidr_range": "10.0.25.0/24",
+            "name": "ci-us-west1-25",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-25",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 26,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:01:08.849-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :26 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "D1ckq6VJUB0=",
+            "gateway_address": "10.0.26.1",
+            "id": "us-west1/ci-us-west1-26",
+            "ip_cidr_range": "10.0.26.0/24",
+            "name": "ci-us-west1-26",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-26",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 27,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:00:32.996-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :27 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "wTN-QDztWcs=",
+            "gateway_address": "10.0.27.1",
+            "id": "us-west1/ci-us-west1-27",
+            "ip_cidr_range": "10.0.27.0/24",
+            "name": "ci-us-west1-27",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-27",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 28,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:02:16.640-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :28 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "oZuxOnrpeJU=",
+            "gateway_address": "10.0.28.1",
+            "id": "us-west1/ci-us-west1-28",
+            "ip_cidr_range": "10.0.28.0/24",
+            "name": "ci-us-west1-28",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-28",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 29,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:00:37.420-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :29 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "sAhqLBzhLhw=",
+            "gateway_address": "10.0.29.1",
+            "id": "us-west1/ci-us-west1-29",
+            "ip_cidr_range": "10.0.29.0/24",
+            "name": "ci-us-west1-29",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-29",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 30,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:01:46.342-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :30 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "9IWjaD6LsNk=",
+            "gateway_address": "10.0.30.1",
+            "id": "us-west1/ci-us-west1-30",
+            "ip_cidr_range": "10.0.30.0/24",
+            "name": "ci-us-west1-30",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-30",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 31,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:00:52.999-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :31 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "U547Pd0L6SE=",
+            "gateway_address": "10.0.31.1",
+            "id": "us-west1/ci-us-west1-31",
+            "ip_cidr_range": "10.0.31.0/24",
+            "name": "ci-us-west1-31",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-31",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 32,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:01:08.927-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :32 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "v-FHgBtySOo=",
+            "gateway_address": "10.0.32.1",
+            "id": "us-west1/ci-us-west1-32",
+            "ip_cidr_range": "10.0.32.0/24",
+            "name": "ci-us-west1-32",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-32",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 33,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:01:14.825-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :33 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "0Rxvhav64nI=",
+            "gateway_address": "10.0.33.1",
+            "id": "us-west1/ci-us-west1-33",
+            "ip_cidr_range": "10.0.33.0/24",
+            "name": "ci-us-west1-33",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-33",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 34,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:01:18.907-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :34 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "zAAzZRB2P2w=",
+            "gateway_address": "10.0.34.1",
+            "id": "us-west1/ci-us-west1-34",
+            "ip_cidr_range": "10.0.34.0/24",
+            "name": "ci-us-west1-34",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-34",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 35,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:01:29.474-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :35 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "Aoe_C32Qo9Q=",
+            "gateway_address": "10.0.35.1",
+            "id": "us-west1/ci-us-west1-35",
+            "ip_cidr_range": "10.0.35.0/24",
+            "name": "ci-us-west1-35",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-35",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 36,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:01:14.723-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :36 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "XMDXCSTzN8E=",
+            "gateway_address": "10.0.36.1",
+            "id": "us-west1/ci-us-west1-36",
+            "ip_cidr_range": "10.0.36.0/24",
+            "name": "ci-us-west1-36",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-36",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 37,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:00:53.313-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :37 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "rCzZhlVsWUI=",
+            "gateway_address": "10.0.37.1",
+            "id": "us-west1/ci-us-west1-37",
+            "ip_cidr_range": "10.0.37.0/24",
+            "name": "ci-us-west1-37",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-37",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 38,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:01:50.325-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :38 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "V-5BQZo5Pvg=",
+            "gateway_address": "10.0.38.1",
+            "id": "us-west1/ci-us-west1-38",
+            "ip_cidr_range": "10.0.38.0/24",
+            "name": "ci-us-west1-38",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-38",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 39,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:00:37.834-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :39 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "8N33NHHxGDo=",
+            "gateway_address": "10.0.39.1",
+            "id": "us-west1/ci-us-west1-39",
+            "ip_cidr_range": "10.0.39.0/24",
+            "name": "ci-us-west1-39",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-39",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 40,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:01:40.926-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :40 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "nN04eALcufs=",
+            "gateway_address": "10.0.40.1",
+            "id": "us-west1/ci-us-west1-40",
+            "ip_cidr_range": "10.0.40.0/24",
+            "name": "ci-us-west1-40",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-40",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 41,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:01:09.050-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :41 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "bfUCKLWbm88=",
+            "gateway_address": "10.0.41.1",
+            "id": "us-west1/ci-us-west1-41",
+            "ip_cidr_range": "10.0.41.0/24",
+            "name": "ci-us-west1-41",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-41",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 42,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:00:53.135-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :42 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "jzgoulcgQbc=",
+            "gateway_address": "10.0.42.1",
+            "id": "us-west1/ci-us-west1-42",
+            "ip_cidr_range": "10.0.42.0/24",
+            "name": "ci-us-west1-42",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-42",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 43,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:02:17.026-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :43 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "bsWQsb8c6sQ=",
+            "gateway_address": "10.0.43.1",
+            "id": "us-west1/ci-us-west1-43",
+            "ip_cidr_range": "10.0.43.0/24",
+            "name": "ci-us-west1-43",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-43",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 44,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:02:23.274-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :44 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "VmHKQ-pzMS8=",
+            "gateway_address": "10.0.44.1",
+            "id": "us-west1/ci-us-west1-44",
+            "ip_cidr_range": "10.0.44.0/24",
+            "name": "ci-us-west1-44",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-44",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 45,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:02:01.066-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :45 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "uELTtKVDcII=",
+            "gateway_address": "10.0.45.1",
+            "id": "us-west1/ci-us-west1-45",
+            "ip_cidr_range": "10.0.45.0/24",
+            "name": "ci-us-west1-45",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-45",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 46,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:01:44.814-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :46 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "lboACR6D6Gk=",
+            "gateway_address": "10.0.46.1",
+            "id": "us-west1/ci-us-west1-46",
+            "ip_cidr_range": "10.0.46.0/24",
+            "name": "ci-us-west1-46",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-46",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 47,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:02:16.700-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :47 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "FkSglduGgak=",
+            "gateway_address": "10.0.47.1",
+            "id": "us-west1/ci-us-west1-47",
+            "ip_cidr_range": "10.0.47.0/24",
+            "name": "ci-us-west1-47",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-47",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 48,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:00:53.519-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :48 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "S5_Pd3Q_ERo=",
+            "gateway_address": "10.0.48.1",
+            "id": "us-west1/ci-us-west1-48",
+            "ip_cidr_range": "10.0.48.0/24",
+            "name": "ci-us-west1-48",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-48",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 49,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:02:12.357-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :49 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "5yQtl0y7ENA=",
+            "gateway_address": "10.0.49.1",
+            "id": "us-west1/ci-us-west1-49",
+            "ip_cidr_range": "10.0.49.0/24",
+            "name": "ci-us-west1-49",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-49",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 50,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:01:24.424-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :50 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "m9gKkNISUvU=",
+            "gateway_address": "10.0.50.1",
+            "id": "us-west1/ci-us-west1-50",
+            "ip_cidr_range": "10.0.50.0/24",
+            "name": "ci-us-west1-50",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-50",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 51,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:02:16.524-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :51 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "kQez44VIDMc=",
+            "gateway_address": "10.0.51.1",
+            "id": "us-west1/ci-us-west1-51",
+            "ip_cidr_range": "10.0.51.0/24",
+            "name": "ci-us-west1-51",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-51",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 52,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:00:27.400-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :52 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "UVdQuXwKt1c=",
+            "gateway_address": "10.0.52.1",
+            "id": "us-west1/ci-us-west1-52",
+            "ip_cidr_range": "10.0.52.0/24",
+            "name": "ci-us-west1-52",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-52",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 53,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:01:18.927-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :53 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "Mx7qdoVpe1E=",
+            "gateway_address": "10.0.53.1",
+            "id": "us-west1/ci-us-west1-53",
+            "ip_cidr_range": "10.0.53.0/24",
+            "name": "ci-us-west1-53",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-53",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 54,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:00:48.835-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :54 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "jo97e2WRX1Y=",
+            "gateway_address": "10.0.54.1",
+            "id": "us-west1/ci-us-west1-54",
+            "ip_cidr_range": "10.0.54.0/24",
+            "name": "ci-us-west1-54",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-54",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 55,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:01:45.323-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :55 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "qBBRb5sttRw=",
+            "gateway_address": "10.0.55.1",
+            "id": "us-west1/ci-us-west1-55",
+            "ip_cidr_range": "10.0.55.0/24",
+            "name": "ci-us-west1-55",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-55",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 56,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:01:51.047-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :56 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "r9He_BSAE4A=",
+            "gateway_address": "10.0.56.1",
+            "id": "us-west1/ci-us-west1-56",
+            "ip_cidr_range": "10.0.56.0/24",
+            "name": "ci-us-west1-56",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-56",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 57,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:01:19.442-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :57 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "3o1CVKFw4QE=",
+            "gateway_address": "10.0.57.1",
+            "id": "us-west1/ci-us-west1-57",
+            "ip_cidr_range": "10.0.57.0/24",
+            "name": "ci-us-west1-57",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-57",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 58,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:02:01.015-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :58 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "swmljw_bSWA=",
+            "gateway_address": "10.0.58.1",
+            "id": "us-west1/ci-us-west1-58",
+            "ip_cidr_range": "10.0.58.0/24",
+            "name": "ci-us-west1-58",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-58",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        },
+        {
+          "index_key": 59,
+          "schema_version": 0,
+          "attributes": {
+            "creation_timestamp": "2019-06-24T11:00:53.312-07:00",
+            "description": "Subnetwork for continuous integration build that runs on the :59 second.",
+            "enable_flow_logs": false,
+            "fingerprint": "7TPeFbxufH0=",
+            "gateway_address": "10.0.59.1",
+            "id": "us-west1/ci-us-west1-59",
+            "ip_cidr_range": "10.0.59.0/24",
+            "name": "ci-us-west1-59",
+            "network": "https://www.googleapis.com/compute/v1/projects/open-match-build/global/networks/open-match-ci",
+            "private_ip_google_access": true,
+            "project": "open-match-build",
+            "region": "us-west1",
+            "secondary_ip_range": [],
+            "self_link": "https://www.googleapis.com/compute/v1/projects/open-match-build/regions/us-west1/subnetworks/ci-us-west1-59",
+            "timeouts": null
+          },
+          "private": "eyJlMmJmYjczMC1lY2FhLTExZTYtOGY4OC0zNDM2M2JjN2M0YzAiOnsiY3JlYXRlIjozNjAwMDAwMDAwMDAsImRlbGV0ZSI6MzYwMDAwMDAwMDAwLCJ1cGRhdGUiOjM2MDAwMDAwMDAwMH19",
+          "depends_on": [
+            "google_compute_network.ci_network"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "google_project_iam_binding",
+      "name": "cluster_reaper_role_binding",
+      "provider": "provider.google",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "etag": "BwWMFWaHQ9M=",
+            "id": "open-match-build/projects/open-match-build/roles/continuousintegration.reaper",
+            "members": [
+              "serviceAccount:cluster-reaper@open-match-build.iam.gserviceaccount.com"
+            ],
+            "project": "open-match-build",
+            "role": "projects/open-match-build/roles/continuousintegration.reaper"
+          },
+          "private": "bnVsbA==",
+          "depends_on": [
+            "google_project_iam_custom_role.cluster_reaper_role",
+            "google_service_account.cluster_reaper",
+            "null_resource.after_service_account_creation"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "google_project_iam_binding",
+      "name": "cluster_reaper_role_binding_for_cloud_run_invoker",
+      "provider": "provider.google-beta",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "etag": "BwWMFWaHQ9M=",
+            "id": "open-match-build/roles/run.invoker",
+            "members": [
+              "serviceAccount:cluster-reaper@open-match-build.iam.gserviceaccount.com"
+            ],
+            "project": "open-match-build",
+            "role": "roles/run.invoker"
+          },
+          "private": "bnVsbA==",
+          "depends_on": [
+            "google_project_iam_custom_role.cluster_reaper_role",
+            "google_service_account.cluster_reaper",
+            "null_resource.after_service_account_creation"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "google_project_iam_custom_role",
+      "name": "cluster_reaper_role",
+      "provider": "provider.google-beta",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "deleted": false,
+            "description": "Role to authorize the cluster reaper to delete GKE clusters and invoke itself through Cloud Scheduler.",
+            "id": "projects/open-match-build/roles/continuousintegration.reaper",
+            "permissions": [
+              "container.clusters.delete",
+              "container.clusters.get",
+              "container.clusters.list",
+              "container.operations.get",
+              "container.operations.list",
+              "resourcemanager.projects.get"
+            ],
+            "project": "open-match-build",
+            "role_id": "continuousintegration.reaper",
+            "stage": "BETA",
+            "title": "Open Match CI Cluster Reaper"
+          },
+          "private": "bnVsbA=="
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "google_service_account",
+      "name": "cluster_reaper",
+      "provider": "provider.google",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "account_id": "cluster-reaper",
+            "display_name": "cluster-reaper",
+            "email": "cluster-reaper@open-match-build.iam.gserviceaccount.com",
+            "id": "projects/open-match-build/serviceAccounts/cluster-reaper@open-match-build.iam.gserviceaccount.com",
+            "name": "projects/open-match-build/serviceAccounts/cluster-reaper@open-match-build.iam.gserviceaccount.com",
+            "policy_data": null,
+            "project": "open-match-build",
+            "unique_id": "113986504004685979719"
+          },
+          "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjAifQ=="
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "after_service_account_creation",
+      "provider": "provider.null",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "8479162583625273473",
+            "triggers": null
+          },
+          "depends_on": [
+            "null_resource.delay_after_service_account_creation"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "before_service_account_creation",
+      "provider": "provider.null",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "7115930437854691294",
+            "triggers": null
+          },
+          "depends_on": [
+            "google_service_account.cluster_reaper"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "delay_after_service_account_creation",
+      "provider": "provider.null",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "id": "7842531114429703719",
+            "triggers": {
+              "before": "7115930437854691294"
+            }
+          },
+          "depends_on": [
+            "null_resource.before_service_account_creation"
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This change introduces Terraform management of Open Match CI. Right now it'll manage the subnets and service accounts used to allow CI to run. This is GCB/prow agnostic.

Lastly, this change mitigates the subnet collision bug in GKE by provisioning a cluster on it's own subnetwork based on the second the build runs. This isn't a perfect solution but it should mitigate the vast majority of collisions we are seeing.