### PR TITLE
Add TLS support to the Helm chart.

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -221,6 +221,9 @@ issues:
     - source: "stats."
       linters:
         - gochecknoglobals
+    - source: "serviceAddressList"
+      linters:
+        - gochecknoglobals
 
     # Exclude known linters from partially hard-vendored code,
     # which is impossible to exclude via "nolint" comments.

--- a/Makefile
+++ b/Makefile
@@ -342,7 +342,7 @@ build/chart/index.yaml.$(YEAR_MONTH_DAY): build/chart/index.yaml
 
 build/chart/: build/chart/index.yaml build/chart/index.yaml.$(YEAR_MONTH_DAY)
 
-install-large-chart: build/toolchain/bin/helm$(EXE_EXTENSION)
+install-large-chart: build/toolchain/bin/helm$(EXE_EXTENSION) install/helm/open-match/secrets/
 	$(HELM) upgrade $(OPEN_MATCH_CHART_NAME) --install --wait --debug install/helm/open-match \
 		--timeout=400 \
 		--namespace=$(OPEN_MATCH_KUBERNETES_NAMESPACE) \
@@ -355,7 +355,7 @@ install-large-chart: build/toolchain/bin/helm$(EXE_EXTENSION)
 		--set openmatch.monitoring.stackdriver.enabled=true \
 		--set openmatch.monitoring.stackdriver.gcpProjectId=$(GCP_PROJECT_ID)
 
-install-chart: build/toolchain/bin/helm$(EXE_EXTENSION)
+install-chart: build/toolchain/bin/helm$(EXE_EXTENSION) install/helm/open-match/secrets/
 	$(HELM) upgrade $(OPEN_MATCH_CHART_NAME) --install --wait --debug install/helm/open-match \
 		--timeout=400 \
 		--namespace=$(OPEN_MATCH_KUBERNETES_NAMESPACE) \
@@ -368,7 +368,7 @@ install-chart: build/toolchain/bin/helm$(EXE_EXTENSION)
 		--set openmatch.monitoring.stackdriver.enabled=true \
 		--set openmatch.monitoring.stackdriver.gcpProjectId=$(GCP_PROJECT_ID)
 
-install-ci-chart: build/toolchain/bin/helm$(EXE_EXTENSION)
+install-ci-chart: build/toolchain/bin/helm$(EXE_EXTENSION) install/helm/open-match/secrets/
 	$(HELM) upgrade $(OPEN_MATCH_CHART_NAME) --install --wait --debug install/helm/open-match \
 		--timeout=400 \
 		--namespace=$(OPEN_MATCH_KUBERNETES_NAMESPACE) \
@@ -395,6 +395,7 @@ delete-chart: build/toolchain/bin/helm$(EXE_EXTENSION) build/toolchain/bin/kubec
 	-$(KUBECTL) --ignore-not-found=true delete crd prometheuses.monitoring.coreos.com
 	-$(KUBECTL) --ignore-not-found=true delete crd servicemonitors.monitoring.coreos.com
 	-$(KUBECTL) --ignore-not-found=true delete crd prometheusrules.monitoring.coreos.com
+	-$(KUBECTL) delete namespace $(OPEN_MATCH_KUBERNETES_NAMESPACE)
 
 install/yaml/: install/yaml/install.yaml install/yaml/install-demo.yaml install/yaml/01-redis-chart.yaml install/yaml/02-open-match.yaml install/yaml/03-prometheus-chart.yaml install/yaml/04-grafana-chart.yaml install/yaml/05-jaeger-chart.yaml
 
@@ -758,15 +759,15 @@ pkg/pb/mmlogic.pb.go: pkg/pb/messages.pb.go
 pkg/pb/evaluator.pb.go: pkg/pb/messages.pb.go
 internal/pb/synchronizer.pb.go: pkg/pb/messages.pb.go
 
-build:
+build: assets
 	$(GO) build ./...
 	$(GO) build -tags e2ecluster ./... 
 
-test:
+test: assets
 	$(GO) test -cover -test.count $(GOLANG_TEST_COUNT) -race ./...
 	$(GO) test -cover -test.count $(GOLANG_TEST_COUNT) -run IgnoreRace$$ ./...
 
-test-e2e-cluster:
+test-e2e-cluster: assets
 	$(GO) test ./... -race -tags e2ecluster
 
 stress-frontend-%: build/toolchain/python/

--- a/install/helm/open-match/templates/backend.yaml
+++ b/install/helm/open-match/templates/backend.yaml
@@ -71,5 +71,5 @@ spec:
           containerPort: {{ .Values.openmatch.backend.grpc.port }}
         - name: http
           containerPort: {{ .Values.openmatch.backend.http.port }}
-        {{- include "kubernetes.probe" (dict "port" .Values.openmatch.backend.http.port) | nindent 8 }}
+        {{- include "kubernetes.probe" (dict "port" .Values.openmatch.backend.http.port "isHTTPS" .Values.openmatch.tls.enabled) | nindent 8 }}
 {{- end }}

--- a/install/helm/open-match/templates/demoevaluator.yaml
+++ b/install/helm/open-match/templates/demoevaluator.yaml
@@ -70,5 +70,5 @@ spec:
           containerPort: {{ .Values.openmatch.demoevaluator.grpc.port }}
         - name: http
           containerPort: {{ .Values.openmatch.demoevaluator.http.port }}
-        {{- include "kubernetes.probe" (dict "port" .Values.openmatch.demoevaluator.http.port) | nindent 8 }}
+        {{- include "kubernetes.probe" (dict "port" .Values.openmatch.demoevaluator.http.port "isHTTPS" .Values.openmatch.tls.enabled) | nindent 8 }}
 {{- end }}

--- a/install/helm/open-match/templates/demofunction.yaml
+++ b/install/helm/open-match/templates/demofunction.yaml
@@ -71,5 +71,5 @@ spec:
           containerPort: {{ .Values.openmatch.demofunction.grpc.port }}
         - name: http
           containerPort: {{ .Values.openmatch.demofunction.http.port }}
-        {{- include "kubernetes.probe" (dict "port" .Values.openmatch.demofunction.http.port) | nindent 8 }}
+        {{- include "kubernetes.probe" (dict "port" .Values.openmatch.demofunction.http.port "isHTTPS" .Values.openmatch.tls.enabled) | nindent 8 }}
 {{- end }}

--- a/install/helm/open-match/templates/e2eevaluator.yaml
+++ b/install/helm/open-match/templates/e2eevaluator.yaml
@@ -70,5 +70,5 @@ spec:
           containerPort: {{ .Values.openmatch.e2eevaluator.grpc.port }}
         - name: http
           containerPort: {{ .Values.openmatch.e2eevaluator.http.port }}
-        {{- include "kubernetes.probe" (dict "port" .Values.openmatch.e2eevaluator.http.port) | nindent 8 }}
+        {{- include "kubernetes.probe" (dict "port" .Values.openmatch.e2eevaluator.http.port "isHTTPS" .Values.openmatch.tls.enabled) | nindent 8 }}
 {{- end }}

--- a/install/helm/open-match/templates/e2ematchfunction.yaml
+++ b/install/helm/open-match/templates/e2ematchfunction.yaml
@@ -71,5 +71,5 @@ spec:
           containerPort: {{ .Values.openmatch.e2ematchfunction.grpc.port }}
         - name: http
           containerPort: {{ .Values.openmatch.e2ematchfunction.http.port }}
-        {{- include "kubernetes.probe" (dict "port" .Values.openmatch.e2ematchfunction.http.port) | nindent 8 }}
+        {{- include "kubernetes.probe" (dict "port" .Values.openmatch.e2ematchfunction.http.port "isHTTPS" .Values.openmatch.tls.enabled) | nindent 8 }}
 {{- end }}

--- a/install/helm/open-match/templates/frontend.yaml
+++ b/install/helm/open-match/templates/frontend.yaml
@@ -72,5 +72,5 @@ spec:
           containerPort: {{ .Values.openmatch.frontend.grpc.port }}
         - name: http
           containerPort: {{ .Values.openmatch.frontend.http.port }}
-        {{- include "kubernetes.probe" (dict "port" .Values.openmatch.frontend.http.port) | nindent 8 }}
+        {{- include "kubernetes.probe" (dict "port" .Values.openmatch.frontend.http.port "isHTTPS" .Values.openmatch.tls.enabled) | nindent 8 }}
 {{- end }}

--- a/install/helm/open-match/templates/mmlogic.yaml
+++ b/install/helm/open-match/templates/mmlogic.yaml
@@ -72,5 +72,5 @@ spec:
           containerPort: {{ .Values.openmatch.mmlogic.grpc.port }}
         - name: http
           containerPort: {{ .Values.openmatch.mmlogic.http.port }}
-        {{- include "kubernetes.probe" (dict "port" .Values.openmatch.mmlogic.http.port) | nindent 8 }}
+        {{- include "kubernetes.probe" (dict "port" .Values.openmatch.mmlogic.http.port "isHTTPS" .Values.openmatch.tls.enabled) | nindent 8 }}
 {{- end }}

--- a/install/helm/open-match/templates/synchronizer.yaml
+++ b/install/helm/open-match/templates/synchronizer.yaml
@@ -71,6 +71,6 @@ spec:
           containerPort: {{ .Values.openmatch.synchronizer.grpc.port }}
         - name: http
           containerPort: {{ .Values.openmatch.synchronizer.http.port }}
-        {{- include "kubernetes.probe" (dict "port" .Values.openmatch.synchronizer.http.port) | nindent 8 }}
+        {{- include "kubernetes.probe" (dict "port" .Values.openmatch.synchronizer.http.port "isHTTPS" .Values.openmatch.tls.enabled) | nindent 8 }}
         
 {{- end }}

--- a/install/helm/open-match/templates/tls-secret.yaml
+++ b/install/helm/open-match/templates/tls-secret.yaml
@@ -1,0 +1,41 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ {{- if .Values.openmatch.tls.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: om-tls-rootca
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "openmatch.name" . }}
+    component: tls
+    {{- include "openmatch.chartmeta" (set . "indent" 4) }}
+type: Opaque
+data:
+  {{- (.Files.Glob "secrets/tls/root-ca/public.cert").AsSecrets | nindent 2 }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: om-tls-server
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "openmatch.name" . }}
+    component: tls
+    {{- include "openmatch.chartmeta" (set . "indent" 4) }}
+type: Opaque
+data:
+  {{- (.Files.Glob "secrets/tls/server/*").AsSecrets | nindent 2 }}
+{{- end }}

--- a/install/helm/open-match/values.yaml
+++ b/install/helm/open-match/values.yaml
@@ -114,6 +114,13 @@ openmatch:
     rate: 200
     duration: 30s
     porttype: LoadBalancer
+  tls: 
+    # If you enable TLS, uncomment the tls section under "api:"
+    enabled: false
+    root:
+      mountPath: /app/secrets/tls/rootca
+    server:
+      mountPath: /app/secrets/tls/server
   kubernetes:
     serviceAccount: open-match-unprivileged-service
 
@@ -125,7 +132,7 @@ openmatch:
         logging:
           level: debug
           format: text
-          rpc: true
+          rpc: false
         # Open Match applies the exponential backoff strategy for its retryable gRPC calls.
         # The settings below are the default backoff configuration used in Open Match.
         # See https://github.com/cenkalti/backoff/blob/v3/exponential.go for detailed explanations
@@ -142,6 +149,12 @@ openmatch:
           maxElapsedTime: 3000ms
 
         api:
+          # TODO: Figure out how to key this off of tls.enabled=true. For now someone can uncomment these to turn it on.
+          #tls:
+          #  trustedCertificatePath: "{{.Values.openmatch.tls.root.mountPath}}/public.cert"
+          #  certificatefile: "{{.Values.openmatch.tls.server.mountPath}}/public.cert"
+          #  privatekey: "{{.Values.openmatch.tls.server.mountPath}}/private.key"
+          #  rootcertificatefile: "{{.Values.openmatch.tls.root.mountPath}}/public.cert"
           backend:
             hostname: om-backend
             grpcport: "{{.Values.openmatch.backend.grpc.port}}"

--- a/internal/app/backend/backend_service_test.go
+++ b/internal/app/backend/backend_service_test.go
@@ -29,12 +29,17 @@ import (
 	statestoreTesting "open-match.dev/open-match/internal/statestore/testing"
 	"open-match.dev/open-match/pkg/pb"
 	"open-match.dev/open-match/pkg/structs"
+	certgenTesting "open-match.dev/open-match/tools/certgen/testing"
 )
 
 func TestDoFetchMatchesInChannel(t *testing.T) {
 	insecureCfg := viper.New()
 	secureCfg := viper.New()
-	secureCfg.Set("tls.enabled", true)
+	pub, _, err := certgenTesting.CreateCertificateAndPrivateKeyForTesting([]string{})
+	if err != nil {
+		t.Fatalf("cannot create TLS keys: %s", err)
+	}
+	secureCfg.Set("api.tls.rootCertificateFile", pub)
 	restFuncCfg := &pb.FetchMatchesRequest{
 		Config:   &pb.FunctionConfig{Host: "om-test", Port: 54321, Type: pb.FunctionConfig_REST},
 		Profiles: []*pb.MatchProfile{{Name: "1"}, {Name: "2"}},

--- a/internal/rpc/clients_test.go
+++ b/internal/rpc/clients_test.go
@@ -189,8 +189,7 @@ func configureConfigAndKeysForTesting(assert *assert.Assertions, tlsEnabled bool
 		assert.Nil(err)
 
 		// Generate a config view with paths to the manifests
-		cfg.Set("tls.enabled", true)
-		cfg.Set("tls.trustedCertificatePath", pubFile.Name())
+		cfg.Set(configNameClientTrustedCertificatePath, pubFile.Name())
 
 		rpcParams.SetTLSConfiguration(pubBytes, pubBytes, priBytes)
 	}

--- a/internal/rpc/server.go
+++ b/internal/rpc/server.go
@@ -35,6 +35,12 @@ import (
 	"open-match.dev/open-match/internal/util/netlistener"
 )
 
+const (
+	configNameServerPublicCertificateFile = "api.tls.certificateFile"
+	configNameServerPrivateKeyFile        = "api.tls.privateKey"
+	configNameServerRootCertificatePath   = "api.tls.rootCertificateFile"
+)
+
 var (
 	serverLogger = logrus.WithFields(logrus.Fields{
 		"app":       "openmatch",
@@ -92,8 +98,8 @@ func NewServerParamsFromConfig(cfg config.View, prefix string) (*ServerParams, e
 	}
 	p := NewServerParamsFromListeners(grpcLh, httpLh)
 
-	certFile := cfg.GetString("api.tls.certificatefile")
-	privateKeyFile := cfg.GetString("api.tls.privatekey")
+	certFile := cfg.GetString(configNameServerPublicCertificateFile)
+	privateKeyFile := cfg.GetString(configNameServerPrivateKeyFile)
 	if len(certFile) > 0 && len(privateKeyFile) > 0 {
 		serverLogger.Debugf("Loading TLS certificate (%s) and private key (%s)", certFile, privateKeyFile)
 		publicCertData, err := ioutil.ReadFile(certFile)
@@ -109,7 +115,7 @@ func NewServerParamsFromConfig(cfg config.View, prefix string) (*ServerParams, e
 		// If there's no root CA certificate then use the public certificate as the trusted root.
 		rootPublicCertData := publicCertData
 
-		rootCertFile := cfg.GetString("api.tls.rootcertificatefile")
+		rootCertFile := cfg.GetString(configNameServerRootCertificatePath)
 		if len(rootCertFile) > 0 {
 			serverLogger.Debugf("Loading Root CA TLS certificate (%s)", rootCertFile)
 			rootPublicCertData, err = ioutil.ReadFile(rootCertFile)

--- a/tools/certgen/certgen.go
+++ b/tools/certgen/certgen.go
@@ -27,13 +27,27 @@ import (
 )
 
 var (
+	// serviceAddresses is a list of all the HTTP hostname:port combinations for generating a TLS certificate.
+	// It appears that gRPC does not care about validating the port number so we only add the HTTP addresses here.
+	serviceAddressList = []string{
+		"om-backend:51505",
+		"om-demo:51507",
+		"om-demoevaluator:51508",
+		"om-demofunction:51502",
+		"om-e2eevaluator:51518",
+		"om-e2ematchfunction:51512",
+		"om-frontend:51504",
+		"om-mmlogic:51503",
+		"om-swaggerui:51500",
+		"om-synchronizer:51506",
+	}
 	caFlag                    = flag.Bool("ca", false, "Create a root certificate. Use if you want a chain of trust with other certificates.")
 	rootPublicCertificateFlag = flag.String("rootpubliccertificate", "", "(optional) Path to root certificate file. If set the output certificate is rooted from this certificate.")
 	rootPrivateKeyFlag        = flag.String("rootprivatekey", "", "(required if --rootpubliccertificate is set) Path to private key paired from root certificate file.")
 	publicCertificateFlag     = flag.String("publiccertificate", "public.cert", "Public key certificate path to be generated")
 	privateKeyFlag            = flag.String("privatekey", "private.key", "Private key file path to be generated")
 	validityDurationFlag      = flag.Duration("duration", time.Hour*24*365*5, "Lifetime for certificate validity (default is 5 years)")
-	hostnamesFlag             = flag.String("hostnames", "om-frontendapi,om-backendapi,om-evaluatorapi,om-function,om-mmlogicapi", "Comma separated list of host names.")
+	hostnamesFlag             = flag.String("hostnames", strings.Join(serviceAddressList, ","), "Comma separated list of host names.")
 	rsaKeyLengthFlag          = flag.Int("rsa", 2048, "RSA Encryption Key bit length for certificate.")
 )
 


### PR DESCRIPTION
This change allows someone to deploy Open Match with TLS encryption.

This mode will not be enabled by default (for now) because of the added configuration complexity. The demo and swaggerui will still serve on HTTP (because there's no compelling reason to do HTTPS for them and they don't use the `internal/rpc/` package for serving). They are however communicating to their backends using HTTPS.