### PR TITLE
Merge logrus loggers

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,7 +24,7 @@ import (
 )
 
 var (
-	cfgLog = logrus.WithFields(logrus.Fields{
+	logger = logrus.WithFields(logrus.Fields{
 		"app":       "openmatch",
 		"component": "config",
 	})
@@ -82,9 +82,7 @@ func Read() (View, error) {
 	// Read in config file using Viper
 	err := cfg.ReadInConfig()
 	if err != nil {
-		cfgLog.WithFields(logrus.Fields{
-			"error": err.Error(),
-		}).Fatal("Fatal error reading config file")
+		logger.WithError(err).Fatal("Fatal error reading config file")
 	}
 
 	// Bind this envvars to viper config vars.
@@ -96,15 +94,14 @@ func Read() (View, error) {
 		err = cfg.BindEnv(cfgKey, envVar)
 
 		if err != nil {
-			cfgLog.WithFields(logrus.Fields{
+			logger.WithError(err).WithFields(logrus.Fields{
 				"configkey": cfgKey,
 				"envvar":    envVar,
-				"error":     err.Error(),
 				"module":    "config",
 			}).Warn("Unable to bind environment var as a config variable")
 
 		} else {
-			cfgLog.WithFields(logrus.Fields{
+			logger.WithFields(logrus.Fields{
 				"configkey": cfgKey,
 				"envvar":    envVar,
 				"module":    "config",
@@ -120,7 +117,7 @@ func Read() (View, error) {
 	cfg.WatchConfig() // Watch and re-read config file.
 	// Write a log when the configuration changes.
 	cfg.OnConfigChange(func(event fsnotify.Event) {
-		cfgLog.WithFields(logrus.Fields{
+		logger.WithFields(logrus.Fields{
 			"filename":  event.Name,
 			"operation": event.Op,
 		}).Info("Server configuration changed.")

--- a/internal/rpc/insecure.go
+++ b/internal/rpc/insecure.go
@@ -23,17 +23,9 @@ import (
 
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"open-match.dev/open-match/internal/monitoring"
 	"open-match.dev/open-match/internal/util/netlistener"
-)
-
-var (
-	insecureLogger = logrus.WithFields(logrus.Fields{
-		"app":       "openmatch",
-		"component": "insecure_server",
-	})
 )
 
 type insecureServer struct {
@@ -70,7 +62,7 @@ func (s *insecureServer) start(params *ServerParams) (func(), error) {
 	serverStartWaiter.Add(1)
 	go func() {
 		serverStartWaiter.Done()
-		insecureLogger.Infof("Serving gRPC: %s", s.grpcLh.AddrString())
+		serverLogger.Infof("Serving gRPC: %s", s.grpcLh.AddrString())
 		gErr := s.grpcServer.Serve(s.grpcListener)
 		if gErr != nil {
 			return
@@ -105,11 +97,11 @@ func (s *insecureServer) start(params *ServerParams) (func(), error) {
 	serverStartWaiter.Add(1)
 	go func() {
 		serverStartWaiter.Done()
-		insecureLogger.Infof("Serving HTTP: %s", s.httpLh.AddrString())
+		serverLogger.Infof("Serving HTTP: %s", s.httpLh.AddrString())
 		hErr := s.httpServer.Serve(s.httpListener)
 		defer cancel()
 		if hErr != nil {
-			insecureLogger.Debugf("error closing gRPC server: %s", hErr)
+			serverLogger.Debugf("error closing gRPC server: %s", hErr)
 		}
 	}()
 
@@ -119,15 +111,15 @@ func (s *insecureServer) start(params *ServerParams) (func(), error) {
 func (s *insecureServer) stop() {
 	s.grpcServer.Stop()
 	if err := s.grpcListener.Close(); err != nil {
-		insecureLogger.Debugf("error closing gRPC listener: %s", err)
+		serverLogger.Debugf("error closing gRPC listener: %s", err)
 	}
 
 	if err := s.httpServer.Close(); err != nil {
-		insecureLogger.Debugf("error closing HTTP server: %s", err)
+		serverLogger.Debugf("error closing HTTP server: %s", err)
 	}
 
 	if err := s.httpListener.Close(); err != nil {
-		insecureLogger.Debugf("error closing HTTP listener: %s", err)
+		serverLogger.Debugf("error closing HTTP listener: %s", err)
 	}
 }
 

--- a/pkg/harness/evaluator/golang/evaluator_service.go
+++ b/pkg/harness/evaluator/golang/evaluator_service.go
@@ -27,9 +27,9 @@ import (
 )
 
 var (
-	evaluatorLogger = logrus.WithFields(logrus.Fields{
+	logger = logrus.WithFields(logrus.Fields{
 		"app":       "openmatch",
-		"component": "harness.golang.evaluator_service",
+		"component": "evaluator.harness.golang",
 	})
 )
 
@@ -58,20 +58,23 @@ type EvaluatorParams struct {
 // Evaluate is this harness's implementation of the gRPC call defined in
 // api/evaluator.proto.
 func (s *evaluatorService) Evaluate(ctx context.Context, req *pb.EvaluateRequest) (*pb.EvaluateResponse, error) {
-	evaluatorLogger.WithFields(logrus.Fields{
+	logger.WithFields(logrus.Fields{
 		"proposals": req.GetMatches(),
 	}).Debug("matches sent to the evaluator")
 
 	// Run the customized evaluator!
 	results, err := s.evaluate(&EvaluatorParams{
-		Logger:  evaluatorLogger,
+		Logger: logrus.WithFields(logrus.Fields{
+			"app":       "openmatch",
+			"component": "evaluator.implementation",
+		}),
 		Matches: req.GetMatches(),
 	})
 	if err != nil {
 		return nil, status.Error(codes.Aborted, err.Error())
 	}
 
-	evaluatorLogger.WithFields(logrus.Fields{
+	logger.WithFields(logrus.Fields{
 		"results": results,
 	}).Debug("matches accepted by the evaluator")
 	return &pb.EvaluateResponse{Matches: results}, nil

--- a/pkg/harness/evaluator/golang/harness.go
+++ b/pkg/harness/evaluator/golang/harness.go
@@ -24,31 +24,24 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var (
-	harnessLogger = logrus.WithFields(logrus.Fields{
-		"app":       "openmatch",
-		"component": "evaluator.golang.harness",
-	})
-)
-
 // RunEvaluator is a hook for the main() method in the main executable.
 func RunEvaluator(eval Evaluator) {
 	cfg, err := config.Read()
 	if err != nil {
-		harnessLogger.WithFields(logrus.Fields{
+		logger.WithFields(logrus.Fields{
 			"error": err.Error(),
 		}).Fatalf("cannot read configuration.")
 	}
 
 	p, err := rpc.NewServerParamsFromConfig(cfg, "api.evaluator")
 	if err != nil {
-		harnessLogger.WithFields(logrus.Fields{
+		logger.WithFields(logrus.Fields{
 			"error": err.Error(),
 		}).Fatalf("cannot construct server.")
 	}
 
 	if err := BindService(p, cfg, eval); err != nil {
-		harnessLogger.WithFields(logrus.Fields{
+		logger.WithFields(logrus.Fields{
 			"error": err.Error(),
 		}).Fatalf("failed to bind evaluator service.")
 	}

--- a/pkg/harness/function/golang/harness.go
+++ b/pkg/harness/function/golang/harness.go
@@ -24,13 +24,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var (
-	harnessLogger = logrus.WithFields(logrus.Fields{
-		"app":       "openmatch",
-		"component": "matchfunction.golang.harness",
-	})
-)
-
 // FunctionSettings is a collection of parameters used to customize matchfunction views.
 type FunctionSettings struct {
 	Func MatchFunction
@@ -40,19 +33,19 @@ type FunctionSettings struct {
 func RunMatchFunction(settings *FunctionSettings) {
 	cfg, err := config.Read()
 	if err != nil {
-		harnessLogger.WithFields(logrus.Fields{
+		logger.WithFields(logrus.Fields{
 			"error": err.Error(),
 		}).Fatalf("cannot read configuration.")
 	}
 	p, err := rpc.NewServerParamsFromConfig(cfg, "api.functions")
 	if err != nil {
-		harnessLogger.WithFields(logrus.Fields{
+		logger.WithFields(logrus.Fields{
 			"error": err.Error(),
 		}).Fatalf("cannot construct server.")
 	}
 
 	if err := BindService(p, cfg, settings); err != nil {
-		harnessLogger.WithFields(logrus.Fields{
+		logger.WithFields(logrus.Fields{
 			"error": err.Error(),
 		}).Fatalf("failed to bind functions service.")
 	}


### PR DESCRIPTION
We are moving to a model where there's 1 logger per package. Some extra loggers are ok if they make sense. Like the rpc package has a client and server logger.

This change does not include the logger merge for monitoring package. That's in https://github.com/googleforgames/open-match/pull/648