### PR TITLE
Config cleanup and improved health checking (#623)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,6 @@ ifeq ($(GCP_PROJECT_ID),)
 endif
 
 ifeq ($(OS),Windows_NT)
-	# TODO: Windows packages are here but things are broken since many paths are Linux based and zip vs tar.gz.
 	HELM_PACKAGE = https://storage.googleapis.com/kubernetes-helm/helm-v$(HELM_VERSION)-windows-amd64.zip
 	MINIKUBE_PACKAGE = https://storage.googleapis.com/minikube/releases/$(MINIKUBE_VERSION)/minikube-windows-amd64.exe
 	SKAFFOLD_PACKAGE = https://storage.googleapis.com/skaffold/releases/$(SKAFFOLD_VERSION)/skaffold-windows-amd64.exe

--- a/install/helm/open-match/templates/backend.yaml
+++ b/install/helm/open-match/templates/backend.yaml
@@ -64,7 +64,7 @@ spec:
       containers:
       - name: om-backend
         image: "{{ .Values.openmatch.image.registry }}/{{ .Values.openmatch.image.backend.name}}:{{ .Values.openmatch.image.tag }}"
-        imagePullPolicy: {{ .Values.openmatch.image.backend.pullPolicy }}
+        imagePullPolicy: {{ .Values.openmatch.image.pullPolicy }}
         volumeMounts:
         - name: om-config-volume
           mountPath: {{ .Values.openmatch.config.mountPath }}

--- a/install/helm/open-match/templates/demo.yaml
+++ b/install/helm/open-match/templates/demo.yaml
@@ -61,7 +61,7 @@ spec:
       containers:
       - name: om-demo
         image: "{{ .Values.openmatch.image.registry }}/{{ .Values.openmatch.image.demo.name}}:{{ .Values.openmatch.image.tag }}"
-        imagePullPolicy: {{ .Values.openmatch.image.demo.pullPolicy }}
+        imagePullPolicy: {{ .Values.openmatch.image.pullPolicy }}
         volumeMounts:
         - name: om-config-volume
           mountPath: {{ .Values.openmatch.config.mountPath }}

--- a/install/helm/open-match/templates/demoevaluator.yaml
+++ b/install/helm/open-match/templates/demoevaluator.yaml
@@ -63,7 +63,7 @@ spec:
       containers:
       - name: om-demoevaluator
         image: "{{ .Values.openmatch.image.registry }}/{{ .Values.openmatch.image.demoevaluator.name}}:{{ .Values.openmatch.image.tag }}"
-        imagePullPolicy: {{ .Values.openmatch.image.demoevaluator.pullPolicy }}
+        imagePullPolicy: {{ .Values.openmatch.image.pullPolicy }}
         volumeMounts:
         - name: om-config-volume
           mountPath: {{ .Values.openmatch.config.mountPath }}

--- a/install/helm/open-match/templates/demofunction.yaml
+++ b/install/helm/open-match/templates/demofunction.yaml
@@ -64,7 +64,7 @@ spec:
       containers:
       - name: om-demofunction
         image: "{{ .Values.openmatch.image.registry }}/{{ .Values.openmatch.image.demofunction.name}}:{{ .Values.openmatch.image.tag }}"
-        imagePullPolicy: {{ .Values.openmatch.image.demofunction.pullPolicy }}
+        imagePullPolicy: {{ .Values.openmatch.image.pullPolicy }}
         volumeMounts:
         - name: om-config-volume
           mountPath: {{ .Values.openmatch.config.mountPath }}

--- a/install/helm/open-match/templates/e2eevaluator.yaml
+++ b/install/helm/open-match/templates/e2eevaluator.yaml
@@ -63,7 +63,7 @@ spec:
       containers:
       - name: om-e2eevaluator
         image: "{{ .Values.openmatch.image.registry }}/{{ .Values.openmatch.image.e2eevaluator.name}}:{{ .Values.openmatch.image.tag }}"
-        imagePullPolicy: {{ .Values.openmatch.image.e2eevaluator.pullPolicy }}
+        imagePullPolicy: {{ .Values.openmatch.image.pullPolicy }}
         volumeMounts:
         - name: om-config-volume
           mountPath: {{ .Values.openmatch.config.mountPath }}

--- a/install/helm/open-match/templates/e2ematchfunction.yaml
+++ b/install/helm/open-match/templates/e2ematchfunction.yaml
@@ -64,7 +64,7 @@ spec:
       containers:
       - name: om-e2ematchfunction
         image: "{{ .Values.openmatch.image.registry }}/{{ .Values.openmatch.image.e2ematchfunction.name}}:{{ .Values.openmatch.image.tag }}"
-        imagePullPolicy: {{ .Values.openmatch.image.e2ematchfunction.pullPolicy }}
+        imagePullPolicy: {{ .Values.openmatch.image.pullPolicy }}
         volumeMounts:
         - name: om-config-volume
           mountPath: {{ .Values.openmatch.config.mountPath }}

--- a/install/helm/open-match/templates/frontend.yaml
+++ b/install/helm/open-match/templates/frontend.yaml
@@ -65,7 +65,7 @@ spec:
       containers:
       - name: om-frontend
         image: "{{ .Values.openmatch.image.registry }}/{{ .Values.openmatch.image.frontend.name}}:{{ .Values.openmatch.image.tag }}"
-        imagePullPolicy: {{ .Values.openmatch.image.frontend.pullPolicy }}
+        imagePullPolicy: {{ .Values.openmatch.image.pullPolicy }}
         volumeMounts:
         - name: om-config-volume
           mountPath: {{ .Values.openmatch.config.mountPath }}

--- a/install/helm/open-match/templates/mmlogic.yaml
+++ b/install/helm/open-match/templates/mmlogic.yaml
@@ -65,7 +65,7 @@ spec:
       containers:
       - name: om-mmlogic
         image: "{{ .Values.openmatch.image.registry }}/{{ .Values.openmatch.image.mmlogic.name}}:{{ .Values.openmatch.image.tag }}"
-        imagePullPolicy: {{ .Values.openmatch.image.mmlogic.pullPolicy }}
+        imagePullPolicy: {{ .Values.openmatch.image.pullPolicy }}
         volumeMounts:
         - name: om-config-volume
           mountPath: {{ .Values.openmatch.config.mountPath }}

--- a/install/helm/open-match/templates/podsecuritypolicy.yaml
+++ b/install/helm/open-match/templates/podsecuritypolicy.yaml
@@ -84,7 +84,7 @@ spec:
   #- ALL
   runAsUser:
     rule: "RunAsAny"
-    # Blocked on https://github.com/GoogleContainerTools/distroless/pull/368
+    # Blocked on isolating the open match services from dependencies (Redis, Prometheus, etc.)
     # Require the container to run without root privileges.
     #rule: 'MustRunAsNonRoot'
   seLinux:

--- a/install/helm/open-match/templates/swaggerui.yaml
+++ b/install/helm/open-match/templates/swaggerui.yaml
@@ -59,7 +59,7 @@ spec:
       containers:
       - name: om-swaggerui
         image: "{{ .Values.openmatch.image.registry }}/{{ .Values.openmatch.image.swaggerui.name}}:{{ .Values.openmatch.image.tag }}"
-        imagePullPolicy: {{ .Values.openmatch.image.swaggerui.pullPolicy }}
+        imagePullPolicy: {{ .Values.openmatch.image.pullPolicy }}
         volumeMounts:
         - name: om-config-volume
           mountPath: {{ .Values.openmatch.config.mountPath }}

--- a/install/helm/open-match/templates/synchronizer.yaml
+++ b/install/helm/open-match/templates/synchronizer.yaml
@@ -64,7 +64,7 @@ spec:
       containers:
       - name: om-synchronizer
         image: "{{ .Values.openmatch.image.registry }}/{{ .Values.openmatch.image.synchronizer.name}}:{{ .Values.openmatch.image.tag }}"
-        imagePullPolicy: {{ .Values.openmatch.image.synchronizer.pullPolicy }}
+        imagePullPolicy: {{ .Values.openmatch.image.pullPolicy }}
         volumeMounts:
         - name: om-config-volume
           mountPath: {{ .Values.openmatch.config.mountPath }}

--- a/install/helm/open-match/values.yaml
+++ b/install/helm/open-match/values.yaml
@@ -160,6 +160,9 @@ openmatch:
             httpport: "{{.Values.openmatch.demoevaluator.http.port}}"
           swaggerui:
             httpport: "{{.Values.openmatch.swaggerui.http.port}}"
+          demo:
+            hostname: om-demo
+            httpport: "{{.Values.openmatch.demo.http.port}}"
 
         synchronizer:
           enabled: false
@@ -245,43 +248,33 @@ openmatch:
   image:
     registry: gcr.io/open-match-public-images
     tag: 0.0.0-dev
+    pullPolicy: Always
     backend:
       name: openmatch-backend
-      pullPolicy: Always
     frontend:
       name: openmatch-frontend
-      pullPolicy: Always
     mmlogic:
       name: openmatch-mmlogic
-      pullPolicy: Always
     synchronizer:
       name: openmatch-synchronizer
-      pullPolicy: Always
     swaggerui:
       name: openmatch-swaggerui
-      pullPolicy: Always
     demoevaluator:
       name: openmatch-evaluator-go-simple
-      pullPolicy: Always
     demofunction:
       name: openmatch-mmf-go-soloduel
-      pullPolicy: Always
     demo:
       name: openmatch-demo
-      pullPolicy: Always
     e2ematchfunction:
       name: openmatch-mmf-go-pool
-      pullPolicy: Always
     e2eevaluator:
       name: openmatch-evaluator-go-simple
-      pullPolicy: Always
 
 # https://hub.helm.sh/charts/stable/redis
 # https://github.com/helm/charts/tree/master/stable/redis
 redis:
   fullnameOverride: om-redis
-  # TODO: Temporarily disable password protected Redis until all the examples are no longer talking directly to the database.
-  usePassword: false
+  usePassword: true
   master:
     disableCommands: [] # don't disable 'FLUSH-' commands
   metrics:

--- a/internal/app/swaggerui/swaggerui.go
+++ b/internal/app/swaggerui/swaggerui.go
@@ -16,7 +16,6 @@
 package swaggerui
 
 import (
-	"context"
 	"os"
 
 	"fmt"
@@ -65,7 +64,7 @@ func serve(cfg config.View) {
 	}
 
 	mux.Handle("/", http.FileServer(http.Dir(directory)))
-	mux.HandleFunc("/healthz", monitoring.NewHealthProbe([]func(context.Context) error{}))
+	mux.Handle(monitoring.HealthCheckEndpoint, monitoring.NewAlwaysReadyHealthCheck())
 	bindHandler(mux, cfg, "/v1/frontend/", "frontend")
 	bindHandler(mux, cfg, "/v1/backend/", "backend")
 	bindHandler(mux, cfg, "/v1/mmlogic/", "mmlogic")

--- a/internal/monitoring/probe.go
+++ b/internal/monitoring/probe.go
@@ -17,23 +17,71 @@ package monitoring
 import (
 	"context"
 	"fmt"
+	"github.com/sirupsen/logrus"
 	"net/http"
+	"sync/atomic"
 )
 
-// NewHealthProbe creates an HTTP handler for Kubernetes liveness and readiness checks.
-func NewHealthProbe(probes []func(context.Context) error) func(http.ResponseWriter, *http.Request) {
-	return func(w http.ResponseWriter, req *http.Request) {
-		if len(req.URL.Query()) > 0 {
-			// Readiness probe are triggered if there's a query (ie "?" in the url).
-			// If so then scan all the probes.
-			for _, probe := range probes {
-				err := probe(req.Context())
-				if err != nil {
-					http.Error(w, err.Error(), http.StatusServiceUnavailable)
-					return
+const (
+	// HealthCheckEndpoint is the endpoint for Kubernetes health probes.
+	// See: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
+	HealthCheckEndpoint   = "/healthz"
+	healthStateFirstProbe = int32(0)
+	healthStateHealthy    = int32(1)
+	healthStateUnhealthy  = int32(2)
+)
+
+var (
+	probeLogger = logrus.WithFields(logrus.Fields{
+		"app":       "openmatch",
+		"component": "monitoring.probe",
+	})
+)
+
+type statefulProbe struct {
+	healthState *int32
+	probes      []func(context.Context) error
+}
+
+// ServeHTTP serves the health check endpoint to tell Kubernetes that the service is healthy.
+// This class will print logs based on the health status.
+func (sp *statefulProbe) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	if len(req.URL.Query()) > 0 {
+		// Readiness probe are triggered if there's a query (ie "?" in the url).
+		// If so then scan all the probes.
+		for _, probe := range sp.probes {
+			err := probe(req.Context())
+			if err != nil {
+				old := atomic.SwapInt32(sp.healthState, healthStateUnhealthy)
+				if old == healthStateUnhealthy {
+					probeLogger.WithError(err).Warningf("%s health check continues to fail. The server is at risk of termination.", HealthCheckEndpoint)
+				} else {
+					probeLogger.WithError(err).Warningf("%s health check failed. The server will terminate if this continues to happen.", HealthCheckEndpoint)
 				}
+				http.Error(w, err.Error(), http.StatusServiceUnavailable)
+				return
 			}
 		}
-		fmt.Fprintf(w, "ok")
+		old := atomic.SwapInt32(sp.healthState, healthStateHealthy)
+		if old == healthStateUnhealthy {
+			probeLogger.Infof("%s is healthy again.", HealthCheckEndpoint)
+		} else if old == healthStateFirstProbe {
+			probeLogger.Infof("%s is reporting healthy, .", HealthCheckEndpoint)
+		}
+	}
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprintf(w, "ok")
+}
+
+// NewAlwaysReadyHealthCheck indicates that the service is always healthy. Used for static HTTP servers.
+func NewAlwaysReadyHealthCheck() http.Handler {
+	return NewHealthCheck([]func(context.Context) error{})
+}
+
+// NewHealthCheck creates an HTTP handler for Kubernetes liveness and readiness checks.
+func NewHealthCheck(probes []func(context.Context) error) http.Handler {
+	return &statefulProbe{
+		healthState: new(int32),
+		probes:      probes,
 	}
 }

--- a/internal/monitoring/probe_test.go
+++ b/internal/monitoring/probe_test.go
@@ -17,11 +17,11 @@ package monitoring
 import (
 	"context"
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/url"
+	"sync/atomic"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func angryHealthCheck(context.Context) error {
@@ -30,6 +30,10 @@ func angryHealthCheck(context.Context) error {
 
 func happyHealthCheck(context.Context) error {
 	return nil
+}
+
+func TestAlwaysReadyHealthCheck(t *testing.T) {
+	assertHealthCheck(t, NewAlwaysReadyHealthCheck(), "")
 }
 
 func TestHealthCheck(t *testing.T) {
@@ -44,14 +48,28 @@ func TestHealthCheck(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			assert := assert.New(t)
-			hc := NewHealthProbe(tc.healthChecks)
-			assert.HTTPSuccess(hc, http.MethodGet, "/", url.Values{}, "ok")
-			if tc.errorString == "" {
-				assert.HTTPSuccess(hc, http.MethodGet, "/?readiness=true", url.Values{}, "ok")
-			} else {
-				assert.HTTPError(hc, http.MethodGet, "/", url.Values{"readiness": []string{"true"}}, tc.errorString)
-			}
+			assertHealthCheck(t, NewHealthCheck(tc.healthChecks), tc.errorString)
 		})
+	}
+}
+
+func assertHealthCheck(t *testing.T, hc http.Handler, errorString string) {
+	assert := assert.New(t)
+	sp, ok := hc.(*statefulProbe)
+	assert.True(ok)
+	assert.Equal(healthStateFirstProbe, atomic.LoadInt32(sp.healthState))
+
+	hcFunc := func(w http.ResponseWriter, r *http.Request) {
+		hc.ServeHTTP(w, r)
+	}
+	assert.HTTPSuccess(hcFunc, http.MethodGet, "/", url.Values{}, "ok")
+	// A readiness probe has not happened yet so it's still in "first state"
+	assert.Equal(healthStateFirstProbe, atomic.LoadInt32(sp.healthState))
+	if errorString == "" {
+		assert.HTTPSuccess(hcFunc, http.MethodGet, "/", url.Values{"readiness": []string{"true"}}, "ok")
+		assert.Equal(healthStateHealthy, atomic.LoadInt32(sp.healthState))
+	} else {
+		assert.HTTPError(hcFunc, http.MethodGet, "/", url.Values{"readiness": []string{"true"}}, errorString)
+		assert.Equal(healthStateUnhealthy, atomic.LoadInt32(sp.healthState))
 	}
 }

--- a/internal/rpc/clients_test.go
+++ b/internal/rpc/clients_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
+	"open-match.dev/open-match/internal/monitoring"
 	shellTesting "open-match.dev/open-match/internal/testing"
 	netlistenerTesting "open-match.dev/open-match/internal/util/netlistener/testing"
 	"open-match.dev/open-match/pkg/pb"
@@ -139,7 +140,7 @@ func runHTTPClientTests(assert *assert.Assertions, cfg config.View, rpcParams *S
 	assert.Nil(err)
 
 	// Confirm the client works as expected
-	httpReq, err := http.NewRequest(http.MethodGet, baseURL+"/healthz", nil)
+	httpReq, err := http.NewRequest(http.MethodGet, baseURL+monitoring.HealthCheckEndpoint, nil)
 	assert.Nil(err)
 	assert.NotNil(httpReq)
 

--- a/internal/rpc/insecure.go
+++ b/internal/rpc/insecure.go
@@ -70,6 +70,7 @@ func (s *insecureServer) start(params *ServerParams) (func(), error) {
 	serverStartWaiter.Add(1)
 	go func() {
 		serverStartWaiter.Done()
+		insecureLogger.Infof("Serving gRPC: %s", s.grpcLh.AddrString())
 		gErr := s.grpcServer.Serve(s.grpcListener)
 		if gErr != nil {
 			return
@@ -93,7 +94,7 @@ func (s *insecureServer) start(params *ServerParams) (func(), error) {
 		}
 	}
 
-	s.httpMux.HandleFunc("/healthz", monitoring.NewHealthProbe(params.handlersForHealthCheck))
+	s.httpMux.Handle(monitoring.HealthCheckEndpoint, monitoring.NewHealthCheck(params.handlersForHealthCheck))
 	s.httpMux.Handle("/", s.proxyMux)
 	s.httpServer = &http.Server{
 		Addr:    s.httpListener.Addr().String(),
@@ -102,6 +103,7 @@ func (s *insecureServer) start(params *ServerParams) (func(), error) {
 	serverStartWaiter.Add(1)
 	go func() {
 		serverStartWaiter.Done()
+		insecureLogger.Infof("Serving HTTP: %s", s.httpLh.AddrString())
 		hErr := s.httpServer.Serve(s.httpListener)
 		defer cancel()
 		if hErr != nil {

--- a/internal/rpc/server_test.go
+++ b/internal/rpc/server_test.go
@@ -17,18 +17,17 @@ package rpc
 import (
 	"context"
 	"fmt"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
 	"io/ioutil"
 	"net/http"
+	"open-match.dev/open-match/internal/monitoring"
+	shellTesting "open-match.dev/open-match/internal/testing"
+	netlistenerTesting "open-match.dev/open-match/internal/util/netlistener/testing"
+	"open-match.dev/open-match/pkg/pb"
 	"strings"
 	"testing"
 	"time"
-
-	"open-match.dev/open-match/pkg/pb"
-
-	"github.com/stretchr/testify/assert"
-	"google.golang.org/grpc"
-	shellTesting "open-match.dev/open-match/internal/testing"
-	netlistenerTesting "open-match.dev/open-match/internal/util/netlistener/testing"
 )
 
 func TestStartStopServer(t *testing.T) {
@@ -105,7 +104,7 @@ func runGrpcWithProxyTests(assert *assert.Assertions, s grpcServerWithProxy, con
 	assert.Equal(200, httpResp.StatusCode)
 	assert.Equal("{}", string(body))
 
-	httpReq, err = http.NewRequest(http.MethodGet, endpoint+"/healthz", nil)
+	httpReq, err = http.NewRequest(http.MethodGet, endpoint+monitoring.HealthCheckEndpoint, nil)
 	assert.Nil(err)
 
 	httpResp, err = httpClient.Do(httpReq)


### PR DESCRIPTION
Remove redundant pullPolicy for images and unify the health checking logic for all services.
The health checker is now stateful so it can report more useful log messages.