### PR TITLE
Add metrics for Open Match

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -209,6 +209,9 @@ issues:
     - source: "flag."
       linters:
         - gochecknoglobals
+    - source: "monitoring."
+      linters:
+        - gochecknoglobals
     - source: "View."
       linters:
         - gochecknoglobals

--- a/install/helm/open-match/dashboards/storage.json
+++ b/install/helm/open-match/dashboards/storage.json
@@ -1,0 +1,314 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": "-- Grafana --",
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 0,
+    "id": 4,
+    "links": [],
+    "panels": [
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "fill": 1,
+        "gridPos": {
+          "h": 9,
+          "w": 12,
+          "x": 0,
+          "y": 0
+        },
+        "id": 2,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null",
+        "options": {},
+        "percentage": false,
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [
+          {
+            "alias": "Get Assignments",
+            "yaxis": 2
+          }
+        ],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "sum(rate(statestore_createticket[$timewindow]))",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "Create Ticket",
+            "refId": "A"
+          },
+          {
+            "expr": "sum(rate(statestore_indexticket[$timewindow]))",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "Index Ticket",
+            "refId": "B"
+          },
+          {
+            "expr": "sum(rate(statestore_deindexticket[$timewindow]))",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "Deindex Ticket",
+            "refId": "D"
+          },
+          {
+            "expr": "sum(rate(statestore_updateassignment[$timewindow]))",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "Update Assignment",
+            "refId": "F"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Write Operations",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "decimals": null,
+            "format": "wps",
+            "label": null,
+            "logBase": 2,
+            "max": null,
+            "min": "0",
+            "show": true
+          },
+          {
+            "decimals": null,
+            "format": "rps",
+            "label": null,
+            "logBase": 2,
+            "max": null,
+            "min": "0",
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "fill": 1,
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 0
+        },
+        "id": 4,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null",
+        "options": {},
+        "percentage": false,
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "sum(rate(statestore_getassignments[$timewindow]))",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "Get Assignment",
+            "refId": "A"
+          },
+          {
+            "expr": "sum(rate(statestore_filterticket[$timewindow]))",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "Filter Ticket",
+            "refId": "B"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Read Operations",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "rps",
+            "label": null,
+            "logBase": 2,
+            "max": null,
+            "min": "0",
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      }
+    ],
+    "schemaVersion": 18,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+      "list": [
+        {
+          "allValue": null,
+          "current": {
+            "text": "5m",
+            "value": "5m"
+          },
+          "hide": 0,
+          "includeAll": false,
+          "label": "Time Window",
+          "multi": false,
+          "name": "timewindow",
+          "options": [
+            {
+              "selected": true,
+              "text": "5m",
+              "value": "5m"
+            },
+            {
+              "selected": false,
+              "text": "10m",
+              "value": "10m"
+            },
+            {
+              "selected": false,
+              "text": "15m",
+              "value": "15m"
+            },
+            {
+              "selected": false,
+              "text": "30m",
+              "value": "30m"
+            },
+            {
+              "selected": false,
+              "text": "1h",
+              "value": "1h"
+            },
+            {
+              "selected": false,
+              "text": "4h",
+              "value": "4h"
+            }
+          ],
+          "query": "5m,10m,15m,30m,1h,4h",
+          "skipUrlSync": false,
+          "type": "custom"
+        }
+      ]
+    },
+    "time": {
+      "from": "now-6h",
+      "to": "now"
+    },
+    "timepicker": {
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "time_options": [
+        "5m",
+        "15m",
+        "1h",
+        "6h",
+        "12h",
+        "24h",
+        "2d",
+        "7d",
+        "30d"
+      ]
+    },
+    "timezone": "",
+    "title": "Storage",
+    "uid": "4mIVcfSWz",
+    "version": 3
+  }

--- a/install/helm/open-match/dashboards/tickets.json
+++ b/install/helm/open-match/dashboards/tickets.json
@@ -1,0 +1,290 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": "-- Grafana --",
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 0,
+    "id": 3,
+    "iteration": 1562886170229,
+    "links": [],
+    "panels": [
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "fill": 1,
+        "gridPos": {
+          "h": 9,
+          "w": 12,
+          "x": 0,
+          "y": 0
+        },
+        "id": 2,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null",
+        "options": {},
+        "percentage": false,
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "sum(rate(frontend_tickets_created[$timewindow]))",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "Created",
+            "refId": "A"
+          },
+          {
+            "expr": "sum(rate(frontend_tickets_deleted[$timewindow]))",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "Deleted",
+            "refId": "B"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Ticket Flow",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "description": "",
+        "fill": 1,
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 0
+        },
+        "id": 4,
+        "interval": "",
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null",
+        "options": {},
+        "percentage": false,
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "sum(rate(frontend_tickets_assignments_retrieved[$timewindow]))",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "Assignments Retrieved",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Assignments",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "decimals": null,
+            "format": "reqps",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": "0",
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      }
+    ],
+    "schemaVersion": 18,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+      "list": [
+        {
+          "allValue": null,
+          "current": {
+            "text": "5m",
+            "value": "5m"
+          },
+          "hide": 0,
+          "includeAll": false,
+          "label": "Time Window",
+          "multi": false,
+          "name": "timewindow",
+          "options": [
+            {
+              "selected": true,
+              "text": "5m",
+              "value": "5m"
+            },
+            {
+              "selected": false,
+              "text": "10m",
+              "value": "10m"
+            },
+            {
+              "selected": false,
+              "text": "15m",
+              "value": "15m"
+            },
+            {
+              "selected": false,
+              "text": "30m",
+              "value": "30m"
+            },
+            {
+              "selected": false,
+              "text": "1h",
+              "value": "1h"
+            },
+            {
+              "selected": false,
+              "text": "4h",
+              "value": "4h"
+            }
+          ],
+          "query": "5m,10m,15m,30m,1h,4h",
+          "skipUrlSync": false,
+          "type": "custom"
+        }
+      ]
+    },
+    "time": {
+      "from": "now-6h",
+      "to": "now"
+    },
+    "timepicker": {
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "time_options": [
+        "5m",
+        "15m",
+        "1h",
+        "6h",
+        "12h",
+        "24h",
+        "2d",
+        "7d",
+        "30d"
+      ]
+    },
+    "timezone": "",
+    "title": "Tickets",
+    "uid": "TlgyFfIWz",
+    "version": 6
+  }

--- a/install/helm/open-match/values.yaml
+++ b/install/helm/open-match/values.yaml
@@ -24,7 +24,7 @@ openmatch:
       serviceDiscovery: true
     stackdriver:
       enabled: false
-      gcpProjectId: "project_id"
+      gcpProjectId: "replace_with_your_project_id"
       metricPrefix: "open_match"
     zipkin:
       enabled: false

--- a/internal/app/backend/backend.go
+++ b/internal/app/backend/backend.go
@@ -23,30 +23,23 @@ import (
 	"open-match.dev/open-match/pkg/pb"
 )
 
-var (
-	backendLogger = logrus.WithFields(logrus.Fields{
-		"app":       "openmatch",
-		"component": "backend",
-	})
-)
-
 // RunApplication creates a server.
 func RunApplication() {
 	cfg, err := config.Read()
 	if err != nil {
-		backendLogger.WithFields(logrus.Fields{
+		logger.WithFields(logrus.Fields{
 			"error": err.Error(),
 		}).Fatalf("cannot read configuration.")
 	}
 	p, err := rpc.NewServerParamsFromConfig(cfg, "api.backend")
 	if err != nil {
-		backendLogger.WithFields(logrus.Fields{
+		logger.WithFields(logrus.Fields{
 			"error": err.Error(),
 		}).Fatalf("cannot construct server.")
 	}
 
 	if err := BindService(p, cfg); err != nil {
-		backendLogger.WithFields(logrus.Fields{
+		logger.WithFields(logrus.Fields{
 			"error": err.Error(),
 		}).Fatalf("failed to bind backend service.")
 	}

--- a/internal/app/backend/synchronizer_client.go
+++ b/internal/app/backend/synchronizer_client.go
@@ -5,9 +5,14 @@ import (
 	"sync"
 
 	"open-match.dev/open-match/internal/config"
+	"open-match.dev/open-match/internal/monitoring"
 	ipb "open-match.dev/open-match/internal/pb"
 	"open-match.dev/open-match/internal/rpc"
 	"open-match.dev/open-match/pkg/pb"
+)
+
+var (
+	mMatchEvaluations = monitoring.Counter("backend/matches_evaluated", "matches evaluated")
 )
 
 type synchronizerClient struct {
@@ -60,6 +65,7 @@ func (sc *synchronizerClient) evaluate(ctx context.Context, id string, proposals
 		return nil, err
 	}
 
+	monitoring.IncrementCounterN(ctx, mMatchEvaluations, len(resp.Matches))
 	return resp.Matches, nil
 }
 

--- a/internal/app/frontend/frontend.go
+++ b/internal/app/frontend/frontend.go
@@ -23,30 +23,23 @@ import (
 	"open-match.dev/open-match/pkg/pb"
 )
 
-var (
-	frontendLogger = logrus.WithFields(logrus.Fields{
-		"app":       "openmatch",
-		"component": "frontend",
-	})
-)
-
 // RunApplication creates a server.
 func RunApplication() {
 	cfg, err := config.Read()
 	if err != nil {
-		frontendLogger.WithFields(logrus.Fields{
+		logger.WithFields(logrus.Fields{
 			"error": err.Error(),
 		}).Fatalf("cannot read configuration.")
 	}
 	p, err := rpc.NewServerParamsFromConfig(cfg, "api.frontend")
 	if err != nil {
-		frontendLogger.WithFields(logrus.Fields{
+		logger.WithFields(logrus.Fields{
 			"error": err.Error(),
 		}).Fatalf("cannot construct server.")
 	}
 
 	if err := BindService(p, cfg); err != nil {
-		frontendLogger.WithFields(logrus.Fields{
+		logger.WithFields(logrus.Fields{
 			"error": err.Error(),
 		}).Fatalf("failed to bind frontend service.")
 	}

--- a/internal/app/minimatch/minimatch.go
+++ b/internal/app/minimatch/minimatch.go
@@ -25,7 +25,7 @@ import (
 )
 
 var (
-	minimatchLogger = logrus.WithFields(logrus.Fields{
+	logger = logrus.WithFields(logrus.Fields{
 		"app":       "openmatch",
 		"component": "minimatch",
 	})
@@ -35,19 +35,19 @@ var (
 func RunApplication() {
 	cfg, err := config.Read()
 	if err != nil {
-		minimatchLogger.WithFields(logrus.Fields{
+		logger.WithFields(logrus.Fields{
 			"error": err.Error(),
 		}).Fatalf("cannot read configuration.")
 	}
 	p, err := rpc.NewServerParamsFromConfig(cfg, "api.frontend")
 	if err != nil {
-		minimatchLogger.WithFields(logrus.Fields{
+		logger.WithFields(logrus.Fields{
 			"error": err.Error(),
 		}).Fatalf("cannot construct server.")
 	}
 
 	if err := BindService(p, cfg); err != nil {
-		minimatchLogger.WithFields(logrus.Fields{
+		logger.WithFields(logrus.Fields{
 			"error": err.Error(),
 		}).Fatalf("cannot bind server.")
 	}

--- a/internal/app/mmlogic/mmlogic.go
+++ b/internal/app/mmlogic/mmlogic.go
@@ -23,30 +23,23 @@ import (
 	"open-match.dev/open-match/pkg/pb"
 )
 
-var (
-	mmlogicLogger = logrus.WithFields(logrus.Fields{
-		"app":       "openmatch",
-		"component": "mmlogic",
-	})
-)
-
 // RunApplication creates a server.
 func RunApplication() {
 	cfg, err := config.Read()
 	if err != nil {
-		mmlogicLogger.WithFields(logrus.Fields{
+		logger.WithFields(logrus.Fields{
 			"error": err.Error(),
 		}).Fatalf("cannot read configuration.")
 	}
 	p, err := rpc.NewServerParamsFromConfig(cfg, "api.mmlogic")
 	if err != nil {
-		mmlogicLogger.WithFields(logrus.Fields{
+		logger.WithFields(logrus.Fields{
 			"error": err.Error(),
 		}).Fatalf("cannot construct server.")
 	}
 
 	if err := BindService(p, cfg); err != nil {
-		mmlogicLogger.WithFields(logrus.Fields{
+		logger.WithFields(logrus.Fields{
 			"error": err.Error(),
 		}).Fatalf("failed to bind mmlogic service.")
 	}

--- a/internal/app/mmlogic/mmlogic_service.go
+++ b/internal/app/mmlogic/mmlogic_service.go
@@ -27,9 +27,9 @@ import (
 )
 
 var (
-	mmlogicServiceLogger = logrus.WithFields(logrus.Fields{
+	logger = logrus.WithFields(logrus.Fields{
 		"app":       "openmatch",
-		"component": "app.mmlogic.mmlogic_service",
+		"component": "app.mmlogic",
 	})
 )
 
@@ -54,7 +54,7 @@ func (s *mmlogicService) QueryTickets(req *pb.QueryTicketsRequest, responseServe
 	callback := func(tickets []*pb.Ticket) error {
 		err := responseServer.Send(&pb.QueryTicketsResponse{Tickets: tickets})
 		if err != nil {
-			mmlogicServiceLogger.WithError(err).Error("Failed to send Redis response to grpc server")
+			logger.WithError(err).Error("Failed to send Redis response to grpc server")
 			return status.Errorf(codes.Aborted, err.Error())
 		}
 		return nil
@@ -67,7 +67,7 @@ func doQueryTickets(ctx context.Context, filters []*pb.Filter, pageSize int, sen
 	// Send requests to the storage service
 	err := store.FilterTickets(ctx, filters, pageSize, sender)
 	if err != nil {
-		mmlogicServiceLogger.WithError(err).Error("Failed to retrieve result from storage service.")
+		logger.WithError(err).Error("Failed to retrieve result from storage service.")
 		return err
 	}
 
@@ -94,12 +94,12 @@ func getPageSize(cfg config.View) int {
 
 	pSize := cfg.GetInt("storage.page.size")
 	if pSize < minPageSize {
-		mmlogicServiceLogger.Infof("page size %v is lower than the minimum limit of %v", pSize, maxPageSize)
+		logger.Infof("page size %v is lower than the minimum limit of %v", pSize, maxPageSize)
 		pSize = minPageSize
 	}
 
 	if pSize > maxPageSize {
-		mmlogicServiceLogger.Infof("page size %v is higher than the maximum limit of %v", pSize, maxPageSize)
+		logger.Infof("page size %v is higher than the maximum limit of %v", pSize, maxPageSize)
 		return maxPageSize
 	}
 

--- a/internal/app/swaggerui/swaggerui.go
+++ b/internal/app/swaggerui/swaggerui.go
@@ -31,7 +31,7 @@ import (
 )
 
 var (
-	swaggeruiLogger = logrus.WithFields(logrus.Fields{
+	logger = logrus.WithFields(logrus.Fields{
 		"app":       "openmatch",
 		"component": "swaggerui",
 	})
@@ -41,7 +41,7 @@ var (
 func RunApplication() {
 	cfg, err := config.Read()
 	if err != nil {
-		swaggeruiLogger.WithFields(logrus.Fields{
+		logger.WithFields(logrus.Fields{
 			"error": err.Error(),
 		}).Fatalf("cannot read configuration.")
 	}
@@ -55,13 +55,13 @@ func serve(cfg config.View) {
 	port := cfg.GetInt("api.swaggerui.httpport")
 	baseDir, err := os.Getwd()
 	if err != nil {
-		swaggeruiLogger.WithError(err).Fatal("cannot get current working directory")
+		logger.WithError(err).Fatal("cannot get current working directory")
 	}
 	directory := filepath.Join(baseDir, "static")
 
 	_, err = os.Stat(directory)
 	if err != nil {
-		swaggeruiLogger.WithError(err).Fatalf("Cannot access directory %s", directory)
+		logger.WithError(err).Fatalf("Cannot access directory %s", directory)
 	}
 
 	mux.Handle("/", http.FileServer(http.Dir(directory)))
@@ -77,10 +77,10 @@ func serve(cfg config.View) {
 		Addr:    addr,
 		Handler: mux,
 	}
-	swaggeruiLogger.Infof("SwaggerUI for Open Match")
-	swaggeruiLogger.Infof("Serving static directory: %s", directory)
-	swaggeruiLogger.Infof("Serving on %s", addr)
-	swaggeruiLogger.Fatal(srv.ListenAndServe())
+	logger.Infof("SwaggerUI for Open Match")
+	logger.Infof("Serving static directory: %s", directory)
+	logger.Infof("Serving on %s", addr)
+	logger.Fatal(srv.ListenAndServe())
 }
 
 func bindHandler(mux *http.ServeMux, cfg config.View, path string, service string) {
@@ -88,7 +88,7 @@ func bindHandler(mux *http.ServeMux, cfg config.View, path string, service strin
 	if err != nil {
 		panic(err)
 	}
-	swaggeruiLogger.Infof("Registering reverse proxy %s -> %s", path, endpoint)
+	logger.Infof("Registering reverse proxy %s -> %s", path, endpoint)
 	mux.Handle(path, overlayURLProxy(mustURLParse(endpoint), client))
 }
 
@@ -107,7 +107,7 @@ func overlayURLProxy(target *url.URL, client *http.Client) *httputil.ReverseProx
 			// explicitly disable User-Agent so it's not set to default value
 			req.Header.Set("User-Agent", "")
 		}
-		swaggeruiLogger.Debugf("URL: %s", req.URL)
+		logger.Debugf("URL: %s", req.URL)
 	}
 	return &httputil.ReverseProxy{
 		Director:  director,
@@ -118,7 +118,7 @@ func overlayURLProxy(target *url.URL, client *http.Client) *httputil.ReverseProx
 func mustURLParse(u string) *url.URL {
 	url, err := url.Parse(u)
 	if err != nil {
-		swaggeruiLogger.Fatalf("failed to parse URL %s, %v", u, err)
+		logger.Fatalf("failed to parse URL %s, %v", u, err)
 	}
 	return url
 }

--- a/internal/app/synchronizer/synchronizer_service.go
+++ b/internal/app/synchronizer/synchronizer_service.go
@@ -39,6 +39,13 @@ const (
 	stateEvaluation
 )
 
+var (
+	logger = logrus.WithFields(logrus.Fields{
+		"app":       "openmatch",
+		"component": "app.synchronizer",
+	})
+)
+
 // The requestData holds the state of each pending request for evaluation. The
 // lifespan of this data is same as the lifespan of a request.
 type requestData struct {
@@ -69,13 +76,6 @@ type synchronizerService struct {
 	state      synchronizerState  // Current state of the Synchronizer
 	stateMutex sync.Mutex         // Mutex to check on current state and take specific actions.
 }
-
-var (
-	synchronizerServiceLogger = logrus.WithFields(logrus.Fields{
-		"app":       "openmatch",
-		"component": "app.synchronizer.synchronizer_service",
-	})
-)
 
 func newSynchronizerService(cfg config.View, eval evaluator, store statestore.Service) *synchronizerService {
 	service := &synchronizerService{
@@ -113,7 +113,7 @@ func (s *synchronizerService) Register(ctx context.Context, req *ipb.RegisterReq
 		// After waking up, the first request that encounters the idle state changes
 		// state to requestRegistration and initializes the state for this synchronization
 		// cycle. Consequent registration requests bypass this initialization.
-		synchronizerServiceLogger.Info("Changing state from idle to requestRegistration")
+		logger.Info("Changing state from idle to requestRegistration")
 		s.state = stateRequestRegistration
 		s.cycleData = &synchronizerData{
 			idToRequestData: make(map[string]*requestData),
@@ -129,7 +129,7 @@ func (s *synchronizerService) Register(ctx context.Context, req *ipb.RegisterReq
 	// request data for this request.
 	id := xid.New().String()
 	s.cycleData.idToRequestData[id] = &requestData{}
-	synchronizerServiceLogger.WithFields(logrus.Fields{
+	logger.WithFields(logrus.Fields{
 		"id": id,
 	}).Info("Registered request for synchronization")
 	return &ipb.RegisterResponse{Id: id}, nil
@@ -142,7 +142,7 @@ func (s *synchronizerService) Register(ctx context.Context, req *ipb.RegisterReq
 //  end of the cycle, the user defined evaluation method is triggered and the
 // matches accepted by it are returned as results.
 func (s *synchronizerService) EvaluateProposals(ctx context.Context, req *ipb.EvaluateProposalsRequest) (*ipb.EvaluateProposalsResponse, error) {
-	synchronizerServiceLogger.WithFields(logrus.Fields{
+	logger.WithFields(logrus.Fields{
 		"id":        req.GetId(),
 		"proposals": getMatchIds(req.GetMatches()),
 	}).Info("Received request to evaluate propsals")
@@ -221,14 +221,14 @@ func (s *synchronizerService) fetchResults(id string) ([]*pb.Match, error) {
 	// TODO: Add a timeout in case results are not ready within a certain duration.
 	<-s.cycleData.resultsReady
 	if s.cycleData.evalError != nil {
-		synchronizerServiceLogger.WithError(s.cycleData.evalError).Errorf(
+		logger.WithError(s.cycleData.evalError).Errorf(
 			"Evaluation failed for request %v", id)
 		return nil, s.cycleData.evalError
 	}
 
 	results = make([]*pb.Match, len(s.cycleData.idToRequestData[id].results))
 	copy(results, s.cycleData.idToRequestData[id].results)
-	synchronizerServiceLogger.WithFields(logrus.Fields{
+	logger.WithFields(logrus.Fields{
 		"id":      id,
 		"results": getMatchIds(results),
 		"elapsed": time.Since(t).String(),
@@ -252,7 +252,7 @@ func (s *synchronizerService) Evaluate() {
 		}
 	}
 
-	synchronizerServiceLogger.WithFields(logrus.Fields{
+	logger.WithFields(logrus.Fields{
 		"proposals": getMatchIds(aggregateProposals),
 	}).Info("Requesting evaluation of proposals")
 	results, err := s.eval.evaluate(aggregateProposals)
@@ -260,11 +260,11 @@ func (s *synchronizerService) Evaluate() {
 		// Evaluation failed. Set the error on the synchronization cycle data and
 		// signal completion of evaluation. Do not process any partial results.
 		s.cycleData.evalError = err
-		synchronizerServiceLogger.WithError(err).Errorf("Failed to evaluate proposals: %v", getMatchIds(aggregateProposals))
+		logger.WithError(err).Errorf("Failed to evaluate proposals: %v", getMatchIds(aggregateProposals))
 	} else {
 		// Evaluation succeeded. Process all the results and add them to the results list
 		// for the corresponding request data
-		synchronizerServiceLogger.WithFields(logrus.Fields{
+		logger.WithFields(logrus.Fields{
 			"results": getMatchIds(results),
 		}).Info("Evaluation successfully returned results")
 		for _, m := range results {
@@ -272,7 +272,7 @@ func (s *synchronizerService) Evaluate() {
 			if !ok {
 				// Evaluator returned a match that the synchronizer did not submit for evaluation. This
 				// could happen if the match id was modified accidentally.
-				synchronizerServiceLogger.WithFields(logrus.Fields{
+				logger.WithFields(logrus.Fields{
 					"match": m.GetMatchId(),
 				}).Warning("Result does not belong to any known requests")
 				continue
@@ -288,7 +288,7 @@ func (s *synchronizerService) Evaluate() {
 	// Wait for all fetchMatches to complete processing results and then set synchronizer
 	// to idle state and signal any blocked registration requests to proceed.
 	s.cycleData.pendingRequests.Wait()
-	synchronizerServiceLogger.Info("Changing state from evaluating to idle")
+	logger.Info("Changing state from evaluating to idle")
 	s.state = stateIdle
 	s.idleCond.Broadcast()
 }
@@ -297,7 +297,7 @@ func (s *synchronizerService) trackRegistrationWindow() {
 	time.Sleep(s.registrationInterval())
 	s.stateMutex.Lock()
 	defer s.stateMutex.Unlock()
-	synchronizerServiceLogger.Info("Changing state from requestRegistration to proposalCollection")
+	logger.Info("Changing state from requestRegistration to proposalCollection")
 	s.state = stateProposalCollection
 	go s.trackProposalWindow()
 }
@@ -306,7 +306,7 @@ func (s *synchronizerService) trackProposalWindow() {
 	time.Sleep(s.proposalCollectionInterval())
 	s.stateMutex.Lock()
 	defer s.stateMutex.Unlock()
-	synchronizerServiceLogger.Info("Changing state from proposalCollection to evaluation")
+	logger.Info("Changing state from proposalCollection to evaluation")
 	s.state = stateEvaluation
 	s.Evaluate()
 }

--- a/internal/monitoring/prometheus.go
+++ b/internal/monitoring/prometheus.go
@@ -25,6 +25,11 @@ import (
 	"open-match.dev/open-match/internal/config"
 )
 
+const (
+	// ConfigNameEnableMetrics indicates that monitoring is enabled.
+	ConfigNameEnableMetrics = "monitoring.prometheus.enable"
+)
+
 var (
 	prometheusLogger = logrus.WithFields(logrus.Fields{
 		"app":       "openmatch",

--- a/internal/monitoring/public.go
+++ b/internal/monitoring/public.go
@@ -15,10 +15,12 @@
 package monitoring
 
 import (
+	"context"
 	"net/http"
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"open-match.dev/open-match/internal/config"
 )
@@ -37,7 +39,7 @@ func Setup(mux *http.ServeMux, cfg config.View) {
 	if err != nil {
 		publicLogger.WithFields(logrus.Fields{
 			"error":           err,
-			"retentionPeriod": periodString,
+			"reportingPeriod": periodString,
 		}).Info("Failed to parse monitoring.reportingPeriod, defaulting to 10s")
 		reportingPeriod = time.Second * 10
 	}
@@ -51,15 +53,39 @@ func Setup(mux *http.ServeMux, cfg config.View) {
 	// Change the frequency of updates to the metrics endpoint
 	view.SetReportingPeriod(reportingPeriod)
 
-	// Register the OpenCensus views we want to export to Prometheus
-	/*
-		err = view.Register(views...)
-		if err != nil {
-			publicLogger.Fatalf("Failed to register OpenCensus views for metrics gathering: %v", err)
-		}
-	*/
-
 	publicLogger.WithFields(logrus.Fields{
-		"retentionPeriod": reportingPeriod,
+		"reportingPeriod": reportingPeriod,
 	}).Info("Monitoring has been configured.")
+}
+
+// Counter creates a counter metric.
+func Counter(name string, description string) *stats.Int64Measure {
+	s := stats.Int64(name, "Count of "+description+".", "1")
+	counterView(s)
+	return s
+}
+
+// IncrementCounter +1's the counter metric.
+func IncrementCounter(ctx context.Context, s *stats.Int64Measure) {
+	IncrementCounterN(ctx, s, 1)
+}
+
+// IncrementCounterN increases a metric by n.
+func IncrementCounterN(ctx context.Context, s *stats.Int64Measure, n int) {
+	stats.Record(ctx, s.M(int64(n)))
+}
+
+// CounterView converts the measurement into a view for a counter.
+func counterView(s *stats.Int64Measure) *view.View {
+	v := &view.View{
+		Name:        s.Name(),
+		Measure:     s,
+		Description: s.Description(),
+		Aggregation: view.Count(),
+	}
+	err := view.Register(v)
+	if err != nil {
+		publicLogger.WithError(err).Infof("cannot register view for metric: %s, it will not be reported", s.Name())
+	}
+	return v
 }

--- a/internal/monitoring/public_test.go
+++ b/internal/monitoring/public_test.go
@@ -1,0 +1,44 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package monitoring
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opencensus.io/stats"
+)
+
+func TestIncrementCounter(t *testing.T) {
+	//assert := assert.New(t)
+	c := Counter("monitoring/fake_metric", "fake")
+	IncrementCounter(context.Background(), c)
+	IncrementCounter(context.Background(), c)
+}
+func TestDoubleMetric(t *testing.T) {
+	assert := assert.New(t)
+	c := Counter("monitoring/fake_metric", "fake")
+	c2 := Counter("monitoring/fake_metric", "fake")
+	assert.Equal(c, c2)
+}
+
+func TestDoubleRegisterView(t *testing.T) {
+	assert := assert.New(t)
+	mFakeCounter := stats.Int64("monitoring/fake_metric", "Fake", "1")
+	v := counterView(mFakeCounter)
+	v2 := counterView(mFakeCounter)
+	assert.Equal(v, v2)
+}

--- a/internal/rpc/clients.go
+++ b/internal/rpc/clients.go
@@ -34,11 +34,11 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"open-match.dev/open-match/internal/config"
+	"open-match.dev/open-match/internal/monitoring"
 )
 
 const (
 	configNameEnableRPCLogging = "logging.rpc"
-	configNameEnableMetrics    = "monitoring.prometheus.enable"
 	// configNameClientTrustedCertificatePath is the same as the root CA cert that the server trusts.
 	configNameClientTrustedCertificatePath = configNameServerRootCertificatePath
 )
@@ -69,7 +69,7 @@ func GRPCClientFromConfig(cfg config.View, prefix string) (*grpc.ClientConn, err
 		Hostname:         cfg.GetString(prefix + ".hostname"),
 		Port:             cfg.GetInt(prefix + ".grpcport"),
 		EnableRPCLogging: cfg.GetBool(configNameEnableRPCLogging),
-		EnableMetrics:    cfg.GetBool(configNameEnableMetrics),
+		EnableMetrics:    cfg.GetBool(monitoring.ConfigNameEnableMetrics),
 	}
 
 	// If TLS support is enabled in the config, fill in the trusted certificates for decrpting server certificate.
@@ -93,7 +93,7 @@ func GRPCClientFromConfig(cfg config.View, prefix string) (*grpc.ClientConn, err
 // GRPCClientFromEndpoint creates a gRPC client connection from endpoint.
 func GRPCClientFromEndpoint(cfg config.View, address string) (*grpc.ClientConn, error) {
 	// TODO: investigate if it is possible to keep a cache of the certpool and transport credentials
-	grpcOptions := newGRPCDialOptions(cfg.GetBool(configNameEnableMetrics), cfg.GetBool(configNameEnableRPCLogging))
+	grpcOptions := newGRPCDialOptions(cfg.GetBool(monitoring.ConfigNameEnableMetrics), cfg.GetBool(configNameEnableRPCLogging))
 
 	if cfg.GetString(configNameClientTrustedCertificatePath) != "" {
 		_, err := os.Stat(cfg.GetString(configNameClientTrustedCertificatePath))
@@ -149,7 +149,7 @@ func HTTPClientFromConfig(cfg config.View, prefix string) (*http.Client, string,
 		Hostname:         cfg.GetString(prefix + ".hostname"),
 		Port:             cfg.GetInt(prefix + ".httpport"),
 		EnableRPCLogging: cfg.GetBool(configNameEnableRPCLogging),
-		EnableMetrics:    cfg.GetBool(configNameEnableMetrics),
+		EnableMetrics:    cfg.GetBool(monitoring.ConfigNameEnableMetrics),
 	}
 
 	// If TLS support is enabled in the config, fill in the trusted certificates for decrpting server certificate.

--- a/internal/rpc/server.go
+++ b/internal/rpc/server.go
@@ -127,7 +127,7 @@ func NewServerParamsFromConfig(cfg config.View, prefix string) (*ServerParams, e
 		p.SetTLSConfiguration(rootPublicCertData, publicCertData, privateKeyData)
 	}
 
-	p.enableMetrics = cfg.GetBool(configNameEnableMetrics)
+	p.enableMetrics = cfg.GetBool(monitoring.ConfigNameEnableMetrics)
 	p.enableRPCLogging = cfg.GetBool(configNameEnableRPCLogging)
 	// TODO: This isn't ideal since monitoring requires config for it to be initialized.
 	// This forces us to initialize readiness probes earlier than necessary.

--- a/internal/statestore/instrumented.go
+++ b/internal/statestore/instrumented.go
@@ -1,0 +1,116 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statestore
+
+import (
+	"context"
+
+	"open-match.dev/open-match/internal/monitoring"
+	"open-match.dev/open-match/pkg/pb"
+)
+
+var (
+	mStateStoreCreateTicket           = monitoring.Counter("statestore/createticket", "tickets created")
+	mStateStoreGetTicket              = monitoring.Counter("statestore/getticket", "tickets retrieve")
+	mStateStoreDeleteTicket           = monitoring.Counter("statestore/deleteticket", "tickets deleted")
+	mStateStoreIndexTicket            = monitoring.Counter("statestore/indexticket", "tickets indexed")
+	mStateStoreDeindexTicket          = monitoring.Counter("statestore/deindexticket", "tickets deindexed")
+	mStateStoreFilterTickets          = monitoring.Counter("statestore/filterticket", "tickets that were filtered and returned")
+	mStateStoreUpdateAssignments      = monitoring.Counter("statestore/updateassignment", "tickets assigned")
+	mStateStoreGetAssignments         = monitoring.Counter("statestore/getassignments", "ticket assigned retrieved")
+	mStateStoreAddTicketsToIgnoreList = monitoring.Counter("statestore/addticketstoignorelist", "tickets moved to ignore list")
+)
+
+// instrumentedService is a wrapper for a statestore service that provides instrumentation (metrics and tracing) of the database.
+type instrumentedService struct {
+	s Service
+}
+
+// Close the connection to the database.
+func (is *instrumentedService) Close() error {
+	return is.s.Close()
+}
+
+// HealthCheck indicates if the database is reachable.
+func (is *instrumentedService) HealthCheck(ctx context.Context) error {
+	err := is.s.HealthCheck(ctx)
+	return err
+}
+
+// CreateTicket creates a new Ticket in the state storage. If the id already exists, it will be overwritten.
+func (is *instrumentedService) CreateTicket(ctx context.Context, ticket *pb.Ticket) error {
+	monitoring.IncrementCounter(ctx, mStateStoreCreateTicket)
+	return is.s.CreateTicket(ctx, ticket)
+}
+
+// GetTicket gets the Ticket with the specified id from state storage. This method fails if the Ticket does not exist.
+func (is *instrumentedService) GetTicket(ctx context.Context, id string) (*pb.Ticket, error) {
+	monitoring.IncrementCounter(ctx, mStateStoreGetTicket)
+	return is.s.GetTicket(ctx, id)
+}
+
+// DeleteTicket removes the Ticket with the specified id from state storage.
+func (is *instrumentedService) DeleteTicket(ctx context.Context, id string) error {
+	monitoring.IncrementCounter(ctx, mStateStoreDeleteTicket)
+	return is.s.DeleteTicket(ctx, id)
+}
+
+// IndexTicket indexes the Ticket id for the configured index fields.
+func (is *instrumentedService) IndexTicket(ctx context.Context, ticket *pb.Ticket) error {
+	monitoring.IncrementCounter(ctx, mStateStoreIndexTicket)
+	return is.s.IndexTicket(ctx, ticket)
+}
+
+// DeindexTicket removes the indexing for the specified Ticket. Only the indexes are removed but the Ticket continues to exist.
+func (is *instrumentedService) DeindexTicket(ctx context.Context, id string) error {
+	monitoring.IncrementCounter(ctx, mStateStoreDeindexTicket)
+	return is.s.DeindexTicket(ctx, id)
+}
+
+// FilterTickets returns the Ticket ids and required attribute key-value pairs for the Tickets meeting the specified filtering criteria.
+// map[ticket.Id]map[attributeName][attributeValue]
+// {
+//  "testplayer1": {"ranking" : 56, "loyalty_level": 4},
+//  "testplayer2": {"ranking" : 50, "loyalty_level": 3},
+// }
+func (is *instrumentedService) FilterTickets(ctx context.Context, filters []*pb.Filter, pageSize int, callback func([]*pb.Ticket) error) error {
+	return is.s.FilterTickets(ctx, filters, pageSize, func(t []*pb.Ticket) error {
+		monitoring.IncrementCounterN(ctx, mStateStoreFilterTickets, len(t))
+		return callback(t)
+	})
+}
+
+// UpdateAssignments update the match assignments for the input ticket ids.
+// This function guarantees if any of the input ids does not exists, the state of the storage service won't be altered.
+// However, since Redis does not support transaction roll backs (see https://redis.io/topics/transactions), some of the
+// assignment fields might be partially updated if this function encounters an error halfway through the execution.
+func (is *instrumentedService) UpdateAssignments(ctx context.Context, ids []string, assignment *pb.Assignment) error {
+	monitoring.IncrementCounter(ctx, mStateStoreUpdateAssignments)
+	return is.s.UpdateAssignments(ctx, ids, assignment)
+}
+
+// GetAssignments returns the assignment associated with the input ticket id
+func (is *instrumentedService) GetAssignments(ctx context.Context, id string, callback func(*pb.Assignment) error) error {
+	return is.s.GetAssignments(ctx, id, func(a *pb.Assignment) error {
+		monitoring.IncrementCounter(ctx, mStateStoreGetAssignments)
+		return callback(a)
+	})
+}
+
+// AddProposedTickets appends new proposed tickets to the proposed sorted set with current timestamp
+func (is *instrumentedService) AddTicketsToIgnoreList(ctx context.Context, ids []string) error {
+	monitoring.IncrementCounterN(ctx, mStateStoreAddTicketsToIgnoreList, len(ids))
+	return is.s.AddTicketsToIgnoreList(ctx, ids)
+}

--- a/internal/statestore/public.go
+++ b/internal/statestore/public.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"open-match.dev/open-match/internal/config"
+	"open-match.dev/open-match/internal/monitoring"
 	"open-match.dev/open-match/pkg/pb"
 )
 
@@ -59,5 +60,11 @@ type Service interface {
 
 // New creates a Service based on the configuration.
 func New(cfg config.View) Service {
-	return newRedis(cfg)
+	s := newRedis(cfg)
+	if cfg.GetBool(monitoring.ConfigNameEnableMetrics) {
+		return &instrumentedService{
+			s: s,
+		}
+	}
+	return s
 }

--- a/internal/statestore/redis.go
+++ b/internal/statestore/redis.go
@@ -44,6 +44,7 @@ type redisBackend struct {
 	cfg             config.View
 }
 
+// Close the connection to the database.
 func (rb *redisBackend) Close() error {
 	return rb.redisPool.Close()
 }

--- a/internal/statestore/redis_test.go
+++ b/internal/statestore/redis_test.go
@@ -28,6 +28,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"open-match.dev/open-match/internal/config"
+	"open-match.dev/open-match/internal/monitoring"
 	internalTesting "open-match.dev/open-match/internal/testing"
 	"open-match.dev/open-match/pkg/pb"
 	"open-match.dev/open-match/pkg/structs"
@@ -334,7 +335,9 @@ func TestConnect(t *testing.T) {
 	store := New(cfg)
 	defer store.Close()
 
-	rb, ok := store.(*redisBackend)
+	is, ok := store.(*instrumentedService)
+	assert.True(ok)
+	rb, ok := is.s.(*redisBackend)
 	assert.True(ok)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -364,6 +367,7 @@ func createRedis(t *testing.T) (config.View, func()) {
 	cfg.Set("backoff.multiplier", 0.5)
 	cfg.Set("backoff.maxInterval", 300*time.Millisecond)
 	cfg.Set("backoff.maxElapsedTime", 100*time.Millisecond)
+	cfg.Set(monitoring.ConfigNameEnableMetrics, true)
 	cfg.Set("ticketIndices", []string{"testindex1", "testindex2"})
 
 	return cfg, func() { mredis.Close() }


### PR DESCRIPTION
This is a first pass and very rough attempt at adding specific metrics to Open Match. Many of these metrics may not be immediately useful but we need something in for now so that we can build dashboards and analyze key metrics based on stress testing.

This change is also removing some logger instances. There will be a future changes to make 1 logger per package unless there's a reason to keep a separate one for example, delegated client calls.