### PR TITLE
Add e2eevaluator and e2ematchfunction setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -351,6 +351,30 @@ install-chart: build/toolchain/bin/helm$(EXE_EXTENSION)
 		--set openmatch.monitoring.stackdriver.enabled=true \
 		--set openmatch.monitoring.stackdriver.gcpProjectId=$(GCP_PROJECT_ID)
 
+install-e2e-chart: build/toolchain/bin/helm$(EXE_EXTENSION)
+	$(HELM) upgrade $(OPEN_MATCH_CHART_NAME) --install --wait --debug install/helm/open-match \
+		--timeout=400 \
+		--namespace=$(OPEN_MATCH_KUBERNETES_NAMESPACE) \
+		--set openmatch.image.registry=$(REGISTRY) \
+		--set openmatch.image.tag=$(TAG) \
+		--set grafana.enabled=false \
+		--set jaeger.enabled=false \
+		--set prometheus.enabled=false \
+		--set redis.enabled=false \
+		--set openmatch.monitoring.stackdriver.enabled=true \
+		--set openmatch.monitoring.stackdriver.gcpProjectId=$(GCP_PROJECT_ID) \
+		--set openmatch.config.install=false \
+		--set openmatch.backend.install=false \
+		--set openmatch.frontend.install=false \
+		--set openmatch.mmlogic.install=false \
+		--set openmatch.synchronizer.install=false \
+		--set openmatch.swaggerui.install=false \
+		--set openmatch.demoevaluator.install=false \
+		--set openmatch.demo.install=false \
+		--set openmatch.demofunction.install=false \
+		--set openmatch.e2eevaluator.install=true \
+		--set openmatch.e2ematchfunction.install=true
+
 dry-chart: build/toolchain/bin/helm$(EXE_EXTENSION)
 	$(HELM) upgrade --install --wait --debug --dry-run $(OPEN_MATCH_CHART_NAME) install/helm/open-match \
 		--namespace=$(OPEN_MATCH_KUBERNETES_NAMESPACE) \
@@ -733,7 +757,7 @@ test:
 	$(GO) test -cover -test.count $(GOLANG_TEST_COUNT) -race ./...
 	$(GO) test -cover -test.count $(GOLANG_TEST_COUNT) -run IgnoreRace$$ ./...
 
-e2ecluster:
+test-e2e-cluster:
 	$(GO) test ./... -race -tags e2ecluster
 
 stress-frontend-%: build/toolchain/python/

--- a/Makefile
+++ b/Makefile
@@ -360,18 +360,9 @@ install-e2e-chart: build/toolchain/bin/helm$(EXE_EXTENSION)
 		--set grafana.enabled=false \
 		--set jaeger.enabled=false \
 		--set prometheus.enabled=false \
-		--set redis.enabled=false \
+		--set redis.enabled=true \
 		--set openmatch.monitoring.stackdriver.enabled=true \
-		--set openmatch.monitoring.stackdriver.gcpProjectId=$(GCP_PROJECT_ID) \
-		--set openmatch.config.install=false \
-		--set openmatch.backend.install=false \
-		--set openmatch.frontend.install=false \
-		--set openmatch.mmlogic.install=false \
-		--set openmatch.synchronizer.install=false \
-		--set openmatch.swaggerui.install=false \
-		--set openmatch.demoevaluator.install=false \
-		--set openmatch.demo.install=false \
-		--set openmatch.demofunction.install=false \
+		--set openmatch.monitoring.stackdriver.gcpProjectId=$(GCP_PROJECT_ID)
 		--set openmatch.e2eevaluator.install=true \
 		--set openmatch.e2ematchfunction.install=true
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -135,12 +135,12 @@ steps:
 
 - id: 'Test: Deploy Open Match'
   name: 'gcr.io/$PROJECT_ID/open-match-build'
-  args: ['make', 'SHORT_SHA=${SHORT_SHA}', 'install-chart']
+  args: ['make', 'SHORT_SHA=${SHORT_SHA}', 'install-chart', 'install-e2e-chart']
   waitFor: ['Test: Create Cluster', 'Build: Docker Images']
 
 - id: 'Test: End-to-End Cluster'
   name: 'gcr.io/$PROJECT_ID/open-match-build'
-  args: ['make', 'GOPROXY=off', 'SHORT_SHA=${SHORT_SHA}', 'e2ecluster']
+  args: ['make', 'GOPROXY=off', 'SHORT_SHA=${SHORT_SHA}', 'test-e2e-cluster']
   waitFor: ['Test: Deploy Open Match', 'Build: Assets']
   volumes:
   - name: 'go-vol'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -135,7 +135,7 @@ steps:
 
 - id: 'Test: Deploy Open Match'
   name: 'gcr.io/$PROJECT_ID/open-match-build'
-  args: ['make', 'SHORT_SHA=${SHORT_SHA}', 'install-chart', 'install-e2e-chart']
+  args: ['make', 'SHORT_SHA=${SHORT_SHA}', 'install-e2e-chart']
   waitFor: ['Test: Create Cluster', 'Build: Docker Images']
 
 - id: 'Test: End-to-End Cluster'

--- a/examples/evaluator/golang/simple/evaluate/evaluator.go
+++ b/examples/evaluator/golang/simple/evaluate/evaluator.go
@@ -11,16 +11,14 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package main
+package evaluate
 
 import (
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	harness "open-match.dev/open-match/pkg/harness/evaluator/golang"
 	"open-match.dev/open-match/pkg/pb"
 )
 
 // Evaluate is where your custom evaluation logic lives.
 func Evaluate(p *harness.EvaluatorParams) ([]*pb.Match, error) {
-	return nil, status.Error(codes.Unimplemented, "not implemented")
+	return p.Matches, nil
 }

--- a/examples/evaluator/golang/simple/main.go
+++ b/examples/evaluator/golang/simple/main.go
@@ -14,10 +14,11 @@
 package main
 
 import (
+	simple "open-match.dev/open-match/examples/evaluator/golang/simple/evaluate"
 	harness "open-match.dev/open-match/pkg/harness/evaluator/golang"
 )
 
 func main() {
 	// Invoke the harness to setup a GRPC service that handles requests to run the evaluator.
-	harness.RunEvaluator(Evaluate)
+	harness.RunEvaluator(simple.Evaluate)
 }

--- a/examples/functions/golang/pool/Dockerfile
+++ b/examples/functions/golang/pool/Dockerfile
@@ -1,0 +1,24 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM open-match-base-build as builder
+
+WORKDIR /go/src/open-match.dev/open-match/examples/functions/golang/pool
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o matchfunction .
+
+FROM gcr.io/distroless/static:nonroot
+WORKDIR /app/
+COPY --from=builder --chown=nonroot /go/src/open-match.dev/open-match/examples/functions/golang/pool/matchfunction /app/
+
+ENTRYPOINT ["/app/matchfunction"]

--- a/examples/functions/golang/pool/main.go
+++ b/examples/functions/golang/pool/main.go
@@ -20,7 +20,7 @@
 package main
 
 import (
-	soloduel "open-match.dev/open-match/examples/functions/golang/soloduel/mmf"
+	pool "open-match.dev/open-match/examples/functions/golang/pool/mmf"
 	mmfHarness "open-match.dev/open-match/pkg/harness/function/golang"
 )
 
@@ -30,6 +30,6 @@ func main() {
 	// the specified request and passes the pools to the match function to generate
 	// proposals.
 	mmfHarness.RunMatchFunction(&mmfHarness.FunctionSettings{
-		Func: soloduel.MakeMatches,
+		Func: pool.MakeMatches,
 	})
 }

--- a/examples/functions/golang/pool/mmf/matchfunction.go
+++ b/examples/functions/golang/pool/mmf/matchfunction.go
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package pool provides a sample match function that uses the GRPC harness to set up
+// Package mmf provides a sample match function that uses the GRPC harness to set up
 // the match making function as a service. This sample is a reference
 // to demonstrate the usage of the GRPC harness and should only be used as
 // a starting point for your match function. You will need to modify the
 // matchmaking logic in this function based on your game's requirements.
-package pool
+package mmf
 
 import (
 	"github.com/rs/xid"

--- a/examples/functions/golang/pool/mmf/matchfunction_test.go
+++ b/examples/functions/golang/pool/mmf/matchfunction_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package pool
+package mmf
 
 import (
 	"testing"

--- a/examples/functions/golang/soloduel/mmf/matchfunction.go
+++ b/examples/functions/golang/soloduel/mmf/matchfunction.go
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package main provides a sample match function that uses the GRPC harness to set up 1v1 matches.
+// Package mmf provides a sample match function that uses the GRPC harness to set up 1v1 matches.
 // This sample is a reference to demonstrate the usage of the GRPC harness and should only be used as
 // a starting point for your match function. You will need to modify the
 // matchmaking logic in this function based on your game's requirements.
-package main
+package mmf
 
 import (
 	"fmt"

--- a/examples/functions/golang/soloduel/mmf/matchfunction_test.go
+++ b/examples/functions/golang/soloduel/mmf/matchfunction_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package mmf
 
 import (
 	"testing"

--- a/install/helm/open-match/values.yaml
+++ b/install/helm/open-match/values.yaml
@@ -37,7 +37,7 @@ openmatch:
     grpc:
       port: 50506
     http:
-      port: 50506
+      port: 51506
     porttype: LoadBalancer
   backend:
     install: true
@@ -45,7 +45,7 @@ openmatch:
     grpc:
       port: 50505
     http:
-      port: 50505
+      port: 51505
     porttype: LoadBalancer
   frontend:
     install: true
@@ -53,7 +53,7 @@ openmatch:
     grpc:
       port: 50504
     http:
-      port: 50504
+      port: 51504
     porttype: LoadBalancer
   mmlogic:
     install: true
@@ -61,7 +61,7 @@ openmatch:
     grpc:
       port: 50503
     http:
-      port: 50503
+      port: 51503
     porttype: LoadBalancer
   e2eevaluator:
     install: false
@@ -77,7 +77,7 @@ openmatch:
     grpc:
       port: 50508
     http:
-      port: 50508
+      port: 51508
     porttype: LoadBalancer
   e2ematchfunction:
     install: false
@@ -92,7 +92,7 @@ openmatch:
     grpc:
       port: 50502
     http:
-      port: 50502
+      port: 51502
     porttype: LoadBalancer
   demo:
     # TODO: Change to true once the demo is available.

--- a/install/helm/open-match/values.yaml
+++ b/install/helm/open-match/values.yaml
@@ -31,13 +31,21 @@ openmatch:
       endpoint: "/zipkin"
       reporterEndpoint: "zipkin"
     reportingPeriod: "5s"
+  synchronizer:
+    install: true
+    replicas: 1
+    grpc:
+      port: 50506
+    http:
+      port: 50506
+    porttype: LoadBalancer
   backend:
     install: true
     replicas: 3
     grpc:
       port: 50505
     http:
-      port: 51505
+      port: 50505
     porttype: LoadBalancer
   frontend:
     install: true
@@ -45,7 +53,7 @@ openmatch:
     grpc:
       port: 50504
     http:
-      port: 51504
+      port: 50504
     porttype: LoadBalancer
   mmlogic:
     install: true
@@ -53,21 +61,15 @@ openmatch:
     grpc:
       port: 50503
     http:
-      port: 51503
+      port: 50503
     porttype: LoadBalancer
-  synchronizer:
-    install: true
+  e2eevaluator:
+    install: false
     replicas: 1
     grpc:
-      port: 50506
+      port: 50518
     http:
-      port: 51506
-    porttype: LoadBalancer
-  swaggerui:
-    install: true
-    replicas: 3
-    http:
-      port: 50500
+      port: 51518
     porttype: LoadBalancer
   demoevaluator:
     install: true
@@ -75,15 +77,22 @@ openmatch:
     grpc:
       port: 50508
     http:
-      port: 51508
+      port: 50508
     porttype: LoadBalancer
+  e2ematchfunction:
+    install: false
+    replicas: 1
+    grpc:
+      port: 50512
+    http:
+      port: 51512
   demofunction:
     install: true
     replicas: 3
     grpc:
       port: 50502
     http:
-      port: 51502
+      port: 50502
     porttype: LoadBalancer
   demo:
     # TODO: Change to true once the demo is available.
@@ -92,6 +101,12 @@ openmatch:
     replicas: 3
     http:
       port: 51507
+    porttype: LoadBalancer
+  swaggerui:
+    install: true
+    replicas: 3
+    http:
+      port: 51500
     porttype: LoadBalancer
 
   config:

--- a/test/e2e/minimatch/evaluator_setup.go
+++ b/test/e2e/minimatch/evaluator_setup.go
@@ -22,8 +22,8 @@ import (
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"open-match.dev/open-match/internal/rpc"
-	"open-match.dev/open-match/pkg/pb"
 
+	simple "open-match.dev/open-match/examples/evaluator/golang/simple/evaluate"
 	rpcTesting "open-match.dev/open-match/internal/rpc/testing"
 	harness "open-match.dev/open-match/pkg/harness/evaluator/golang"
 )
@@ -32,16 +32,8 @@ import (
 func createEvaluatorForTest(t *testing.T) *rpcTesting.TestContext {
 	tc := rpcTesting.MustServeInsecure(t, func(p *rpc.ServerParams) {
 		cfg := viper.New()
-		assert.Nil(t, harness.BindService(p, cfg, Evaluate))
+		assert.Nil(t, harness.BindService(p, cfg, simple.Evaluate))
 	})
 
 	return tc
-}
-
-// Evaluate implements the evaluator function that will be triggered by the
-// minimatch synchronizer service.
-func Evaluate(p *harness.EvaluatorParams) ([]*pb.Match, error) {
-	// TODO: This is just a placeholder. Add test evaluation logic here or
-	// refactor this to use the demo sample evaluator.
-	return p.Matches, nil
 }

--- a/test/e2e/minimatch/mmf_setup.go
+++ b/test/e2e/minimatch/mmf_setup.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
-	"open-match.dev/open-match/examples/functions/golang/pool"
+	pool "open-match.dev/open-match/examples/functions/golang/pool/mmf"
 	"open-match.dev/open-match/internal/rpc"
 	rpcTesting "open-match.dev/open-match/internal/rpc/testing"
 	mmfHarness "open-match.dev/open-match/pkg/harness/function/golang"


### PR DESCRIPTION
This commit adds the e2eevaluator and e2ematchfunction to the `make install-chart` command. Will add the helm charts and modify the cloudbuild file in a later PR.