### PR TITLE
Break out rpc client cache for reuse.

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -328,6 +328,7 @@ google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiq
 google.golang.org/grpc v1.21.0/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
 google.golang.org/grpc v1.21.1 h1:j6XxA85m/6txkUCHvzlV5f+HBNl/1r5cZ2A/3IEFOO8=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
+google.golang.org/grpc v1.22.0 h1:J0UbZOIrCAl+fpTOf8YLs4dJo8L/owV4LYVtAXQoPkw=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=

--- a/internal/app/backend/backend.go
+++ b/internal/app/backend/backend.go
@@ -15,8 +15,6 @@
 package backend
 
 import (
-	"sync"
-
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"open-match.dev/open-match/internal/config"
@@ -59,10 +57,9 @@ func RunApplication() {
 // BindService creates the backend service and binds it to the serving harness.
 func BindService(p *rpc.ServerParams, cfg config.View) error {
 	service := &backendService{
-		cfg:          cfg,
 		synchronizer: &synchronizerClient{cfg: cfg},
 		store:        statestore.New(cfg),
-		mmfClients:   &sync.Map{},
+		mmfClients:   rpc.NewClientCache(cfg),
 	}
 
 	p.AddHealthCheckFunc(service.store.HealthCheck)

--- a/internal/app/backend/backend_service.go
+++ b/internal/app/backend/backend_service.go
@@ -21,12 +21,11 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"sync"
 
 	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"open-match.dev/open-match/internal/config"
 	"open-match.dev/open-match/internal/rpc"
 	"open-match.dev/open-match/internal/statestore"
 	"open-match.dev/open-match/pkg/pb"
@@ -35,19 +34,9 @@ import (
 // The service implementing the Backend API that is called to generate matches
 // and make assignments for Tickets.
 type backendService struct {
-	cfg          config.View
 	synchronizer *synchronizerClient
 	store        statestore.Service
-	mmfClients   *sync.Map
-}
-
-type grpcData struct {
-	client pb.MatchFunctionClient
-}
-
-type httpData struct {
-	client  *http.Client
-	baseURL string
+	mmfClients   *rpc.ClientCache
 }
 
 type mmfResult struct {
@@ -86,7 +75,7 @@ func (s *backendService) FetchMatches(ctx context.Context, req *pb.FetchMatchesR
 		return nil, err
 	}
 
-	err = doFetchMatchesReceiveMmfResult(ctx, s.cfg, s.mmfClients, req, resultChan)
+	err = doFetchMatchesReceiveMmfResult(ctx, s.mmfClients, req, resultChan)
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +98,7 @@ func (s *backendService) FetchMatches(ctx context.Context, req *pb.FetchMatchesR
 	return &pb.FetchMatchesResponse{Match: results}, nil
 }
 
-func doFetchMatchesReceiveMmfResult(ctx context.Context, cfg config.View, mmfClients *sync.Map, req *pb.FetchMatchesRequest, resultChan chan<- mmfResult) error {
+func doFetchMatchesReceiveMmfResult(ctx context.Context, mmfClients *rpc.ClientCache, req *pb.FetchMatchesRequest, resultChan chan<- mmfResult) error {
 	var grpcClient pb.MatchFunctionClient
 	var httpClient *http.Client
 	var baseURL string
@@ -121,7 +110,8 @@ func doFetchMatchesReceiveMmfResult(ctx context.Context, cfg config.View, mmfCli
 	switch configType {
 	// MatchFunction Hosted as a GRPC service
 	case pb.FunctionConfig_GRPC:
-		grpcClient, err = getGRPCClient(cfg, mmfClients, address)
+		var conn *grpc.ClientConn
+		conn, err = mmfClients.GetGRPC(address)
 		if err != nil {
 			backendServiceLogger.WithFields(logrus.Fields{
 				"error":    err.Error(),
@@ -129,9 +119,10 @@ func doFetchMatchesReceiveMmfResult(ctx context.Context, cfg config.View, mmfCli
 			}).Error("failed to establish grpc client connection to match function")
 			return status.Error(codes.InvalidArgument, "failed to connect to match function")
 		}
+		grpcClient = pb.NewMatchFunctionClient(conn)
 	// MatchFunction Hosted as a REST service
 	case pb.FunctionConfig_REST:
-		httpClient, baseURL, err = getHTTPClient(cfg, mmfClients, address)
+		httpClient, baseURL, err = mmfClients.GetHTTP(address)
 		if err != nil {
 			backendServiceLogger.WithFields(logrus.Fields{
 				"error":    err.Error(),
@@ -195,35 +186,6 @@ func doFetchMatchesAddIgnoredTickets(ctx context.Context, store statestore.Servi
 		}
 	}
 	return store.AddTicketsToIgnoreList(ctx, ids)
-}
-
-func getHTTPClient(cfg config.View, mmfClients *sync.Map, addr string) (*http.Client, string, error) {
-	val, exists := mmfClients.Load(addr)
-	data, ok := val.(httpData)
-	if !ok || !exists {
-		client, baseURL, err := rpc.HTTPClientFromEndpoint(cfg, addr)
-		if err != nil {
-			return nil, "", err
-		}
-		data = httpData{client, baseURL}
-		mmfClients.Store(addr, data)
-	}
-	return data.client, data.baseURL, nil
-}
-
-func getGRPCClient(cfg config.View, mmfClients *sync.Map, addr string) (pb.MatchFunctionClient, error) {
-	val, exists := mmfClients.Load(addr)
-	data, ok := val.(grpcData)
-	if !ok || !exists {
-		conn, err := rpc.GRPCClientFromEndpoint(cfg, addr)
-		if err != nil {
-			return nil, err
-		}
-		data = grpcData{pb.NewMatchFunctionClient(conn)}
-		mmfClients.Store(addr, data)
-	}
-
-	return data.client, nil
 }
 
 func matchesFromHTTPMMF(ctx context.Context, profile *pb.MatchProfile, client *http.Client, baseURL string) ([]*pb.Match, error) {

--- a/internal/app/backend/backend_service_test.go
+++ b/internal/app/backend/backend_service_test.go
@@ -16,7 +16,6 @@ package backend
 
 import (
 	"context"
-	"sync"
 	"testing"
 	"time"
 
@@ -25,6 +24,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"open-match.dev/open-match/internal/config"
+	"open-match.dev/open-match/internal/rpc"
 	"open-match.dev/open-match/internal/statestore"
 	statestoreTesting "open-match.dev/open-match/internal/statestore/testing"
 	"open-match.dev/open-match/pkg/pb"
@@ -88,8 +88,9 @@ func TestDoFetchMatchesInChannel(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
+			cc := rpc.NewClientCache(test.cfg)
 			resultChan := make(chan mmfResult, len(test.req.GetProfile()))
-			err := doFetchMatchesReceiveMmfResult(context.Background(), test.cfg, &sync.Map{}, test.req, resultChan)
+			err := doFetchMatchesReceiveMmfResult(context.Background(), cc, test.req, resultChan)
 			assert.Equal(t, test.wantErr, err)
 		})
 	}
@@ -158,36 +159,6 @@ func TestDoFetchMatchesFilterChannel(t *testing.T) {
 			assert.Equal(t, test.wantCode, status.Convert(err).Code())
 		})
 	}
-}
-
-func TestGetHTTPClient(t *testing.T) {
-	assert := assert.New(t)
-	cache := &sync.Map{}
-	client, url, err := getHTTPClient(viper.New(), cache, "om-test:54321")
-	assert.Nil(err)
-	assert.NotNil(client)
-	assert.NotNil(url)
-	cachedClient, url, err := getHTTPClient(viper.New(), cache, "om-test:54321")
-	assert.Nil(err)
-	assert.NotNil(client)
-	assert.NotNil(url)
-
-	// Test caching by comparing pointer value
-	assert.EqualValues(client, cachedClient)
-}
-
-func TestGetGRPCClient(t *testing.T) {
-	assert := assert.New(t)
-	cache := &sync.Map{}
-	client, err := getGRPCClient(viper.New(), cache, "om-test:54321")
-	assert.Nil(err)
-	assert.NotNil(client)
-	cachedClient, err := getGRPCClient(viper.New(), cache, "om-test:54321")
-	assert.Nil(err)
-	assert.NotNil(client)
-
-	// Test caching by comparing pointer value
-	assert.EqualValues(client, cachedClient)
 }
 
 func TestDoAssignTickets(t *testing.T) {

--- a/internal/rpc/clientcache.go
+++ b/internal/rpc/clientcache.go
@@ -1,0 +1,78 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rpc
+
+import (
+	"google.golang.org/grpc"
+	"net/http"
+	"open-match.dev/open-match/internal/config"
+	"sync"
+)
+
+// ClientCache holds GRPC and HTTP clients based on an address.
+type ClientCache struct {
+	cfg   config.View
+	cache *sync.Map
+}
+
+type cachedGRPCClient struct {
+	client *grpc.ClientConn
+}
+
+type cachedHTTPClient struct {
+	client  *http.Client
+	baseURL string
+}
+
+// GetGRPC gets a GRPC client with the address.
+func (cc *ClientCache) GetGRPC(address string) (*grpc.ClientConn, error) {
+	val, exists := cc.cache.Load(address)
+	c, ok := val.(cachedGRPCClient)
+	if !ok || !exists {
+		conn, err := GRPCClientFromEndpoint(cc.cfg, address)
+		if err != nil {
+			return nil, err
+		}
+		c = cachedGRPCClient{
+			client: conn,
+		}
+		cc.cache.Store(address, c)
+	}
+
+	return c.client, nil
+}
+
+// GetHTTP gets a HTTP client with the address.
+func (cc *ClientCache) GetHTTP(address string) (*http.Client, string, error) {
+	val, exists := cc.cache.Load(address)
+	c, ok := val.(cachedHTTPClient)
+	if !ok || !exists {
+		client, baseURL, err := HTTPClientFromEndpoint(cc.cfg, address)
+		if err != nil {
+			return nil, "", err
+		}
+		c = cachedHTTPClient{client, baseURL}
+		cc.cache.Store(address, c)
+	}
+	return c.client, c.baseURL, nil
+}
+
+// NewClientCache creates a cache with all the clients.
+func NewClientCache(cfg config.View) *ClientCache {
+	return &ClientCache{
+		cfg:   cfg,
+		cache: &sync.Map{},
+	}
+}

--- a/internal/rpc/clientcache_test.go
+++ b/internal/rpc/clientcache_test.go
@@ -1,0 +1,56 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rpc
+
+import (
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+const (
+	fakeHTTPAddress = "http://om-test:54321"
+	fakeGRPCAddress = "om-test:54321"
+)
+
+func TestGetGRPC(t *testing.T) {
+	assert := assert.New(t)
+
+	cc := NewClientCache(viper.New())
+	client, err := cc.GetGRPC(fakeGRPCAddress)
+	assert.Nil(err)
+
+	cachedClient, err := cc.GetGRPC(fakeGRPCAddress)
+	assert.Nil(err)
+
+	// Test caching by comparing pointer value
+	assert.EqualValues(client, cachedClient)
+}
+
+func TestGetHTTP(t *testing.T) {
+	assert := assert.New(t)
+
+	cc := NewClientCache(viper.New())
+	client, address, err := cc.GetHTTP(fakeHTTPAddress)
+	assert.Nil(err)
+	assert.Equal(fakeHTTPAddress, address)
+
+	cachedClient, address, err := cc.GetHTTP(fakeHTTPAddress)
+	assert.Nil(err)
+	assert.Equal(fakeHTTPAddress, address)
+
+	// Test caching by comparing pointer value
+	assert.EqualValues(client, cachedClient)
+}

--- a/internal/rpc/clients_test.go
+++ b/internal/rpc/clients_test.go
@@ -59,6 +59,7 @@ func TestHTTPSFromConfig(t *testing.T) {
 
 	runHTTPClientTests(assert, cfg, rpcParams)
 }
+
 func TestInsecureHTTPFromConfig(t *testing.T) {
 	assert := assert.New(t)
 
@@ -66,6 +67,33 @@ func TestInsecureHTTPFromConfig(t *testing.T) {
 	defer closer()
 
 	runHTTPClientTests(assert, cfg, rpcParams)
+}
+
+func TestSanitizeHTTPAddress(t *testing.T) {
+	tests := []struct {
+		address     string
+		preferHTTPS bool
+		expected    string
+		err         error
+	}{
+		{"om-test:54321", false, "http://om-test:54321", nil},
+		{"om-test:54321", true, "https://om-test:54321", nil},
+		{"http://om-test:54321", false, "http://om-test:54321", nil},
+		{"https://om-test:54321", false, "https://om-test:54321", nil},
+		{"http://om-test:54321", true, "http://om-test:54321", nil},
+		{"https://om-test:54321", true, "https://om-test:54321", nil},
+	}
+
+	for _, testCase := range tests {
+		tc := testCase
+		description := fmt.Sprintf("sanitizeHTTPAddress(%s, %t) => (%s, %v)", tc.address, tc.preferHTTPS, tc.expected, tc.err)
+		t.Run(description, func(t *testing.T) {
+			assert := assert.New(t)
+			actual, err := sanitizeHTTPAddress(tc.address, tc.preferHTTPS)
+			assert.Equal(tc.expected, actual)
+			assert.Equal(tc.err, err)
+		})
+	}
 }
 
 func runGrpcClientTests(assert *assert.Assertions, cfg config.View, rpcParams *ServerParams) {


### PR DESCRIPTION
The RPC client cache will be used for the MMF frontend service in addition to the backend service. This change breaks it out from the backend and adds tests for it.