### PR TITLE
Fix Open Match logo in Helm chart

### DIFF
--- a/install/helm/open-match/Chart.yaml
+++ b/install/helm/open-match/Chart.yaml
@@ -32,5 +32,5 @@ maintainers:
    email: open-match-discuss@googlegroups.com
    url: https://groups.google.com/forum/#!forum/open-match-discuss
 engine: gotpl
-icon: https://raw.githubusercontent.com/googleforgames/open-match/master/site/static/images/logo.svg
+icon: https://open-match.dev/site/images/logo.svg
 tillerVersion: ">2.10.0"


### PR DESCRIPTION
This is an artifact that was moved to open-match-docs.