### PR TITLE
Enable E2E Cluster Tests

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -50,4 +50,6 @@ RUN sudo mkdir -p "$GOPATH/src" "$GOPATH/bin" \
 RUN mkdir -p /toolchain
 
 WORKDIR /workspace
-ENV ALLOW_BUILD_WITH_SUDO=1
+ENV OPEN_MATCH_CI_MODE=1
+ENV KUBECONFIG=$HOME/.kube/config
+RUN mkdir -p $HOME/.kube/

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,8 @@ DASHBOARD_PORT = 9092
 OPEN_MATCH_CI_LABEL = open-match-ci
 
 # This flag is set when running in Continuous Integration.
-ifdef ALLOW_BUILD_WITH_SUDO
+ifdef OPEN_MATCH_CI_MODE
+	export KUBECONFIG = $(HOME)/.kube/config
 	GCLOUD = gcloud --quiet --no-user-output-enabled
 	GKE_CLUSTER_NAME = om-cluster-$(SHORT_SHA)
 	GKE_CLUSTER_FLAGS = --labels open-match-ci=1 --node-labels=open-match-ci=1 --network=projects/$(GCP_PROJECT_ID)/global/networks/open-match-ci --subnetwork=projects/$(GCP_PROJECT_ID)/regions/$(GCP_REGION)/subnetworks/ci-$(GCP_REGION)-$(NANOS_MODULO_60)
@@ -1013,7 +1014,7 @@ sleep-30:
 # Prevents users from running with sudo.
 # There's an exception for Google Cloud Build because it runs as root.
 no-sudo:
-ifndef ALLOW_BUILD_WITH_SUDO
+ifndef OPEN_MATCH_CI_MODE
 ifeq ($(shell whoami),root)
 	@echo "ERROR: Running Makefile as root (or sudo)"
 	@echo "Please follow the instructions at https://docs.docker.com/install/linux/linux-postinstall/ if you are trying to sudo run the Makefile because of the 'Cannot connect to the Docker daemon' error."

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -138,20 +138,18 @@ steps:
   args: ['make', 'SHORT_SHA=${SHORT_SHA}', 'install-chart']
   waitFor: ['Test: Create Cluster', 'Build: Docker Images']
 
-# TODO: Once the location of the cluster configs is known run the tests.
-#- id: 'Test: End-to-End Cluster'
-#  name: 'gcr.io/$PROJECT_ID/open-match-build'
-#  args: ['make', 'GOPROXY=off', 'SHORT_SHA=${SHORT_SHA}', 'sleep-30', 'e2ecluster']
-#  waitFor: ['Test: Deploy Open Match', 'Build: Assets']
-#  volumes:
-#  - name: 'go-vol'
-#    path: '/go'
+- id: 'Test: End-to-End Cluster'
+  name: 'gcr.io/$PROJECT_ID/open-match-build'
+  args: ['make', 'GOPROXY=off', 'SHORT_SHA=${SHORT_SHA}', 'e2ecluster']
+  waitFor: ['Test: Deploy Open Match', 'Build: Assets']
+  volumes:
+  - name: 'go-vol'
+    path: '/go'
 
 - id: 'Test: Delete Cluster'
   name: 'gcr.io/$PROJECT_ID/open-match-build'
   args: ['make', 'SHORT_SHA=${SHORT_SHA}', 'GCLOUD_EXTRA_FLAGS=--async', 'GCP_PROJECT_ID=${PROJECT_ID}', 'ci-reap-clusters', 'delete-gke-cluster']
-  waitFor: ['Test: Deploy Open Match']
-#  waitFor: ['Test: End-to-End Cluster']
+  waitFor: ['Test: End-to-End Cluster']
 
 - id: 'Deploy: Deployment Configs'
   name: 'gcr.io/$PROJECT_ID/open-match-build'

--- a/internal/testing/e2e/README.md
+++ b/internal/testing/e2e/README.md
@@ -1,0 +1,70 @@
+# Open Match E2E Tests
+
+Open Match can run locally (aka Minimatch) or on a Kubernetes cluster. This package provides a framework to
+create tests that can run in both environments.
+
+# Minimatch
+Minimatch is a single process instance of Open Match that runs with a test in-memory Redis instance.
+This allows you to run Open Match tests without a Kubernetes cluster quickly. There's only 1 instance of
+each service and they are served from the same port on localhost.
+
+# Kubernetes
+Running Open Match on Kubernetes is how Open Match is meant to be run in production. By default, 3
+replicas of each server is running behind a load balancer. Running tests against a cluster has the benefits
+of running the tests in a realistic setting where requests may not be routed to the same server.
+
+# How to Use the E2E Test Framework?
+
+For a new test package under test/e2e/ do the following:
+
+Copy the contents of internal/testing/e2e/main_test.go and change the package name and add
+the `open-match.dev/open-match/internal/testing/e2e` import.
+
+Example (may be out of date):
+```golang
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tickets
+
+import (
+	"open-match.dev/open-match/internal/testing/e2e"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	e2e.RunMain(m)
+}
+```
+
+Then create your tests like other tests in the `test/e2e/` directory.
+
+If your test is not compatible with E2E cluster tests then add
+`// +build !e2ecluster` at the top of the file. It must be the first line!
+
+# How Does it Work?
+
+## Minimatch
+
+Minimatch mode essentially binds all the services that Open Match provides
+into a single gRPC/HTTP server. The magic happens in the `internal/app/minimatch/minimatch.go`'s
+`BindService()` method.
+
+In addition, there's an in-memory Redis instance that's initialized and bound in `internal/testing/e2e/in_memory.go`.
+
+From here the `OM` instance encapsulates the details of communicating with these components.
+
+## Kubernetes Cluster
+
+Kubernetes cluster mode is managed via `internal/testing/e2e/cluster.go`

--- a/internal/testing/e2e/common_test.go
+++ b/internal/testing/e2e/common_test.go
@@ -1,0 +1,15 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e

--- a/internal/testing/e2e/e2e_test.go
+++ b/internal/testing/e2e/e2e_test.go
@@ -31,19 +31,16 @@ func TestServiceHealth(t *testing.T) {
 func TestGetClients(t *testing.T) {
 	om, closer := New(t)
 	defer closer()
-	fe, fec := om.MustFrontendGRPC()
-	defer fec()
-	if fe == nil {
+
+	if c := om.MustFrontendGRPC(); c == nil {
 		t.Error("cannot get frontend client")
 	}
-	be, bec := om.MustBackendGRPC()
-	defer bec()
-	if be == nil {
+
+	if c := om.MustBackendGRPC(); c == nil {
 		t.Error("cannot get backend client")
 	}
-	mml, mmlc := om.MustMmLogicGRPC()
-	defer mmlc()
-	if mml == nil {
+
+	if c := om.MustMmLogicGRPC(); c == nil {
 		t.Error("cannot get mmlogic client")
 	}
 }
@@ -51,8 +48,7 @@ func TestGetClients(t *testing.T) {
 func TestCreateTicket(t *testing.T) {
 	om, closer := New(t)
 	defer closer()
-	fe, cc := om.MustFrontendGRPC()
-	defer cc()
+	fe := om.MustFrontendGRPC()
 	resp, err := fe.CreateTicket(om.Context(), &pb.CreateTicketRequest{
 		Ticket: &pb.Ticket{
 			Properties: &structpb.Struct{

--- a/test/e2e/tickets/query_tickets_test.go
+++ b/test/e2e/tickets/query_tickets_test.go
@@ -150,10 +150,8 @@ func TestQueryTickets(t *testing.T) {
 
 				om, closer := e2e.New(t)
 				defer closer()
-				fe, fec := om.MustFrontendGRPC()
-				defer fec()
-				mml, mmlc := om.MustMmLogicGRPC()
-				defer mmlc()
+				fe := om.MustFrontendGRPC()
+				mml := om.MustMmLogicGRPC()
 				pageCounts := 0
 
 				test.preAction(fe, t)

--- a/test/e2e/tickets/ticket_test.go
+++ b/test/e2e/tickets/ticket_test.go
@@ -30,10 +30,8 @@ import (
 func TestAssignTickets(t *testing.T) {
 	om, closer := e2e.New(t)
 	defer closer()
-	fe, fec := om.MustFrontendGRPC()
-	defer fec()
-	be, bec := om.MustBackendGRPC()
-	defer bec()
+	fe := om.MustFrontendGRPC()
+	be := om.MustBackendGRPC()
 
 	ctResp, err := fe.CreateTicket(om.Context(), &pb.CreateTicketRequest{Ticket: &pb.Ticket{}})
 	assert.Nil(t, err)
@@ -111,8 +109,7 @@ func TestTicketLifeCycle(t *testing.T) {
 	assert := assert.New(t)
 	om, closer := e2e.New(t)
 	defer closer()
-	fe, fec := om.MustFrontendGRPC()
-	defer fec()
+	fe := om.MustFrontendGRPC()
 	assert.NotNil(fe)
 
 	ticket := &pb.Ticket{


### PR DESCRIPTION
This change enables e2e cluster test to run in CI. Previously it was possible to run e2e against a cluster via `make e2ecluster` but not in CI. This change adds support to scan for a Kubernetes config file via the `KUBECONFIG` environment variable in the test framework and also assign a hard coded path to `KUBECONFIG` in the open-match-build CI docker image.