### PR TITLE
Implement synchronizer client that only establishes connection to the synchronizer on the first call.

### DIFF
--- a/internal/app/backend/backend.go
+++ b/internal/app/backend/backend.go
@@ -15,10 +15,13 @@
 package backend
 
 import (
+	"sync"
+
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"open-match.dev/open-match/internal/config"
 	"open-match.dev/open-match/internal/rpc"
+	"open-match.dev/open-match/internal/statestore"
 	"open-match.dev/open-match/pkg/pb"
 )
 
@@ -55,13 +58,14 @@ func RunApplication() {
 
 // BindService creates the backend service and binds it to the serving harness.
 func BindService(p *rpc.ServerParams, cfg config.View) error {
-	service, err := newBackendService(cfg)
-	if err != nil {
-		return err
+	service := &backendService{
+		cfg:          cfg,
+		synchronizer: &synchronizerClient{cfg: cfg},
+		store:        statestore.New(cfg),
+		mmfClients:   &sync.Map{},
 	}
 
 	p.AddHealthCheckFunc(service.store.HealthCheck)
-
 	p.AddHandleFunc(func(s *grpc.Server) {
 		pb.RegisterBackendServer(s, service)
 	}, pb.RegisterBackendHandlerFromEndpoint)

--- a/internal/app/backend/backend_service.go
+++ b/internal/app/backend/backend_service.go
@@ -27,7 +27,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"open-match.dev/open-match/internal/config"
-	internalpb "open-match.dev/open-match/internal/pb"
 	"open-match.dev/open-match/internal/rpc"
 	"open-match.dev/open-match/internal/statestore"
 	"open-match.dev/open-match/pkg/pb"
@@ -37,7 +36,7 @@ import (
 // and make assignments for Tickets.
 type backendService struct {
 	cfg          config.View
-	synchronizer internalpb.SynchronizerClient
+	synchronizer *synchronizerClient
 	store        statestore.Service
 	mmfClients   *sync.Map
 }
@@ -63,20 +62,6 @@ var (
 	})
 )
 
-func newBackendService(cfg config.View) (*backendService, error) {
-	conn, err := rpc.GRPCClientFromConfig(cfg, "api.synchronizer")
-	if err != nil {
-		return nil, err
-	}
-
-	return &backendService{
-		cfg:          cfg,
-		synchronizer: internalpb.NewSynchronizerClient(conn),
-		store:        statestore.New(cfg),
-		mmfClients:   &sync.Map{},
-	}, nil
-}
-
 // FetchMatches triggers execution of the specfied MatchFunction for each of the
 // specified MatchProfiles. Each MatchFunction execution returns a set of
 // proposals which are then evaluated to generate results. FetchMatches method
@@ -93,17 +78,12 @@ func (s *backendService) FetchMatches(ctx context.Context, req *pb.FetchMatchesR
 
 	resultChan := make(chan mmfResult, len(req.GetProfile()))
 
-	var syncID string
-	if s.synchronizerEnabled() {
-		resp, err := s.synchronizer.Register(ctx, &internalpb.RegisterRequest{})
-		if err != nil {
-			return nil, err
-		}
-
-		syncID = resp.GetId()
+	syncID, err := s.synchronizer.register(ctx)
+	if err != nil {
+		return nil, err
 	}
 
-	err := doFetchMatchesInChannel(ctx, s.cfg, s.mmfClients, req, resultChan)
+	err = doFetchMatchesInChannel(ctx, s.cfg, s.mmfClients, req, resultChan)
 	if err != nil {
 		return nil, err
 	}
@@ -113,16 +93,9 @@ func (s *backendService) FetchMatches(ctx context.Context, req *pb.FetchMatchesR
 		return nil, err
 	}
 
-	results := proposals
-	if s.synchronizerEnabled() {
-		resp, err := s.synchronizer.EvaluateProposals(ctx, &internalpb.EvaluateProposalsRequest{
-			Id:    syncID,
-			Match: proposals})
-		if err != nil {
-			return nil, err
-		}
-
-		results = resp.Match
+	results, err := s.synchronizer.evaluate(ctx, syncID, proposals)
+	if err != nil {
+		return nil, err
 	}
 
 	return &pb.FetchMatchesResponse{Match: results}, nil
@@ -311,12 +284,4 @@ func doAssignTickets(ctx context.Context, req *pb.AssignTicketsRequest, store st
 	}
 
 	return nil
-}
-
-func (s *backendService) synchronizerEnabled() bool {
-	if !s.cfg.IsSet("synchronizer.enabled") {
-		return false
-	}
-
-	return s.cfg.GetBool("synchronizer.enabled")
 }

--- a/internal/app/backend/synchronizer_client.go
+++ b/internal/app/backend/synchronizer_client.go
@@ -1,0 +1,81 @@
+package backend
+
+import (
+	"context"
+	"sync"
+
+	"open-match.dev/open-match/internal/config"
+	ipb "open-match.dev/open-match/internal/pb"
+	"open-match.dev/open-match/internal/rpc"
+	"open-match.dev/open-match/pkg/pb"
+)
+
+type synchronizerClient struct {
+	cfg          config.View
+	synchronizer ipb.SynchronizerClient
+	m            sync.Mutex
+}
+
+// register calls the Register method on Synchronizer service. It only triggers this
+// if the synchronizer is enabled. The first attempt to call the synchronizer service
+// establishes a connection. Consequent requests use the cached connection.
+func (sc *synchronizerClient) register(ctx context.Context) (string, error) {
+	if !sc.cfg.GetBool("synchronizer.enabled") {
+		// Synchronizer is disabled. Succeed the call without returning any ID.
+		return "", nil
+	}
+
+	if err := sc.initialize(); err != nil {
+		// Failed to connect to the synchronizer service.
+		return "", err
+	}
+
+	resp, err := sc.synchronizer.Register(ctx, &ipb.RegisterRequest{})
+	if err != nil {
+		return "", err
+	}
+
+	return resp.GetId(), nil
+}
+
+// evaluate calls the EvaluateProposals method on Synchronizer service. It only triggers
+// this if the synchronizer is enabled. The first attempt to call the synchronizer service
+// establishes a connection. Consequent requests use the cached connection.
+func (sc *synchronizerClient) evaluate(ctx context.Context, id string, proposals []*pb.Match) ([]*pb.Match, error) {
+	if !sc.cfg.GetBool("synchronizer.enabled") {
+		// Synchronizer is disabled. Return all the proposals as results. This is only temporary.
+		// After the synchronizer is implememnted, it will be mandatory and this check will be removed.
+		return proposals, nil
+	}
+
+	if err := sc.initialize(); err != nil {
+		// Failed to connect to the synchronizer service.
+		return nil, err
+	}
+
+	resp, err := sc.synchronizer.EvaluateProposals(ctx, &ipb.EvaluateProposalsRequest{
+		Id:    id,
+		Match: proposals})
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.Match, nil
+}
+
+// initialize attempts to connect to the Sychronizer service. If the connection is
+// successful, the client is cached and reused for all future communication.
+func (sc *synchronizerClient) initialize() error {
+	sc.m.Lock()
+	defer sc.m.Unlock()
+	if sc.synchronizer == nil {
+		conn, err := rpc.GRPCClientFromConfig(sc.cfg, "api.synchronizer")
+		if err != nil {
+			return err
+		}
+
+		sc.synchronizer = ipb.NewSynchronizerClient(conn)
+	}
+
+	return nil
+}

--- a/internal/app/minimatch/minimatch.go
+++ b/internal/app/minimatch/minimatch.go
@@ -19,6 +19,7 @@ import (
 	"open-match.dev/open-match/internal/app/backend"
 	"open-match.dev/open-match/internal/app/frontend"
 	"open-match.dev/open-match/internal/app/mmlogic"
+	"open-match.dev/open-match/internal/app/synchronizer"
 	"open-match.dev/open-match/internal/config"
 	"open-match.dev/open-match/internal/rpc"
 )
@@ -65,6 +66,10 @@ func BindService(p *rpc.ServerParams, cfg config.View) error {
 	}
 
 	if err := mmlogic.BindService(p, cfg); err != nil {
+		return err
+	}
+
+	if err := synchronizer.BindService(p, cfg); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This enables minimatch test setup to set up the synchronizer host, port on the configuration after all the services are up.