### PR TITLE
Reduce Time in CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+.git
+
 # Binaries for programs and plugins
 *.exe
 *.exe~

--- a/Dockerfile.base-build
+++ b/Dockerfile.base-build
@@ -18,4 +18,3 @@ ENV GO111MODULE=on
 WORKDIR /go/src/open-match.dev/open-match
 COPY . .
 RUN go mod download
-

--- a/Makefile
+++ b/Makefile
@@ -599,7 +599,7 @@ ifneq ($(strip $($(KUBECTL) get clusterroles | grep -i rbac)),)
 	$(KUBECTL) patch deploy --namespace kube-system tiller-deploy -p '{"spec":{"template":{"spec":{"serviceAccount":"tiller"}}}}'
 endif
 	@echo "Waiting for Tiller to become ready..."
-	$(KUBECTL) wait deployment --timeout=60s --for condition=available -l app=helm,name=tiller --namespace kube-system
+	$(KUBECTL) wait pod --timeout=60s --for condition=Ready -l app=helm,name=tiller --namespace kube-system
 
 delete-helm: build/toolchain/bin/helm$(EXE_EXTENSION) build/toolchain/bin/kubectl$(EXE_EXTENSION)
 	-$(HELM) reset

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -52,15 +52,15 @@ steps:
   args: ['--destination=gcr.io/$PROJECT_ID/open-match-build', '--cache=true', '--cache-ttl=48h', '--dockerfile=Dockerfile.ci', '.']
   waitFor: ['-']
 
-- id: 'Test: Markdown'
-  name: 'gcr.io/$PROJECT_ID/open-match-build'
-  args: ['make', 'md-test']
-  waitFor: ['Docker Image: open-match-build']
-
 - id: 'Build: Clean'
   name: 'gcr.io/$PROJECT_ID/open-match-build'
   args: ['make', 'clean']
   waitFor: ['Docker Image: open-match-build']
+
+- id: 'Test: Markdown'
+  name: 'gcr.io/$PROJECT_ID/open-match-build'
+  args: ['make', 'md-test']
+  waitFor: ['Build: Clean']
 
 - id: 'Setup: Download Dependencies'
   name: 'gcr.io/$PROJECT_ID/open-match-build'
@@ -135,7 +135,7 @@ steps:
 
 - id: 'Test: Deploy Open Match'
   name: 'gcr.io/$PROJECT_ID/open-match-build'
-  args: ['make', 'SHORT_SHA=${SHORT_SHA}', 'sleep-10', 'install-chart']
+  args: ['make', 'SHORT_SHA=${SHORT_SHA}', 'install-chart']
   waitFor: ['Test: Create Cluster', 'Build: Docker Images']
 
 # TODO: Once the location of the cluster configs is known run the tests.


### PR DESCRIPTION
Reorganize some build steps to only download the cached image once.
Change the `make push-helm` to wait for the tiller pod instead of the tiller deployment.