### PR TITLE
Make default build-*-image rule point to cmd/*/Dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -276,23 +276,8 @@ build-tool-images: build-reaper-image
 build-base-build-image: docker all-protos
 	docker build -f Dockerfile.base-build -t open-match-base-build .
 
-build-backend-image: docker build-base-build-image
-	docker build -f cmd/backend/Dockerfile $(IMAGE_BUILD_ARGS) -t $(REGISTRY)/openmatch-backend:$(TAG) -t $(REGISTRY)/openmatch-backend:$(ALTERNATE_TAG) .
-
-build-frontend-image: docker build-base-build-image
-	docker build -f cmd/frontend/Dockerfile $(IMAGE_BUILD_ARGS) -t $(REGISTRY)/openmatch-frontend:$(TAG) -t $(REGISTRY)/openmatch-frontend:$(ALTERNATE_TAG) .
-
-build-mmlogic-image: docker build-base-build-image
-	docker build -f cmd/mmlogic/Dockerfile $(IMAGE_BUILD_ARGS) -t $(REGISTRY)/openmatch-mmlogic:$(TAG) -t $(REGISTRY)/openmatch-mmlogic:$(ALTERNATE_TAG) .
-
-build-minimatch-image: docker build-base-build-image
-	docker build -f cmd/minimatch/Dockerfile $(IMAGE_BUILD_ARGS) -t $(REGISTRY)/openmatch-minimatch:$(TAG) -t $(REGISTRY)/openmatch-minimatch:$(ALTERNATE_TAG) .
-
-build-synchronizer-image: docker build-base-build-image
-	docker build -f cmd/synchronizer/Dockerfile $(IMAGE_BUILD_ARGS) -t $(REGISTRY)/openmatch-synchronizer:$(TAG) -t $(REGISTRY)/openmatch-synchronizer:$(ALTERNATE_TAG) .
-
-build-swaggerui-image: docker build-base-build-image third_party/swaggerui/
-	docker build -f cmd/swaggerui/Dockerfile $(IMAGE_BUILD_ARGS) -t $(REGISTRY)/openmatch-swaggerui:$(TAG) -t $(REGISTRY)/openmatch-swaggerui:$(ALTERNATE_TAG) .
+build-%-image: docker build-base-build-image
+	docker build -f cmd/$*/Dockerfile $(IMAGE_BUILD_ARGS) -t $(REGISTRY)/openmatch-$*:$(TAG) -t $(REGISTRY)/openmatch-$*:$(ALTERNATE_TAG) .
 
 build-demo-image: docker build-base-build-image
 	docker build -f examples/demo/Dockerfile -t $(REGISTRY)/openmatch-demo:$(TAG) -t $(REGISTRY)/openmatch-demo:$(ALTERNATE_TAG) .


### PR DESCRIPTION
This change simply removes duplication in the Makefile for declaring build docker rules for the service binaries. The push-*-image rules already have this treatment. The special thing with the build rules is the `Dockerfile` is not in a specific location so we can only support the service binaries for this pattern.