### PR TITLE
Make config names constants. (#623)

### DIFF
--- a/internal/app/backend/synchronizer_client.go
+++ b/internal/app/backend/synchronizer_client.go
@@ -11,6 +11,10 @@ import (
 	"open-match.dev/open-match/pkg/pb"
 )
 
+const (
+	configNameSynchronizerEnabled = "synchronizer.enabled"
+)
+
 var (
 	mMatchEvaluations = monitoring.Counter("backend/matches_evaluated", "matches evaluated")
 )
@@ -25,7 +29,7 @@ type synchronizerClient struct {
 // if the synchronizer is enabled. The first attempt to call the synchronizer service
 // establishes a connection. Consequent requests use the cached connection.
 func (sc *synchronizerClient) register(ctx context.Context) (string, error) {
-	if !sc.cfg.GetBool("synchronizer.enabled") {
+	if !sc.cfg.GetBool(configNameSynchronizerEnabled) {
 		// Synchronizer is disabled. Succeed the call without returning any ID.
 		return "", nil
 	}
@@ -47,7 +51,7 @@ func (sc *synchronizerClient) register(ctx context.Context) (string, error) {
 // this if the synchronizer is enabled. The first attempt to call the synchronizer service
 // establishes a connection. Consequent requests use the cached connection.
 func (sc *synchronizerClient) evaluate(ctx context.Context, id string, proposals []*pb.Match) ([]*pb.Match, error) {
-	if !sc.cfg.GetBool("synchronizer.enabled") {
+	if !sc.cfg.GetBool(configNameSynchronizerEnabled) {
 		// Synchronizer is disabled. Return all the proposals as results. This is only temporary.
 		// After the synchronizer is implememnted, it will be mandatory and this check will be removed.
 		return proposals, nil

--- a/internal/app/mmlogic/mmlogic_service.go
+++ b/internal/app/mmlogic/mmlogic_service.go
@@ -26,6 +26,10 @@ import (
 	"open-match.dev/open-match/internal/statestore"
 )
 
+const (
+	configNameStoragePageSize = "storage.page.size"
+)
+
 var (
 	logger = logrus.WithFields(logrus.Fields{
 		"app":       "openmatch",
@@ -76,7 +80,6 @@ func doQueryTickets(ctx context.Context, filters []*pb.Filter, pageSize int, sen
 
 func getPageSize(cfg config.View) int {
 	const (
-		name = "storage.page.size"
 		// Minimum number of tickets to be returned in a streamed response for QueryTickets. This value
 		// will be used if page size is configured lower than the minimum value.
 		minPageSize int = 10
@@ -88,11 +91,11 @@ func getPageSize(cfg config.View) int {
 		maxPageSize int = 10000
 	)
 
-	if !cfg.IsSet(name) {
+	if !cfg.IsSet(configNameStoragePageSize) {
 		return defaultPageSize
 	}
 
-	pSize := cfg.GetInt("storage.page.size")
+	pSize := cfg.GetInt(configNameStoragePageSize)
 	if pSize < minPageSize {
 		logger.Infof("page size %v is lower than the minimum limit of %v", pSize, maxPageSize)
 		pSize = minPageSize

--- a/internal/logging/helper.go
+++ b/internal/logging/helper.go
@@ -21,12 +21,17 @@ import (
 	"open-match.dev/open-match/internal/config"
 )
 
+const (
+	configNameLoggingFormat = "logging.format"
+	configNameLoggingLevel  = "logging.level"
+)
+
 // ConfigureLogging sets up open match logrus instance using the logging section of the matchmaker_config.json
 //  - log line format (text[default] or json)
 //  - min log level to include (debug, info [default], warn, error, fatal, panic)
 //  - include source file and line number for every event (false [default], true)
 func ConfigureLogging(cfg config.View) {
-	switch cfg.GetString("logging.format") {
+	switch cfg.GetString(configNameLoggingFormat) {
 	case "stackdriver":
 		logrus.SetFormatter(stackdriver.NewFormatter())
 	case "json":
@@ -36,7 +41,7 @@ func ConfigureLogging(cfg config.View) {
 		logrus.SetFormatter(&logrus.TextFormatter{})
 	}
 
-	switch cfg.GetString("logging.level") {
+	switch cfg.GetString(configNameLoggingLevel) {
 	case "debug":
 		logrus.SetLevel(logrus.DebugLevel)
 		logrus.Warn("Debug logging level configured. Not recommended for production!")

--- a/internal/monitoring/jaeger.go
+++ b/internal/monitoring/jaeger.go
@@ -21,6 +21,12 @@ import (
 	"open-match.dev/open-match/internal/config"
 )
 
+const (
+	configNameMonitoringJaegerEnable            = "monitoring.jaeger.enable"
+	configNameMonitoringJaegerAgentEndpoint     = "monitoring.jaeger.agentEndpoint"
+	configNameMonitoringJaegerCollectorEndpoint = "monitoring.jaeger.collectorEndpoint"
+)
+
 var (
 	jaegerLogger = logrus.WithFields(logrus.Fields{
 		"app":       "openmatch",
@@ -29,13 +35,13 @@ var (
 )
 
 func bindJaeger(cfg config.View) {
-	if !cfg.GetBool("monitoring.jaeger.enable") {
+	if !cfg.GetBool(configNameMonitoringJaegerEnable) {
 		jaegerLogger.Info("Jaeger Tracing: Disabled")
 		return
 	}
 
-	agentEndpointURI := cfg.GetString("monitoring.jaeger.agentEndpoint")
-	collectorEndpointURI := cfg.GetString("monitoring.jaeger.collectorEndpoint")
+	agentEndpointURI := cfg.GetString(configNameMonitoringJaegerAgentEndpoint)
+	collectorEndpointURI := cfg.GetString(configNameMonitoringJaegerCollectorEndpoint)
 
 	je, err := jaeger.NewExporter(jaeger.Options{
 		AgentEndpoint:     agentEndpointURI,

--- a/internal/monitoring/prometheus.go
+++ b/internal/monitoring/prometheus.go
@@ -27,7 +27,8 @@ import (
 
 const (
 	// ConfigNameEnableMetrics indicates that monitoring is enabled.
-	ConfigNameEnableMetrics = "monitoring.prometheus.enable"
+	ConfigNameEnableMetrics                = "monitoring.prometheus.enable"
+	configNameMonitoringPrometheusEndpoint = "monitoring.prometheus.endpoint"
 )
 
 var (
@@ -38,12 +39,12 @@ var (
 )
 
 func bindPrometheus(mux *http.ServeMux, cfg config.View) {
-	if !cfg.GetBool("monitoring.prometheus.enable") {
+	if !cfg.GetBool(ConfigNameEnableMetrics) {
 		prometheusLogger.Info("Prometheus Metrics: Disabled")
 		return
 	}
 
-	endpoint := cfg.GetString("monitoring.prometheus.endpoint")
+	endpoint := cfg.GetString(configNameMonitoringPrometheusEndpoint)
 	registry := prometheus.NewRegistry()
 	// Register standard prometheus instrumentation.
 	registry.MustRegister(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}))

--- a/internal/monitoring/public.go
+++ b/internal/monitoring/public.go
@@ -25,6 +25,10 @@ import (
 	"open-match.dev/open-match/internal/config"
 )
 
+const (
+	configNameMonitoringReportingPeriod = "monitoring.reportingPeriod"
+)
+
 var (
 	publicLogger = logrus.WithFields(logrus.Fields{
 		"app":       "openmatch",
@@ -34,7 +38,7 @@ var (
 
 // Setup configures the monitoring for the server.
 func Setup(mux *http.ServeMux, cfg config.View) {
-	periodString := cfg.GetString("monitoring.reportingPeriod")
+	periodString := cfg.GetString(configNameMonitoringReportingPeriod)
 	reportingPeriod, err := time.ParseDuration(periodString)
 	if err != nil {
 		publicLogger.WithFields(logrus.Fields{

--- a/internal/monitoring/stackdriver.go
+++ b/internal/monitoring/stackdriver.go
@@ -22,6 +22,12 @@ import (
 	"open-match.dev/open-match/internal/config"
 )
 
+const (
+	configNameMonitoringStackdriverEnable       = "monitoring.stackdriver.enable"
+	configNameMonitoringStackdriverGCPProjectID = "monitoring.stackdriver.gcpProjectId"
+	configNameMonitoringStackdriverMetricPrefix = "monitoring.stackdriver.metricPrefix"
+)
+
 var (
 	stackdriverLogger = logrus.WithFields(logrus.Fields{
 		"app":       "openmatch",
@@ -30,12 +36,12 @@ var (
 )
 
 func bindStackDriver(cfg config.View) {
-	if !cfg.GetBool("monitoring.stackdriver.enable") {
+	if !cfg.GetBool(configNameMonitoringStackdriverEnable) {
 		stackdriverLogger.Info("StackDriver Metrics: Disabled")
 		return
 	}
-	gcpProjectID := cfg.GetString("monitoring.stackdriver.gcpProjectId")
-	metricPrefix := cfg.GetString("monitoring.stackdriver.metricPrefix")
+	gcpProjectID := cfg.GetString(configNameMonitoringStackdriverGCPProjectID)
+	metricPrefix := cfg.GetString(configNameMonitoringStackdriverMetricPrefix)
 	sd, err := stackdriver.NewExporter(stackdriver.Options{
 		ProjectID: gcpProjectID,
 		// MetricPrefix helps uniquely identify your metrics.

--- a/internal/monitoring/zipkin.go
+++ b/internal/monitoring/zipkin.go
@@ -26,6 +26,12 @@ import (
 	"open-match.dev/open-match/internal/config"
 )
 
+const (
+	configNameZipkinEnable           = "monitoring.zipkin.enable"
+	configNameZipkinEndpoint         = "monitoring.zipkin.endpoint"
+	configNameZipkinReporterEndpoint = "monitoring.zipkin.reporterEndpoint"
+)
+
 var (
 	zipkinLogger = logrus.WithFields(logrus.Fields{
 		"app":       "openmatch",
@@ -34,12 +40,12 @@ var (
 )
 
 func bindZipkin(cfg config.View) {
-	if !cfg.GetBool("monitoring.zipkin.enable") {
+	if !cfg.GetBool(configNameZipkinEnable) {
 		zipkinLogger.Info("Zipkin Tracing: Disabled")
 		return
 	}
-	zipkinEndpoint := cfg.GetString("monitoring.zipkin.endpoint")
-	zipkinReporterEndpoint := cfg.GetString("monitoring.zipkin.reporterEndpoint")
+	zipkinEndpoint := cfg.GetString(configNameZipkinEndpoint)
+	zipkinReporterEndpoint := cfg.GetString(configNameZipkinReporterEndpoint)
 	// 1. Configure exporter to export traces to Zipkin.
 	localEndpoint, err := openzipkin.NewEndpoint("open_match", zipkinEndpoint)
 	if err != nil {

--- a/internal/monitoring/zpages.go
+++ b/internal/monitoring/zpages.go
@@ -15,13 +15,18 @@
 package monitoring
 
 import (
-	"go.opencensus.io/zpages"
 	"net/http"
+
+	"go.opencensus.io/zpages"
 	"open-match.dev/open-match/internal/config"
 )
 
+const (
+	configNameMonitoringZpagesEnable = "monitoring.zpages.enable"
+)
+
 func bindZpages(mux *http.ServeMux, cfg config.View) {
-	if !cfg.GetBool("monitoring.zpages.enable") {
+	if !cfg.GetBool(configNameMonitoringZpagesEnable) {
 		return
 	}
 	zpages.Handle(mux, "/debug")

--- a/internal/statestore/redis_test.go
+++ b/internal/statestore/redis_test.go
@@ -135,7 +135,7 @@ func TestIgnoreLists(t *testing.T) {
 	verifyTickets(service, len(tickets)-3)
 
 	// Sleep until the ignore list expired and verify we still have all the tickets
-	time.Sleep(cfg.GetDuration("redis.ignoreLists.ttl"))
+	time.Sleep(cfg.GetDuration(configNameRedisIgnoreListsTTL))
 	verifyTickets(service, len(tickets))
 }
 


### PR DESCRIPTION
Make the configuration names constants so that there's 1 label.
Tests are excluded if it would cause the config name to be exported.