### PR TITLE
Add HorizontalPodAutoscaler policies.

### DIFF
--- a/install/helm/open-match/subcharts/open-match-customize/templates/evaluator.yaml
+++ b/install/helm/open-match/subcharts/open-match-customize/templates/evaluator.yaml
@@ -35,12 +35,24 @@ spec:
     protocol: TCP
     port: {{ .Values.evaluator.httpPort }}
 ---
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .Values.evaluator.hostName }}
+  namespace: {{ .Release.Namespace }}
+  annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    name: {{ .Values.evaluator.hostName }}
+  {{- include "openmatch.HorizontalPodAutoscaler.spec.common" . | nindent 2 }}
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: {{ .Values.evaluator.hostName }}
   namespace: {{ .Release.Namespace }}
-  annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
   labels:
     app: {{ template "openmatch.name" . }}
     component: evaluator

--- a/install/helm/open-match/subcharts/open-match-customize/templates/matchfunctions.yaml
+++ b/install/helm/open-match/subcharts/open-match-customize/templates/matchfunctions.yaml
@@ -35,6 +35,19 @@ spec:
     protocol: TCP
     port: {{ .Values.function.httpPort }}
 ---
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .Values.function.hostName }}
+  namespace: {{ .Release.Namespace }}
+  annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    name: {{ .Values.function.hostName }}
+  {{- include "openmatch.HorizontalPodAutoscaler.spec.common" . | nindent 2 }}
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:

--- a/install/helm/open-match/templates/_helpers.tpl
+++ b/install/helm/open-match/templates/_helpers.tpl
@@ -116,3 +116,9 @@ readinessProbe:
   periodSeconds: 10
   failureThreshold: 2
 {{- end -}}
+
+{{- define "openmatch.HorizontalPodAutoscaler.spec.common" -}}
+minReplicas: 1
+maxReplicas: 10
+targetCPUUtilizationPercentage: 50
+{{- end -}}

--- a/install/helm/open-match/templates/backend.yaml
+++ b/install/helm/open-match/templates/backend.yaml
@@ -37,6 +37,18 @@ spec:
     protocol: TCP
     port: {{ .Values.backend.httpPort }}
 ---
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .Values.backend.hostName }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  scaleTargetRef:
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    name: {{ .Values.backend.hostName }}
+  {{- include "openmatch.HorizontalPodAutoscaler.spec.common" . | nindent 2 }}
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:

--- a/install/helm/open-match/templates/frontend.yaml
+++ b/install/helm/open-match/templates/frontend.yaml
@@ -37,6 +37,18 @@ spec:
     protocol: TCP
     port: {{ .Values.frontend.httpPort }}
 ---
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .Values.frontend.hostName }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  scaleTargetRef:
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    name: {{ .Values.frontend.hostName }}
+  {{- include "openmatch.HorizontalPodAutoscaler.spec.common" . | nindent 2 }}
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:

--- a/install/helm/open-match/templates/mmlogic.yaml
+++ b/install/helm/open-match/templates/mmlogic.yaml
@@ -37,6 +37,18 @@ spec:
     protocol: TCP
     port: {{ .Values.mmlogic.httpPort }}
 ---
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .Values.mmlogic.hostName }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  scaleTargetRef:
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    name: {{ .Values.mmlogic.hostName }}
+  {{- include "openmatch.HorizontalPodAutoscaler.spec.common" . | nindent 2 }}
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:

--- a/install/helm/open-match/values.yaml
+++ b/install/helm/open-match/values.yaml
@@ -54,10 +54,12 @@ evaluator: &evaluator
   hostName: om-evaluator
   grpcPort: 50508
   httpPort: 51508
+  replicas: 3
 function: &function
   hostName: om-function
   grpcPort: 50502
   httpPort: 51502
+  replicas: 3
 
 image:
   registry: gcr.io/open-match-public-images


### PR DESCRIPTION
The change allows Kubernetes to autoscale Open Match services up to 10 replicas.