### PR TITLE
Remove *testing.T dependency from framework structs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -744,6 +744,9 @@ assets: all-protos tls-certs third_party/ build/chart/
 
 all: service-binaries example-binaries tools-binaries
 
+compile:
+	$(GO) build ./...
+
 service-binaries: cmd/minimatch/minimatch$(EXE_EXTENSION) cmd/swaggerui/swaggerui$(EXE_EXTENSION)
 service-binaries: cmd/backend/backend$(EXE_EXTENSION) cmd/frontend/frontend$(EXE_EXTENSION)
 service-binaries: cmd/mmlogic/mmlogic$(EXE_EXTENSION) cmd/synchronizer/synchronizer$(EXE_EXTENSION)
@@ -1011,4 +1014,4 @@ ifeq ($(shell whoami),root)
 endif
 endif
 
-.PHONY: docker gcloud update-deps sync-deps sleep-10 sleep-30 proxy-dashboard proxy-prometheus proxy-grafana clean clean-build clean-toolchain clean-archives clean-binaries clean-protos presubmit test ci-reap-clusters md-test vet
+.PHONY: docker gcloud update-deps sync-deps sleep-10 sleep-30 proxy-dashboard proxy-prometheus proxy-grafana clean clean-build clean-toolchain clean-archives clean-binaries clean-protos presubmit test ci-reap-clusters md-test vet compile

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -88,7 +88,7 @@ steps:
 
 - id: 'Build: Binaries'
   name: 'gcr.io/$PROJECT_ID/open-match-build'
-  args: ['make', 'GOPROXY=off', 'all', '-j8']
+  args: ['make', 'GOPROXY=off', 'all', 'compile', '-j8']
   volumes:
   - name: 'go-vol'
     path: '/go'

--- a/internal/app/backend/backend_service_test.go
+++ b/internal/app/backend/backend_service_test.go
@@ -276,7 +276,7 @@ func TestDoAssignTickets(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cfg := viper.New()
 			cfg.Set("playerIndices", []string{fakeProperty})
-			store, closer := statestoreTesting.NewStoreServiceForTesting(t, cfg)
+			store, closer := statestoreTesting.NewStoreServiceForTesting(cfg)
 			defer closer()
 
 			test.preAction(ctx, cancel, store)

--- a/internal/app/frontend/frontend_service_test.go
+++ b/internal/app/frontend/frontend_service_test.go
@@ -81,7 +81,7 @@ func TestDoCreateTickets(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			store, closer := statestoreTesting.NewStoreServiceForTesting(t, cfg)
+			store, closer := statestoreTesting.NewStoreServiceForTesting(cfg)
 			defer closer()
 
 			ctx, cancel := context.WithCancel(context.Background())
@@ -152,7 +152,7 @@ func TestDoGetAssignments(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			store, closer := statestoreTesting.NewStoreServiceForTesting(t, viper.New())
+			store, closer := statestoreTesting.NewStoreServiceForTesting(viper.New())
 			defer closer()
 
 			senderTriggerCount := 0
@@ -210,7 +210,7 @@ func TestDoDeleteTicket(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
-			store, closer := statestoreTesting.NewStoreServiceForTesting(t, viper.New())
+			store, closer := statestoreTesting.NewStoreServiceForTesting(viper.New())
 			defer closer()
 
 			test.preAction(ctx, cancel, store)
@@ -263,7 +263,7 @@ func TestDoGetTicket(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
-			store, closer := statestoreTesting.NewStoreServiceForTesting(t, viper.New())
+			store, closer := statestoreTesting.NewStoreServiceForTesting(viper.New())
 			defer closer()
 
 			test.preAction(ctx, cancel, store)

--- a/internal/app/mmlogic/mmlogic_service_test.go
+++ b/internal/app/mmlogic/mmlogic_service_test.go
@@ -128,7 +128,7 @@ func TestDoQueryTickets(t *testing.T) {
 			cfg := viper.New()
 			cfg.Set("storage.page.size", 1000)
 			cfg.Set("playerIndices", []string{attribute1, attribute2})
-			store, closer := statestoreTesting.NewStoreServiceForTesting(t, cfg)
+			store, closer := statestoreTesting.NewStoreServiceForTesting(cfg)
 			defer closer()
 
 			test.action(t, store)

--- a/internal/rpc/testing/helpers_test.go
+++ b/internal/rpc/testing/helpers_test.go
@@ -41,10 +41,10 @@ func TestMustServeTLS(t *testing.T) {
 	runMustServeTest(t, MustServeTLS)
 }
 
-func runMustServeTest(t *testing.T, mustServeFunc func(*testing.T, func(*rpc.ServerParams)) *TestContext) {
+func runMustServeTest(t *testing.T, mustServeFunc func(func(*rpc.ServerParams)) *TestContext) {
 	assert := assert.New(t)
 	ff := &shellTesting.FakeFrontend{}
-	tc := mustServeFunc(t, func(spf *rpc.ServerParams) {
+	tc := mustServeFunc(func(spf *rpc.ServerParams) {
 		spf.AddHandleFunc(func(s *grpc.Server) {
 			pb.RegisterFrontendServer(s, ff)
 		}, pb.RegisterFrontendHandlerFromEndpoint)

--- a/internal/statestore/testing/fake_redis.go
+++ b/internal/statestore/testing/fake_redis.go
@@ -15,19 +15,19 @@
 package testing
 
 import (
-	"testing"
 	"time"
 
 	miniredis "github.com/alicebob/miniredis/v2"
+	"log"
 	"open-match.dev/open-match/internal/config"
 	"open-match.dev/open-match/internal/statestore"
 )
 
 // New creates a new in memory Redis instance for testing.
-func New(t *testing.T, cfg config.Mutable) func() {
+func New(cfg config.Mutable) func() {
 	mredis, err := miniredis.Run()
 	if err != nil {
-		t.Fatalf("failed to create miniredis, %v", err)
+		log.Fatalf("failed to create miniredis, %v", err)
 	}
 	cfg.Set("redis.hostname", mredis.Host())
 	cfg.Set("redis.port", mredis.Port())
@@ -47,8 +47,8 @@ func New(t *testing.T, cfg config.Mutable) func() {
 }
 
 // NewStoreServiceForTesting creates a new statestore service for testing
-func NewStoreServiceForTesting(t *testing.T, cfg config.Mutable) (statestore.Service, func()) {
-	closer := New(t, cfg)
+func NewStoreServiceForTesting(cfg config.Mutable) (statestore.Service, func()) {
+	closer := New(cfg)
 	s := statestore.New(cfg)
 
 	return s, closer

--- a/internal/statestore/testing/fake_redis_test.go
+++ b/internal/statestore/testing/fake_redis_test.go
@@ -27,7 +27,7 @@ import (
 func TestFakeStatestore(t *testing.T) {
 	assert := assert.New(t)
 	cfg := viper.New()
-	closer := New(t, cfg)
+	closer := New(cfg)
 	defer closer()
 	s := statestore.New(cfg)
 	ctx := context.Background()

--- a/test/e2e/minimatch/match_test.go
+++ b/test/e2e/minimatch/match_test.go
@@ -25,9 +25,9 @@ import (
 )
 
 func TestFetchMatches(t *testing.T) {
-	mainTc := createMinimatchForTest(t)
+	mainTc := createMinimatchForTest()
 	defer mainTc.Close()
-	mmfTc := createMatchFunctionForTest(t, mainTc)
+	mmfTc := createMatchFunctionForTest(mainTc)
 	defer mmfTc.Close()
 
 	be := pb.NewBackendClient(mainTc.MustGRPC())

--- a/test/e2e/minimatch/minimatch_test.go
+++ b/test/e2e/minimatch/minimatch_test.go
@@ -26,18 +26,6 @@ import (
 	"open-match.dev/open-match/pkg/pb"
 )
 
-const (
-	// Names of the test pools used by this test.
-	map1BeginnerPool = "map1beginner"
-	map1AdvancedPool = "map1advanced"
-	map2BeginnerPool = "map2beginner"
-	map2AdvancedPool = "map2advanced"
-	// Test specific metadata
-	skillattribute = "skill"
-	map1attribute  = "map1"
-	map2attribute  = "map2"
-)
-
 type testProfile struct {
 	name  string
 	pools []*pb.Pool
@@ -45,9 +33,9 @@ type testProfile struct {
 
 func TestMinimatch(t *testing.T) {
 	assert := require.New(t)
-	minimatchTc := createMinimatchForTest(t)
+	minimatchTc := createMinimatchForTest()
 	defer minimatchTc.Close()
-	mmfTc := createMatchFunctionForTest(t, minimatchTc)
+	mmfTc := createMatchFunctionForTest(minimatchTc)
 	defer mmfTc.Close()
 
 	minimatchConn := minimatchTc.MustGRPC()

--- a/test/e2e/minimatch/ticket_test.go
+++ b/test/e2e/minimatch/ticket_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func TestAssignTickets(t *testing.T) {
-	tc := createMinimatchForTest(t)
+	tc := createMinimatchForTest()
 	defer tc.Close()
 
 	fe := pb.NewFrontendClient(tc.MustGRPC())
@@ -111,7 +111,7 @@ func TestAssignTickets(t *testing.T) {
 func TestTicketLifeCycle(t *testing.T) {
 	assert := assert.New(t)
 
-	tc := createMinimatchForTest(t)
+	tc := createMinimatchForTest()
 	defer tc.Close()
 	fe := pb.NewFrontendClient(tc.MustGRPC())
 	assert.NotNil(fe)
@@ -266,7 +266,7 @@ func TestQueryTickets(t *testing.T) {
 			test := test
 			t.Run(test.description, func(t *testing.T) {
 				t.Parallel()
-				tc := createMinimatchForTest(t)
+				tc := createMinimatchForTest()
 				defer tc.Close()
 
 				mml := pb.NewMmLogicClient(tc.MustGRPC())


### PR DESCRIPTION
In preparation for the unified e2e test framework for Minimatch and cluster we'll need to remove the `*testing.T` dependencies since the init code will be moved to `*testing.M`