### PR TITLE
Expose services as backed by a LoadBalancer.

### DIFF
--- a/install/helm/open-match/templates/backend.yaml
+++ b/install/helm/open-match/templates/backend.yaml
@@ -25,6 +25,7 @@ spec:
   selector:
     app: {{ template "openmatch.name" . }}
     component: backend
+  type: {{ .Values.openmatch.backend.porttype }}
   ports:
   - name: grpc
     protocol: TCP

--- a/install/helm/open-match/templates/demo.yaml
+++ b/install/helm/open-match/templates/demo.yaml
@@ -25,6 +25,7 @@ spec:
   selector:
     app: {{ template "openmatch.name" . }}
     component: demo
+  type: {{ .Values.openmatch.demo.porttype }}
   ports:
   - name: http
     protocol: TCP

--- a/install/helm/open-match/templates/demofunction.yaml
+++ b/install/helm/open-match/templates/demofunction.yaml
@@ -25,6 +25,7 @@ spec:
   selector:
     app: {{ template "openmatch.name" . }}
     component: demofunction
+  type: {{ .Values.openmatch.demofunction.porttype }}
   ports:
   - name: grpc
     protocol: TCP

--- a/install/helm/open-match/templates/frontend.yaml
+++ b/install/helm/open-match/templates/frontend.yaml
@@ -26,6 +26,7 @@ spec:
     app: {{ template "openmatch.name" . }}
     component: frontend
     {{- include "openmatch.chartmeta" (set . "indent" 4) }}
+  type: {{ .Values.openmatch.frontend.porttype }}
   ports:
   - name: grpc
     protocol: TCP

--- a/install/helm/open-match/templates/mmlogic.yaml
+++ b/install/helm/open-match/templates/mmlogic.yaml
@@ -26,6 +26,7 @@ spec:
     app: {{ template "openmatch.name" . }}
     component: mmlogic
     {{- include "openmatch.chartmeta" (set . "indent" 4) }}
+  type: {{ .Values.openmatch.mmlogic.porttype }}
   ports:
   - name: grpc
     protocol: TCP

--- a/install/helm/open-match/templates/swaggerui.yaml
+++ b/install/helm/open-match/templates/swaggerui.yaml
@@ -25,6 +25,7 @@ spec:
   selector:
     app: {{ template "openmatch.name" . }}
     component: swaggerui
+  type: {{ .Values.openmatch.swaggerui.porttype }}
   ports:
   - name: http
     protocol: TCP

--- a/install/helm/open-match/templates/synchronizer.yaml
+++ b/install/helm/open-match/templates/synchronizer.yaml
@@ -25,6 +25,7 @@ spec:
   selector:
     app: {{ template "openmatch.name" . }}
     component: synchronizer
+  type: {{ .Values.openmatch.synchronizer.porttype }}
   ports:
   - name: grpc
     protocol: TCP

--- a/install/helm/open-match/values.yaml
+++ b/install/helm/open-match/values.yaml
@@ -38,6 +38,7 @@ openmatch:
       port: 50505
     http:
       port: 51505
+    porttype: LoadBalancer
   frontend:
     install: true
     replicas: 3
@@ -45,6 +46,7 @@ openmatch:
       port: 50504
     http:
       port: 51504
+    porttype: LoadBalancer
   mmlogic:
     install: true
     replicas: 3
@@ -52,6 +54,7 @@ openmatch:
       port: 50503
     http:
       port: 51503
+    porttype: LoadBalancer
   synchronizer:
     install: true
     replicas: 1
@@ -59,25 +62,29 @@ openmatch:
       port: 50506
     http:
       port: 51506
+    porttype: LoadBalancer
   swaggerui:
     install: true
     replicas: 3
     http:
       port: 50500
+    porttype: LoadBalancer
   demofunction:
     install: true
+    replicas: 3
     grpc:
       port: 50502
     http:
       port: 51502
-    replicas: 3
+    porttype: LoadBalancer
   demo:
     # TODO: Change to true once the demo is available.
     # It's currently missing liveness/readiness checks.
     install: false
+    replicas: 3
     http:
       port: 51507
-    replicas: 3
+    porttype: LoadBalancer
 
   config:
     install: true


### PR DESCRIPTION
This change makes it possible to talk to Open Match outside of the Kubernetes cluster.

This unblocks the e2e testing story for on cluster tests.