### PR TITLE
Add config based metrics and logging for gRPC.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/golang/protobuf v1.3.1
 	github.com/gomodule/redigo v1.7.1-0.20190322064113-39e2c31b7ca3
 	github.com/google/go-cmp v0.3.0
+	github.com/grpc-ecosystem/go-grpc-middleware v1.0.0
 	github.com/grpc-ecosystem/grpc-gateway v1.9.2
 	github.com/imdario/mergo v0.3.7 // indirect
 	github.com/openzipkin/zipkin-go v0.1.6

--- a/go.sum
+++ b/go.sum
@@ -111,6 +111,7 @@ github.com/gorilla/mux v1.6.2 h1:Pgr17XVTNXAk3q/r4CpKzC5xBM/qW1uVLV+IhRZpIIk=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gregjones/httpcache v0.0.0-20170728041850-787624de3eb7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
+github.com/grpc-ecosystem/go-grpc-middleware v1.0.0 h1:Iju5GlWwrvL6UBg4zJJt3btmonfrMlCDdsejg4CZE7c=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=

--- a/install/helm/open-match/dashboards/README.md
+++ b/install/helm/open-match/dashboards/README.md
@@ -18,5 +18,7 @@ Steps
  1. Download the file into this directory.
 
 Some templates came from the Grafana Labs site.
+To update copy and paste the URL into the import dashboard page and then click "Share" and save the JSON to a file.
+Do not download the JSON directly from the website.
 
 go-processes.json - https://grafana.com/dashboards/6671

--- a/install/helm/open-match/values.yaml
+++ b/install/helm/open-match/values.yaml
@@ -115,6 +115,7 @@ openmatch:
         logging:
           level: debug
           format: text
+          rpc: true
         # Open Match applies the exponential backoff strategy for its retryable gRPC calls.
         # The settings below are the default backoff configuration used in Open Match.
         # See https://github.com/cenkalti/backoff/blob/v3/exponential.go for detailed explanations

--- a/internal/monitoring/public.go
+++ b/internal/monitoring/public.go
@@ -19,9 +19,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
-	"go.opencensus.io/plugin/ocgrpc"
 	"go.opencensus.io/stats/view"
-	"google.golang.org/grpc"
 	"open-match.dev/open-match/internal/config"
 )
 
@@ -31,11 +29,6 @@ var (
 		"component": "monitoring",
 	})
 )
-
-// MetricsForClient yeah
-func MetricsForClient() grpc.DialOption {
-	return grpc.WithStatsHandler(new(ocgrpc.ClientHandler))
-}
 
 // Setup configures the monitoring for the server.
 func Setup(mux *http.ServeMux, cfg config.View) {

--- a/internal/rpc/clients.go
+++ b/internal/rpc/clients.go
@@ -24,12 +24,21 @@ import (
 	"strings"
 	"time"
 
+	grpc_logrus "github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus"
+	"go.opencensus.io/plugin/ocgrpc"
+
+	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
+	grpc_retry "github.com/grpc-ecosystem/go-grpc-middleware/retry"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"open-match.dev/open-match/internal/config"
-	"open-match.dev/open-match/internal/monitoring"
+)
+
+const (
+	configNameEnableRPCLogging = "logging.rpc"
+	configNameEnableMetrics    = "monitoring.prometheus.enabled"
 )
 
 var (
@@ -44,6 +53,8 @@ type ClientParams struct {
 	Hostname           string
 	Port               int
 	TrustedCertificate []byte
+	EnableRPCLogging   bool
+	EnableMetrics      bool
 }
 
 func (p *ClientParams) usingTLS() bool {
@@ -53,8 +64,10 @@ func (p *ClientParams) usingTLS() bool {
 // GRPCClientFromConfig creates a gRPC client connection from a configuration.
 func GRPCClientFromConfig(cfg config.View, prefix string) (*grpc.ClientConn, error) {
 	clientParams := &ClientParams{
-		Hostname: cfg.GetString(prefix + ".hostname"),
-		Port:     cfg.GetInt(prefix + ".grpcport"),
+		Hostname:         cfg.GetString(prefix + ".hostname"),
+		Port:             cfg.GetInt(prefix + ".grpcport"),
+		EnableRPCLogging: cfg.GetBool(configNameEnableRPCLogging),
+		EnableMetrics:    cfg.GetBool(configNameEnableMetrics),
 	}
 
 	// If TLS support is enabled in the config, fill in the trusted certificates for decrpting server certificate.
@@ -78,7 +91,7 @@ func GRPCClientFromConfig(cfg config.View, prefix string) (*grpc.ClientConn, err
 // GRPCClientFromEndpoint creates a gRPC client connection from endpoint.
 func GRPCClientFromEndpoint(cfg config.View, address string) (*grpc.ClientConn, error) {
 	// TODO: investigate if it is possible to keep a cache of the certpool and transport credentials
-	grpcOptions := newDefaultGRPCDialOptions()
+	grpcOptions := newGRPCDialOptions(cfg.GetBool(configNameEnableMetrics), cfg.GetBool(configNameEnableRPCLogging))
 
 	if cfg.GetBool("tls.enabled") {
 		_, err := os.Stat(cfg.GetString("tls.trustedCertificatePath"))
@@ -112,7 +125,7 @@ func GRPCClientFromEndpoint(cfg config.View, address string) (*grpc.ClientConn, 
 func GRPCClientFromParams(params *ClientParams) (*grpc.ClientConn, error) {
 	address := fmt.Sprintf("%s:%d", params.Hostname, params.Port)
 
-	grpcOptions := newDefaultGRPCDialOptions()
+	grpcOptions := newGRPCDialOptions(params.EnableMetrics, params.EnableRPCLogging)
 
 	if params.usingTLS() {
 		trustedCertPool, err := trustedCertificateFromFileData(params.TrustedCertificate)
@@ -131,8 +144,10 @@ func GRPCClientFromParams(params *ClientParams) (*grpc.ClientConn, error) {
 // HTTPClientFromConfig creates a HTTP client from from a configuration.
 func HTTPClientFromConfig(cfg config.View, prefix string) (*http.Client, string, error) {
 	clientParams := &ClientParams{
-		Hostname: cfg.GetString(prefix + ".hostname"),
-		Port:     cfg.GetInt(prefix + ".httpport"),
+		Hostname:         cfg.GetString(prefix + ".hostname"),
+		Port:             cfg.GetInt(prefix + ".httpport"),
+		EnableRPCLogging: cfg.GetBool(configNameEnableRPCLogging),
+		EnableMetrics:    cfg.GetBool(configNameEnableMetrics),
 	}
 
 	// If TLS support is enabled in the config, fill in the trusted certificates for decrpting server certificate.
@@ -259,6 +274,27 @@ func HTTPClientFromParams(params *ClientParams) (*http.Client, string, error) {
 	return httpClient, baseURL, nil
 }
 
-func newDefaultGRPCDialOptions() []grpc.DialOption {
-	return []grpc.DialOption{monitoring.MetricsForClient()}
+func newGRPCDialOptions(enableMetrics bool, enableRPCLogging bool) []grpc.DialOption {
+	si := []grpc.StreamClientInterceptor{
+		grpc_retry.StreamClientInterceptor(),
+	}
+	ui := []grpc.UnaryClientInterceptor{
+		grpc_retry.UnaryClientInterceptor(),
+	}
+	if enableRPCLogging {
+		grpcLogger := logrus.WithFields(logrus.Fields{
+			"app":       "openmatch",
+			"component": "grpc.client",
+		})
+		si = append(si, grpc_logrus.StreamClientInterceptor(grpcLogger))
+		ui = append(ui, grpc_logrus.UnaryClientInterceptor(grpcLogger))
+	}
+	opts := []grpc.DialOption{
+		grpc.WithStreamInterceptor(grpc_middleware.ChainStreamClient(si...)),
+		grpc.WithUnaryInterceptor(grpc_middleware.ChainUnaryClient(ui...)),
+	}
+	if enableMetrics {
+		opts = append(opts, grpc.WithStatsHandler(new(ocgrpc.ClientHandler)))
+	}
+	return opts
 }

--- a/internal/rpc/insecure.go
+++ b/internal/rpc/insecure.go
@@ -24,7 +24,6 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"go.opencensus.io/plugin/ocgrpc"
 	"google.golang.org/grpc"
 	"open-match.dev/open-match/internal/monitoring"
 	"open-match.dev/open-match/internal/util/netlistener"
@@ -61,7 +60,8 @@ func (s *insecureServer) start(params *ServerParams) (func(), error) {
 		return func() {}, errors.WithStack(err)
 	}
 	s.grpcListener = grpcListener
-	s.grpcServer = grpc.NewServer(grpc.StatsHandler(&ocgrpc.ServerHandler{}))
+
+	s.grpcServer = grpc.NewServer(newGRPCServerOptions(params)...)
 	// Bind gRPC handlers
 	for _, handlerFunc := range params.handlersForGrpc {
 		handlerFunc(s.grpcServer)
@@ -88,7 +88,7 @@ func (s *insecureServer) start(params *ServerParams) (func(), error) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	for _, handlerFunc := range params.handlersForGrpcProxy {
-		dialOpts := newDefaultGRPCDialOptions()
+		dialOpts := newGRPCDialOptions(params.enableMetrics, params.enableRPCLogging)
 		dialOpts = append(dialOpts, grpc.WithInsecure())
 		if err = handlerFunc(ctx, s.proxyMux, grpcListener.Addr().String(), dialOpts); err != nil {
 			cancel()

--- a/internal/rpc/testing/helpers.go
+++ b/internal/rpc/testing/helpers.go
@@ -148,6 +148,8 @@ func (tc *TestContext) newClientParams(address string) *rpc.ClientParams {
 		Hostname:           hostname,
 		Port:               port,
 		TrustedCertificate: tc.trustedCertificate,
+		EnableRPCLogging:   true,
+		EnableMetrics:      false,
 	}
 }
 

--- a/internal/rpc/tls_server.go
+++ b/internal/rpc/tls_server.go
@@ -26,7 +26,6 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"go.opencensus.io/plugin/ocgrpc"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"open-match.dev/open-match/internal/monitoring"
@@ -85,7 +84,10 @@ func (s *tlsServer) start(params *ServerParams) (func(), error) {
 		return func() {}, errors.WithStack(err)
 	}
 	creds := credentials.NewServerTLSFromCert(grpcTLSCertificate)
-	s.grpcServer = grpc.NewServer(grpc.Creds(creds), grpc.StatsHandler(&ocgrpc.ServerHandler{}))
+	serverOpts := newGRPCServerOptions(params)
+	serverOpts = append(serverOpts, grpc.Creds(creds))
+	s.grpcServer = grpc.NewServer(serverOpts...)
+
 	// Bind gRPC handlers
 	for _, handlerFunc := range params.handlersForGrpc {
 		handlerFunc(s.grpcServer)
@@ -110,7 +112,7 @@ func (s *tlsServer) start(params *ServerParams) (func(), error) {
 	// Bind gRPC handlers
 	ctx, cancel := context.WithCancel(context.Background())
 
-	httpsToGrpcProxyOptions := newDefaultGRPCDialOptions()
+	httpsToGrpcProxyOptions := newGRPCDialOptions(params.enableMetrics, params.enableRPCLogging)
 	httpsToGrpcProxyOptions = append(httpsToGrpcProxyOptions, grpc.WithTransportCredentials(credentials.NewClientTLSFromCert(certPoolForGrpcEndpoint, "")))
 
 	for _, handlerFunc := range params.handlersForGrpcProxy {

--- a/internal/testing/e2e/cluster.go
+++ b/internal/testing/e2e/cluster.go
@@ -102,8 +102,10 @@ func (com *clusterOM) getAddressFromServiceName(serviceName string) (string, int
 func (com *clusterOM) getGRPCClientFromServiceName(serviceName string) (*grpc.ClientConn, error) {
 	ipAddress, port := com.getAddressFromServiceName(serviceName)
 	conn, err := rpc.GRPCClientFromParams(&rpc.ClientParams{
-		Hostname: ipAddress,
-		Port:     int(port),
+		Hostname:         ipAddress,
+		Port:             int(port),
+		EnableRPCLogging: true,
+		EnableMetrics:    false,
 	})
 	if err != nil {
 		return nil, errors.Wrapf(err, "cannot connect to gRPC %s:%d", ipAddress, port)


### PR DESCRIPTION
This change introduces verbose logging mode for gRPC calls and the enablement of metrics based on Prometheus being configured.

The `matchmaker_config.yaml` will have a new option to enable RPC verbose logging:
```yaml
logging:
  rpc: true
```

This change also introduces a few other gRPC middlewares (panic-recovery, and API field validation). API field validation is not currently used yet but the protos will be updated soon.