### PR TITLE
Move monitoring/ to telemetry/.

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -209,7 +209,7 @@ issues:
     - source: "flag."
       linters:
         - gochecknoglobals
-    - source: "monitoring."
+    - source: "telemetry."
       linters:
         - gochecknoglobals
     - source: "View."

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@
 ## make all -j$(nproc)
 ## make test
 ##
-## Access monitoring
+## Access telemetry
 ## make proxy-prometheus
 ## make proxy-grafana
 ## make proxy-ui
@@ -352,8 +352,8 @@ install-large-chart: build/toolchain/bin/helm$(EXE_EXTENSION) install/helm/open-
 		--set jaeger.enabled=true \
 		--set prometheus.enabled=true \
 		--set redis.enabled=true \
-		--set openmatch.monitoring.stackdriver.enabled=true \
-		--set openmatch.monitoring.stackdriver.gcpProjectId=$(GCP_PROJECT_ID)
+		--set openmatch.telemetry.stackdriver.enabled=true \
+		--set openmatch.telemetry.stackdriver.gcpProjectId=$(GCP_PROJECT_ID)
 
 install-chart: build/toolchain/bin/helm$(EXE_EXTENSION) install/helm/open-match/secrets/
 	$(HELM) upgrade $(OPEN_MATCH_CHART_NAME) --install --wait --debug install/helm/open-match \
@@ -365,8 +365,8 @@ install-chart: build/toolchain/bin/helm$(EXE_EXTENSION) install/helm/open-match/
 		--set jaeger.enabled=false \
 		--set prometheus.enabled=false \
 		--set redis.enabled=true \
-		--set openmatch.monitoring.stackdriver.enabled=true \
-		--set openmatch.monitoring.stackdriver.gcpProjectId=$(GCP_PROJECT_ID)
+		--set openmatch.telemetry.stackdriver.enabled=true \
+		--set openmatch.telemetry.stackdriver.gcpProjectId=$(GCP_PROJECT_ID)
 
 install-ci-chart: build/toolchain/bin/helm$(EXE_EXTENSION) install/helm/open-match/secrets/
 	$(HELM) upgrade $(OPEN_MATCH_CHART_NAME) --install --wait --debug install/helm/open-match \
@@ -384,8 +384,8 @@ install-ci-chart: build/toolchain/bin/helm$(EXE_EXTENSION) install/helm/open-mat
 		--set openmatch.e2eevaluator.install=true \
 		--set openmatch.e2ematchfunction.install=true \
 		--set openmatch.stresstest.install=true \
-		--set openmatch.monitoring.stackdriver.enabled=true \
-		--set openmatch.monitoring.stackdriver.gcpProjectId=$(GCP_PROJECT_ID)
+		--set openmatch.telemetry.stackdriver.enabled=true \
+		--set openmatch.telemetry.stackdriver.gcpProjectId=$(GCP_PROJECT_ID)
 
 dry-chart: build/toolchain/bin/helm$(EXE_EXTENSION)
 	$(HELM) upgrade --install --wait --debug --dry-run $(OPEN_MATCH_CHART_NAME) install/helm/open-match \

--- a/examples/demo/main.go
+++ b/examples/demo/main.go
@@ -30,7 +30,7 @@ import (
 	"open-match.dev/open-match/examples/demo/updater"
 	"open-match.dev/open-match/internal/config"
 	"open-match.dev/open-match/internal/logging"
-	"open-match.dev/open-match/internal/monitoring"
+	"open-match.dev/open-match/internal/telemetry"
 )
 
 var (
@@ -61,7 +61,7 @@ func main() {
 		fileServe.ServeHTTP(w, r)
 	})
 
-	http.Handle(monitoring.HealthCheckEndpoint, monitoring.NewAlwaysReadyHealthCheck())
+	http.Handle(telemetry.HealthCheckEndpoint, telemetry.NewAlwaysReadyHealthCheck())
 
 	bs := bytesub.New()
 	u := updater.New(context.Background(), func(b []byte) {

--- a/install/helm/open-match/templates/backend.yaml
+++ b/install/helm/open-match/templates/backend.yaml
@@ -54,7 +54,7 @@ spec:
     metadata:
       namespace: {{ .Release.Namespace }}
       annotations:
-        {{- include "prometheus.annotations" (dict "port" .Values.openmatch.backend.http.port "prometheus" .Values.openmatch.monitoring.prometheus) | nindent 8 }}
+        {{- include "prometheus.annotations" (dict "port" .Values.openmatch.backend.http.port "prometheus" .Values.openmatch.telemetry.prometheus) | nindent 8 }}
       labels:
         app: {{ template "openmatch.name" . }}
         component: backend

--- a/install/helm/open-match/templates/demo.yaml
+++ b/install/helm/open-match/templates/demo.yaml
@@ -51,7 +51,7 @@ spec:
     metadata:
       namespace: {{ .Release.Namespace }}
       annotations:
-        {{- include "prometheus.annotations" (dict "port" .Values.openmatch.demo.http.port "prometheus" .Values.openmatch.monitoring.prometheus) | nindent 8 }}
+        {{- include "prometheus.annotations" (dict "port" .Values.openmatch.demo.http.port "prometheus" .Values.openmatch.telemetry.prometheus) | nindent 8 }}
       labels:
         app: {{ template "openmatch.name" . }}
         component: demo

--- a/install/helm/open-match/templates/demoevaluator.yaml
+++ b/install/helm/open-match/templates/demoevaluator.yaml
@@ -53,7 +53,7 @@ spec:
     metadata:
       namespace: {{ .Release.Namespace }}
       annotations:
-        {{- include "prometheus.annotations" (dict "port" .Values.openmatch.demoevaluator.http.port "prometheus" .Values.openmatch.monitoring.prometheus) | nindent 8 }}
+        {{- include "prometheus.annotations" (dict "port" .Values.openmatch.demoevaluator.http.port "prometheus" .Values.openmatch.telemetry.prometheus) | nindent 8 }}
       labels:
         app: {{ template "openmatch.name" . }}
         component: demoevaluator

--- a/install/helm/open-match/templates/demofunction.yaml
+++ b/install/helm/open-match/templates/demofunction.yaml
@@ -54,7 +54,7 @@ spec:
     metadata:
       namespace: {{ .Release.Namespace }}
       annotations:
-        {{- include "prometheus.annotations" (dict "port" .Values.openmatch.demofunction.http.port "prometheus" .Values.openmatch.monitoring.prometheus) | nindent 8 }}
+        {{- include "prometheus.annotations" (dict "port" .Values.openmatch.demofunction.http.port "prometheus" .Values.openmatch.telemetry.prometheus) | nindent 8 }}
       labels:
         app: {{ template "openmatch.name" . }}
         component: demofunction

--- a/install/helm/open-match/templates/e2eevaluator.yaml
+++ b/install/helm/open-match/templates/e2eevaluator.yaml
@@ -54,7 +54,7 @@ spec:
     metadata:
       namespace: {{ .Release.Namespace }}
       annotations:
-        {{- include "prometheus.annotations" (dict "port" .Values.openmatch.e2eevaluator.http.port "prometheus" .Values.openmatch.monitoring.prometheus) | nindent 8 }}
+        {{- include "prometheus.annotations" (dict "port" .Values.openmatch.e2eevaluator.http.port "prometheus" .Values.openmatch.telemetry.prometheus) | nindent 8 }}
       labels:
         app: {{ template "openmatch.name" . }}
         component: e2eevaluator

--- a/install/helm/open-match/templates/e2ematchfunction.yaml
+++ b/install/helm/open-match/templates/e2ematchfunction.yaml
@@ -54,7 +54,7 @@ spec:
     metadata:
       namespace: {{ .Release.Namespace }}
       annotations:
-        {{- include "prometheus.annotations" (dict "port" .Values.openmatch.e2ematchfunction.http.port "prometheus" .Values.openmatch.monitoring.prometheus) | nindent 8 }}
+        {{- include "prometheus.annotations" (dict "port" .Values.openmatch.e2ematchfunction.http.port "prometheus" .Values.openmatch.telemetry.prometheus) | nindent 8 }}
       labels:
         app: {{ template "openmatch.name" . }}
         component: e2ematchfunction

--- a/install/helm/open-match/templates/frontend.yaml
+++ b/install/helm/open-match/templates/frontend.yaml
@@ -55,7 +55,7 @@ spec:
     metadata:
       namespace: {{ .Release.Namespace }}
       annotations:
-        {{- include "prometheus.annotations" (dict "port" .Values.openmatch.frontend.http.port "prometheus" .Values.openmatch.monitoring.prometheus) | nindent 8 }}
+        {{- include "prometheus.annotations" (dict "port" .Values.openmatch.frontend.http.port "prometheus" .Values.openmatch.telemetry.prometheus) | nindent 8 }}
       labels:
         app: {{ template "openmatch.name" . }}
         component: frontend

--- a/install/helm/open-match/templates/mmlogic.yaml
+++ b/install/helm/open-match/templates/mmlogic.yaml
@@ -55,7 +55,7 @@ spec:
     metadata:
       namespace: {{ .Release.Namespace }}
       annotations:
-        {{- include "prometheus.annotations" (dict "port" .Values.openmatch.mmlogic.http.port "prometheus" .Values.openmatch.monitoring.prometheus) | nindent 8 }}
+        {{- include "prometheus.annotations" (dict "port" .Values.openmatch.mmlogic.http.port "prometheus" .Values.openmatch.telemetry.prometheus) | nindent 8 }}
       labels:
         app: {{ template "openmatch.name" . }}
         component: mmlogic

--- a/install/helm/open-match/templates/synchronizer.yaml
+++ b/install/helm/open-match/templates/synchronizer.yaml
@@ -54,7 +54,7 @@ spec:
     metadata:
       namespace: {{ .Release.Namespace }}
       annotations:
-        {{- include "prometheus.annotations" (dict "port" .Values.openmatch.synchronizer.http.port "prometheus" .Values.openmatch.monitoring.prometheus) | nindent 8 }}
+        {{- include "prometheus.annotations" (dict "port" .Values.openmatch.synchronizer.http.port "prometheus" .Values.openmatch.telemetry.prometheus) | nindent 8 }}
       labels:
         app: {{ template "openmatch.name" . }}
         component: synchronizer

--- a/install/helm/open-match/values.yaml
+++ b/install/helm/open-match/values.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 openmatch:
-  monitoring:
+  telemetry:
     jaeger:
       enabled: true
       agentEndpoint: "open-match-jaeger-agent:6831"
@@ -194,26 +194,26 @@ openmatch:
           registrationIntervalMs: 3000ms
           proposalCollectionIntervalMs: 2000ms
 
-        monitoring:
+        telemetry:
           opencensusAgent:
-            enable: "{{.Values.openmatch.monitoring.opencensusAgent.enabled}}"
-            agentEndpoint: "{{.Values.openmatch.monitoring.opencensusAgent.agentEndpoint}}"
+            enable: "{{.Values.openmatch.telemetry.opencensusAgent.enabled}}"
+            agentEndpoint: "{{.Values.openmatch.telemetry.opencensusAgent.agentEndpoint}}"
           jaeger:
-            enable: "{{.Values.openmatch.monitoring.jaeger.enabled}}"
-            agentEndpoint: "{{.Values.openmatch.monitoring.jaeger.agentEndpoint}}"
-            collectorEndpoint: "{{.Values.openmatch.monitoring.jaeger.collectorEndpoint}}"
+            enable: "{{.Values.openmatch.telemetry.jaeger.enabled}}"
+            agentEndpoint: "{{.Values.openmatch.telemetry.jaeger.agentEndpoint}}"
+            collectorEndpoint: "{{.Values.openmatch.telemetry.jaeger.collectorEndpoint}}"
           prometheus:
-            enable: "{{.Values.openmatch.monitoring.prometheus.enabled}}"
-            endpoint: "{{.Values.openmatch.monitoring.prometheus.endpoint}}"
+            enable: "{{.Values.openmatch.telemetry.prometheus.enabled}}"
+            endpoint: "{{.Values.openmatch.telemetry.prometheus.endpoint}}"
           stackdriver:
-            enable: "{{.Values.openmatch.monitoring.stackdriver.enabled}}"
-            gcpProjectId: "{{.Values.openmatch.monitoring.stackdriver.gcpProjectId}}"
-            metricPrefix: "{{.Values.openmatch.monitoring.stackdriver.metricPrefix}}"
+            enable: "{{.Values.openmatch.telemetry.stackdriver.enabled}}"
+            gcpProjectId: "{{.Values.openmatch.telemetry.stackdriver.gcpProjectId}}"
+            metricPrefix: "{{.Values.openmatch.telemetry.stackdriver.metricPrefix}}"
           zipkin:
-            enable: "{{.Values.openmatch.monitoring.zipkin.enabled}}"
-            endpoint: "{{.Values.openmatch.monitoring.zipkin.endpoint}}"
-            reporterEndpoint: "{{.Values.openmatch.monitoring.zipkin.reporterEndpoint}}"
-          reportingPeriod: "{{.Values.openmatch.monitoring.reportingPeriod}}"
+            enable: "{{.Values.openmatch.telemetry.zipkin.enabled}}"
+            endpoint: "{{.Values.openmatch.telemetry.zipkin.endpoint}}"
+            reporterEndpoint: "{{.Values.openmatch.telemetry.zipkin.reporterEndpoint}}"
+          reportingPeriod: "{{.Values.openmatch.telemetry.reportingPeriod}}"
         storage:
           page:
             size: 10000

--- a/internal/app/backend/backend_service.go
+++ b/internal/app/backend/backend_service.go
@@ -26,9 +26,9 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"open-match.dev/open-match/internal/monitoring"
 	"open-match.dev/open-match/internal/rpc"
 	"open-match.dev/open-match/internal/statestore"
+	"open-match.dev/open-match/internal/telemetry"
 	"open-match.dev/open-match/pkg/pb"
 )
 
@@ -50,8 +50,8 @@ var (
 		"app":       "openmatch",
 		"component": "app.backend",
 	})
-	mMatchesFetched  = monitoring.Counter("backend/matches_fetched", "matches fetched")
-	mTicketsAssigned = monitoring.Counter("backend/tickets_assigned", "tickets assigned")
+	mMatchesFetched  = telemetry.Counter("backend/matches_fetched", "matches fetched")
+	mTicketsAssigned = telemetry.Counter("backend/tickets_assigned", "tickets assigned")
 )
 
 // FetchMatches triggers execution of the specfied MatchFunction for each of the
@@ -93,7 +93,7 @@ func (s *backendService) FetchMatches(ctx context.Context, req *pb.FetchMatchesR
 		return nil, err
 	}
 
-	monitoring.IncrementCounterN(ctx, mMatchesFetched, len(results))
+	telemetry.IncrementCounterN(ctx, mMatchesFetched, len(results))
 	return &pb.FetchMatchesResponse{Matches: results}, nil
 }
 
@@ -242,7 +242,7 @@ func (s *backendService) AssignTickets(ctx context.Context, req *pb.AssignTicket
 		return nil, err
 	}
 
-	monitoring.IncrementCounterN(ctx, mTicketsAssigned, len(req.TicketIds))
+	telemetry.IncrementCounterN(ctx, mTicketsAssigned, len(req.TicketIds))
 	return &pb.AssignTicketsResponse{}, nil
 }
 

--- a/internal/app/backend/synchronizer_client.go
+++ b/internal/app/backend/synchronizer_client.go
@@ -5,14 +5,14 @@ import (
 	"sync"
 
 	"open-match.dev/open-match/internal/config"
-	"open-match.dev/open-match/internal/monitoring"
 	ipb "open-match.dev/open-match/internal/pb"
 	"open-match.dev/open-match/internal/rpc"
+	"open-match.dev/open-match/internal/telemetry"
 	"open-match.dev/open-match/pkg/pb"
 )
 
 var (
-	mMatchEvaluations = monitoring.Counter("backend/matches_evaluated", "matches evaluated")
+	mMatchEvaluations = telemetry.Counter("backend/matches_evaluated", "matches evaluated")
 )
 
 type synchronizerClient struct {
@@ -65,7 +65,7 @@ func (sc *synchronizerClient) evaluate(ctx context.Context, id string, proposals
 		return nil, err
 	}
 
-	monitoring.IncrementCounterN(ctx, mMatchEvaluations, len(resp.Matches))
+	telemetry.IncrementCounterN(ctx, mMatchEvaluations, len(resp.Matches))
 	return resp.Matches, nil
 }
 

--- a/internal/app/swaggerui/swaggerui.go
+++ b/internal/app/swaggerui/swaggerui.go
@@ -26,8 +26,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"open-match.dev/open-match/internal/config"
-	"open-match.dev/open-match/internal/monitoring"
 	"open-match.dev/open-match/internal/rpc"
+	"open-match.dev/open-match/internal/telemetry"
 )
 
 var (
@@ -51,7 +51,7 @@ func RunApplication() {
 
 func serve(cfg config.View) {
 	mux := &http.ServeMux{}
-	closer := monitoring.Setup(mux, cfg)
+	closer := telemetry.Setup(mux, cfg)
 	defer closer()
 	port := cfg.GetInt("api.swaggerui.httpport")
 	baseDir, err := os.Getwd()
@@ -66,7 +66,7 @@ func serve(cfg config.View) {
 	}
 
 	mux.Handle("/", http.FileServer(http.Dir(directory)))
-	mux.Handle(monitoring.HealthCheckEndpoint, monitoring.NewAlwaysReadyHealthCheck())
+	mux.Handle(telemetry.HealthCheckEndpoint, telemetry.NewAlwaysReadyHealthCheck())
 	bindHandler(mux, cfg, "/v1/frontend/", "frontend")
 	bindHandler(mux, cfg, "/v1/backend/", "backend")
 	bindHandler(mux, cfg, "/v1/mmlogic/", "mmlogic")

--- a/internal/rpc/clients.go
+++ b/internal/rpc/clients.go
@@ -34,7 +34,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"open-match.dev/open-match/internal/config"
-	"open-match.dev/open-match/internal/monitoring"
+	"open-match.dev/open-match/internal/telemetry"
 )
 
 const (
@@ -69,7 +69,7 @@ func GRPCClientFromConfig(cfg config.View, prefix string) (*grpc.ClientConn, err
 		Hostname:         cfg.GetString(prefix + ".hostname"),
 		Port:             cfg.GetInt(prefix + ".grpcport"),
 		EnableRPCLogging: cfg.GetBool(configNameEnableRPCLogging),
-		EnableMetrics:    cfg.GetBool(monitoring.ConfigNameEnableMetrics),
+		EnableMetrics:    cfg.GetBool(telemetry.ConfigNameEnableMetrics),
 	}
 
 	// If TLS support is enabled in the config, fill in the trusted certificates for decrpting server certificate.
@@ -93,7 +93,7 @@ func GRPCClientFromConfig(cfg config.View, prefix string) (*grpc.ClientConn, err
 // GRPCClientFromEndpoint creates a gRPC client connection from endpoint.
 func GRPCClientFromEndpoint(cfg config.View, address string) (*grpc.ClientConn, error) {
 	// TODO: investigate if it is possible to keep a cache of the certpool and transport credentials
-	grpcOptions := newGRPCDialOptions(cfg.GetBool(monitoring.ConfigNameEnableMetrics), cfg.GetBool(configNameEnableRPCLogging))
+	grpcOptions := newGRPCDialOptions(cfg.GetBool(telemetry.ConfigNameEnableMetrics), cfg.GetBool(configNameEnableRPCLogging))
 
 	if cfg.GetString(configNameClientTrustedCertificatePath) != "" {
 		_, err := os.Stat(cfg.GetString(configNameClientTrustedCertificatePath))
@@ -149,7 +149,7 @@ func HTTPClientFromConfig(cfg config.View, prefix string) (*http.Client, string,
 		Hostname:         cfg.GetString(prefix + ".hostname"),
 		Port:             cfg.GetInt(prefix + ".httpport"),
 		EnableRPCLogging: cfg.GetBool(configNameEnableRPCLogging),
-		EnableMetrics:    cfg.GetBool(monitoring.ConfigNameEnableMetrics),
+		EnableMetrics:    cfg.GetBool(telemetry.ConfigNameEnableMetrics),
 	}
 
 	// If TLS support is enabled in the config, fill in the trusted certificates for decrpting server certificate.

--- a/internal/rpc/clients_test.go
+++ b/internal/rpc/clients_test.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
-	"open-match.dev/open-match/internal/monitoring"
+	"open-match.dev/open-match/internal/telemetry"
 	shellTesting "open-match.dev/open-match/internal/testing"
 	netlistenerTesting "open-match.dev/open-match/internal/util/netlistener/testing"
 	"open-match.dev/open-match/pkg/pb"
@@ -140,7 +140,7 @@ func runHTTPClientTests(assert *assert.Assertions, cfg config.View, rpcParams *S
 	assert.Nil(err)
 
 	// Confirm the client works as expected
-	httpReq, err := http.NewRequest(http.MethodGet, baseURL+monitoring.HealthCheckEndpoint, nil)
+	httpReq, err := http.NewRequest(http.MethodGet, baseURL+telemetry.HealthCheckEndpoint, nil)
 	assert.Nil(err)
 	assert.NotNil(httpReq)
 

--- a/internal/rpc/insecure.go
+++ b/internal/rpc/insecure.go
@@ -24,7 +24,7 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
-	"open-match.dev/open-match/internal/monitoring"
+	"open-match.dev/open-match/internal/telemetry"
 	"open-match.dev/open-match/internal/util/netlistener"
 )
 
@@ -88,7 +88,7 @@ func (s *insecureServer) start(params *ServerParams) (func(), error) {
 		}
 	}
 
-	s.httpMux.Handle(monitoring.HealthCheckEndpoint, monitoring.NewHealthCheck(params.handlersForHealthCheck))
+	s.httpMux.Handle(telemetry.HealthCheckEndpoint, telemetry.NewHealthCheck(params.handlersForHealthCheck))
 	s.httpMux.Handle("/", s.proxyMux)
 	s.httpServer = &http.Server{
 		Addr:    s.httpListener.Addr().String(),

--- a/internal/rpc/server.go
+++ b/internal/rpc/server.go
@@ -30,8 +30,8 @@ import (
 	"go.opencensus.io/plugin/ocgrpc"
 	"google.golang.org/grpc"
 	"open-match.dev/open-match/internal/config"
-	"open-match.dev/open-match/internal/monitoring"
 	"open-match.dev/open-match/internal/signal"
+	"open-match.dev/open-match/internal/telemetry"
 	"open-match.dev/open-match/internal/util/netlistener"
 )
 
@@ -128,11 +128,11 @@ func NewServerParamsFromConfig(cfg config.View, prefix string) (*ServerParams, e
 		p.SetTLSConfiguration(rootPublicCertData, publicCertData, privateKeyData)
 	}
 
-	p.enableMetrics = cfg.GetBool(monitoring.ConfigNameEnableMetrics)
+	p.enableMetrics = cfg.GetBool(telemetry.ConfigNameEnableMetrics)
 	p.enableRPCLogging = cfg.GetBool(configNameEnableRPCLogging)
-	// TODO: This isn't ideal since monitoring requires config for it to be initialized.
+	// TODO: This isn't ideal since telemetry requires config for it to be initialized.
 	// This forces us to initialize readiness probes earlier than necessary.
-	p.closer = monitoring.Setup(p.ServeMux, cfg)
+	p.closer = telemetry.Setup(p.ServeMux, cfg)
 	return p, nil
 }
 

--- a/internal/rpc/server_test.go
+++ b/internal/rpc/server_test.go
@@ -21,7 +21,7 @@ import (
 	"google.golang.org/grpc"
 	"io/ioutil"
 	"net/http"
-	"open-match.dev/open-match/internal/monitoring"
+	"open-match.dev/open-match/internal/telemetry"
 	shellTesting "open-match.dev/open-match/internal/testing"
 	netlistenerTesting "open-match.dev/open-match/internal/util/netlistener/testing"
 	"open-match.dev/open-match/pkg/pb"
@@ -104,7 +104,7 @@ func runGrpcWithProxyTests(assert *assert.Assertions, s grpcServerWithProxy, con
 	assert.Equal(200, httpResp.StatusCode)
 	assert.Equal("{}", string(body))
 
-	httpReq, err = http.NewRequest(http.MethodGet, endpoint+monitoring.HealthCheckEndpoint, nil)
+	httpReq, err = http.NewRequest(http.MethodGet, endpoint+telemetry.HealthCheckEndpoint, nil)
 	assert.Nil(err)
 
 	httpResp, err = httpClient.Do(httpReq)

--- a/internal/rpc/tls_server.go
+++ b/internal/rpc/tls_server.go
@@ -27,7 +27,7 @@ import (
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
-	"open-match.dev/open-match/internal/monitoring"
+	"open-match.dev/open-match/internal/telemetry"
 	"open-match.dev/open-match/internal/util/netlistener"
 )
 
@@ -115,7 +115,7 @@ func (s *tlsServer) start(params *ServerParams) (func(), error) {
 	}
 
 	// Bind HTTPS handlers
-	s.httpMux.Handle(monitoring.HealthCheckEndpoint, monitoring.NewHealthCheck(params.handlersForHealthCheck))
+	s.httpMux.Handle(telemetry.HealthCheckEndpoint, telemetry.NewHealthCheck(params.handlersForHealthCheck))
 	s.httpMux.Handle("/", s.proxyMux)
 	s.httpServer = &http.Server{
 		Addr:    s.httpListener.Addr().String(),

--- a/internal/statestore/instrumented.go
+++ b/internal/statestore/instrumented.go
@@ -17,20 +17,20 @@ package statestore
 import (
 	"context"
 
-	"open-match.dev/open-match/internal/monitoring"
+	"open-match.dev/open-match/internal/telemetry"
 	"open-match.dev/open-match/pkg/pb"
 )
 
 var (
-	mStateStoreCreateTicket           = monitoring.Counter("statestore/createticket", "tickets created")
-	mStateStoreGetTicket              = monitoring.Counter("statestore/getticket", "tickets retrieve")
-	mStateStoreDeleteTicket           = monitoring.Counter("statestore/deleteticket", "tickets deleted")
-	mStateStoreIndexTicket            = monitoring.Counter("statestore/indexticket", "tickets indexed")
-	mStateStoreDeindexTicket          = monitoring.Counter("statestore/deindexticket", "tickets deindexed")
-	mStateStoreFilterTickets          = monitoring.Counter("statestore/filterticket", "tickets that were filtered and returned")
-	mStateStoreUpdateAssignments      = monitoring.Counter("statestore/updateassignment", "tickets assigned")
-	mStateStoreGetAssignments         = monitoring.Counter("statestore/getassignments", "ticket assigned retrieved")
-	mStateStoreAddTicketsToIgnoreList = monitoring.Counter("statestore/addticketstoignorelist", "tickets moved to ignore list")
+	mStateStoreCreateTicket           = telemetry.Counter("statestore/createticket", "tickets created")
+	mStateStoreGetTicket              = telemetry.Counter("statestore/getticket", "tickets retrieve")
+	mStateStoreDeleteTicket           = telemetry.Counter("statestore/deleteticket", "tickets deleted")
+	mStateStoreIndexTicket            = telemetry.Counter("statestore/indexticket", "tickets indexed")
+	mStateStoreDeindexTicket          = telemetry.Counter("statestore/deindexticket", "tickets deindexed")
+	mStateStoreFilterTickets          = telemetry.Counter("statestore/filterticket", "tickets that were filtered and returned")
+	mStateStoreUpdateAssignments      = telemetry.Counter("statestore/updateassignment", "tickets assigned")
+	mStateStoreGetAssignments         = telemetry.Counter("statestore/getassignments", "ticket assigned retrieved")
+	mStateStoreAddTicketsToIgnoreList = telemetry.Counter("statestore/addticketstoignorelist", "tickets moved to ignore list")
 )
 
 // instrumentedService is a wrapper for a statestore service that provides instrumentation (metrics and tracing) of the database.
@@ -51,31 +51,31 @@ func (is *instrumentedService) HealthCheck(ctx context.Context) error {
 
 // CreateTicket creates a new Ticket in the state storage. If the id already exists, it will be overwritten.
 func (is *instrumentedService) CreateTicket(ctx context.Context, ticket *pb.Ticket) error {
-	monitoring.IncrementCounter(ctx, mStateStoreCreateTicket)
+	telemetry.IncrementCounter(ctx, mStateStoreCreateTicket)
 	return is.s.CreateTicket(ctx, ticket)
 }
 
 // GetTicket gets the Ticket with the specified id from state storage. This method fails if the Ticket does not exist.
 func (is *instrumentedService) GetTicket(ctx context.Context, id string) (*pb.Ticket, error) {
-	monitoring.IncrementCounter(ctx, mStateStoreGetTicket)
+	telemetry.IncrementCounter(ctx, mStateStoreGetTicket)
 	return is.s.GetTicket(ctx, id)
 }
 
 // DeleteTicket removes the Ticket with the specified id from state storage.
 func (is *instrumentedService) DeleteTicket(ctx context.Context, id string) error {
-	monitoring.IncrementCounter(ctx, mStateStoreDeleteTicket)
+	telemetry.IncrementCounter(ctx, mStateStoreDeleteTicket)
 	return is.s.DeleteTicket(ctx, id)
 }
 
 // IndexTicket indexes the Ticket id for the configured index fields.
 func (is *instrumentedService) IndexTicket(ctx context.Context, ticket *pb.Ticket) error {
-	monitoring.IncrementCounter(ctx, mStateStoreIndexTicket)
+	telemetry.IncrementCounter(ctx, mStateStoreIndexTicket)
 	return is.s.IndexTicket(ctx, ticket)
 }
 
 // DeindexTicket removes the indexing for the specified Ticket. Only the indexes are removed but the Ticket continues to exist.
 func (is *instrumentedService) DeindexTicket(ctx context.Context, id string) error {
-	monitoring.IncrementCounter(ctx, mStateStoreDeindexTicket)
+	telemetry.IncrementCounter(ctx, mStateStoreDeindexTicket)
 	return is.s.DeindexTicket(ctx, id)
 }
 
@@ -87,7 +87,7 @@ func (is *instrumentedService) DeindexTicket(ctx context.Context, id string) err
 // }
 func (is *instrumentedService) FilterTickets(ctx context.Context, filters []*pb.Filter, pageSize int, callback func([]*pb.Ticket) error) error {
 	return is.s.FilterTickets(ctx, filters, pageSize, func(t []*pb.Ticket) error {
-		monitoring.IncrementCounterN(ctx, mStateStoreFilterTickets, len(t))
+		telemetry.IncrementCounterN(ctx, mStateStoreFilterTickets, len(t))
 		return callback(t)
 	})
 }
@@ -97,20 +97,20 @@ func (is *instrumentedService) FilterTickets(ctx context.Context, filters []*pb.
 // However, since Redis does not support transaction roll backs (see https://redis.io/topics/transactions), some of the
 // assignment fields might be partially updated if this function encounters an error halfway through the execution.
 func (is *instrumentedService) UpdateAssignments(ctx context.Context, ids []string, assignment *pb.Assignment) error {
-	monitoring.IncrementCounter(ctx, mStateStoreUpdateAssignments)
+	telemetry.IncrementCounter(ctx, mStateStoreUpdateAssignments)
 	return is.s.UpdateAssignments(ctx, ids, assignment)
 }
 
 // GetAssignments returns the assignment associated with the input ticket id
 func (is *instrumentedService) GetAssignments(ctx context.Context, id string, callback func(*pb.Assignment) error) error {
 	return is.s.GetAssignments(ctx, id, func(a *pb.Assignment) error {
-		monitoring.IncrementCounter(ctx, mStateStoreGetAssignments)
+		telemetry.IncrementCounter(ctx, mStateStoreGetAssignments)
 		return callback(a)
 	})
 }
 
 // AddProposedTickets appends new proposed tickets to the proposed sorted set with current timestamp
 func (is *instrumentedService) AddTicketsToIgnoreList(ctx context.Context, ids []string) error {
-	monitoring.IncrementCounterN(ctx, mStateStoreAddTicketsToIgnoreList, len(ids))
+	telemetry.IncrementCounterN(ctx, mStateStoreAddTicketsToIgnoreList, len(ids))
 	return is.s.AddTicketsToIgnoreList(ctx, ids)
 }

--- a/internal/statestore/public.go
+++ b/internal/statestore/public.go
@@ -18,7 +18,7 @@ import (
 	"context"
 
 	"open-match.dev/open-match/internal/config"
-	"open-match.dev/open-match/internal/monitoring"
+	"open-match.dev/open-match/internal/telemetry"
 	"open-match.dev/open-match/pkg/pb"
 )
 
@@ -61,7 +61,7 @@ type Service interface {
 // New creates a Service based on the configuration.
 func New(cfg config.View) Service {
 	s := newRedis(cfg)
-	if cfg.GetBool(monitoring.ConfigNameEnableMetrics) {
+	if cfg.GetBool(telemetry.ConfigNameEnableMetrics) {
 		return &instrumentedService{
 			s: s,
 		}

--- a/internal/statestore/redis_test.go
+++ b/internal/statestore/redis_test.go
@@ -28,7 +28,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"open-match.dev/open-match/internal/config"
-	"open-match.dev/open-match/internal/monitoring"
+	"open-match.dev/open-match/internal/telemetry"
 	internalTesting "open-match.dev/open-match/internal/testing"
 	"open-match.dev/open-match/pkg/pb"
 	"open-match.dev/open-match/pkg/structs"
@@ -367,7 +367,7 @@ func createRedis(t *testing.T) (config.View, func()) {
 	cfg.Set("backoff.multiplier", 0.5)
 	cfg.Set("backoff.maxInterval", 300*time.Millisecond)
 	cfg.Set("backoff.maxElapsedTime", 100*time.Millisecond)
-	cfg.Set(monitoring.ConfigNameEnableMetrics, true)
+	cfg.Set(telemetry.ConfigNameEnableMetrics, true)
 	cfg.Set("ticketIndices", []string{"testindex1", "testindex2"})
 
 	return cfg, func() { mredis.Close() }

--- a/internal/telemetry/jaeger.go
+++ b/internal/telemetry/jaeger.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package monitoring
+package telemetry
 
 import (
 	"contrib.go.opencensus.io/exporter/jaeger"
@@ -22,13 +22,13 @@ import (
 )
 
 func bindJaeger(cfg config.View) {
-	if !cfg.GetBool("monitoring.jaeger.enable") {
+	if !cfg.GetBool("telemetry.jaeger.enable") {
 		logger.Info("Jaeger Tracing: Disabled")
 		return
 	}
 
-	agentEndpointURI := cfg.GetString("monitoring.jaeger.agentEndpoint")
-	collectorEndpointURI := cfg.GetString("monitoring.jaeger.collectorEndpoint")
+	agentEndpointURI := cfg.GetString("telemetry.jaeger.agentEndpoint")
+	collectorEndpointURI := cfg.GetString("telemetry.jaeger.collectorEndpoint")
 
 	je, err := jaeger.NewExporter(jaeger.Options{
 		AgentEndpoint:     agentEndpointURI,

--- a/internal/telemetry/opencensus_agent.go
+++ b/internal/telemetry/opencensus_agent.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package monitoring
+package telemetry
 
 import (
 	"contrib.go.opencensus.io/exporter/ocagent"
@@ -23,12 +23,12 @@ import (
 )
 
 func bindOpenCensusAgent(cfg config.View) func() error {
-	if !cfg.GetBool("monitoring.opencensusAgent.enable") {
+	if !cfg.GetBool("telemetry.opencensusAgent.enable") {
 		logger.Info("OpenCensus Agent: Disabled")
 		return func() error { return nil }
 	}
 
-	agentEndpoint := cfg.GetString("monitoring.opencensusAgent.agentEndpoint")
+	agentEndpoint := cfg.GetString("telemetry.opencensusAgent.agentEndpoint")
 	oce, err := ocagent.NewExporter(ocagent.WithAddress(agentEndpoint), ocagent.WithInsecure(), ocagent.WithServiceName("open-match"))
 	if err != nil {
 		logger.WithError(err).Fatalf("Failed to create a new ocagent exporter")

--- a/internal/telemetry/probe.go
+++ b/internal/telemetry/probe.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package monitoring
+package telemetry
 
 import (
 	"context"

--- a/internal/telemetry/probe_test.go
+++ b/internal/telemetry/probe_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package monitoring
+package telemetry
 
 import (
 	"context"

--- a/internal/telemetry/prometheus.go
+++ b/internal/telemetry/prometheus.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package monitoring
+package telemetry
 
 // Taken from https://opencensus.io/quickstart/go/metrics/#1
 import (
@@ -26,17 +26,17 @@ import (
 )
 
 const (
-	// ConfigNameEnableMetrics indicates that monitoring is enabled.
-	ConfigNameEnableMetrics = "monitoring.prometheus.enable"
+	// ConfigNameEnableMetrics indicates that telemetry is enabled.
+	ConfigNameEnableMetrics = "telemetry.prometheus.enable"
 )
 
 func bindPrometheus(mux *http.ServeMux, cfg config.View) {
-	if !cfg.GetBool("monitoring.prometheus.enable") {
+	if !cfg.GetBool("telemetry.prometheus.enable") {
 		logger.Info("Prometheus Metrics: Disabled")
 		return
 	}
 
-	endpoint := cfg.GetString("monitoring.prometheus.endpoint")
+	endpoint := cfg.GetString("telemetry.prometheus.endpoint")
 	registry := prometheus.NewRegistry()
 	// Register standard prometheus instrumentation.
 	registry.MustRegister(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}))

--- a/internal/telemetry/public.go
+++ b/internal/telemetry/public.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package monitoring
+package telemetry
 
 import (
 	"context"
@@ -29,20 +29,20 @@ import (
 var (
 	logger = logrus.WithFields(logrus.Fields{
 		"app":       "openmatch",
-		"component": "monitoring",
+		"component": "telemetry",
 	})
 )
 
-// Setup configures the monitoring for the server.
+// Setup configures the telemetry for the server.
 func Setup(mux *http.ServeMux, cfg config.View) func() {
 	mc := util.NewMultiClose()
-	periodString := cfg.GetString("monitoring.reportingPeriod")
+	periodString := cfg.GetString("telemetry.reportingPeriod")
 	reportingPeriod, err := time.ParseDuration(periodString)
 	if err != nil {
 		logger.WithFields(logrus.Fields{
 			"error":           err,
 			"reportingPeriod": periodString,
-		}).Info("Failed to parse monitoring.reportingPeriod, defaulting to 10s")
+		}).Info("Failed to parse telemetry.reportingPeriod, defaulting to 10s")
 		reportingPeriod = time.Second * 10
 	}
 
@@ -58,7 +58,7 @@ func Setup(mux *http.ServeMux, cfg config.View) func() {
 
 	logger.WithFields(logrus.Fields{
 		"reportingPeriod": reportingPeriod,
-	}).Info("Monitoring has been configured.")
+	}).Info("Telemetry has been configured.")
 	return mc.Close
 }
 

--- a/internal/telemetry/public_test.go
+++ b/internal/telemetry/public_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package monitoring
+package telemetry
 
 import (
 	"context"
@@ -24,20 +24,20 @@ import (
 
 func TestIncrementCounter(t *testing.T) {
 	//assert := assert.New(t)
-	c := Counter("monitoring/fake_metric", "fake")
+	c := Counter("telemetry/fake_metric", "fake")
 	IncrementCounter(context.Background(), c)
 	IncrementCounter(context.Background(), c)
 }
 func TestDoubleMetric(t *testing.T) {
 	assert := assert.New(t)
-	c := Counter("monitoring/fake_metric", "fake")
-	c2 := Counter("monitoring/fake_metric", "fake")
+	c := Counter("telemetry/fake_metric", "fake")
+	c2 := Counter("telemetry/fake_metric", "fake")
 	assert.Equal(c, c2)
 }
 
 func TestDoubleRegisterView(t *testing.T) {
 	assert := assert.New(t)
-	mFakeCounter := stats.Int64("monitoring/fake_metric", "Fake", "1")
+	mFakeCounter := stats.Int64("telemetry/fake_metric", "Fake", "1")
 	v := counterView(mFakeCounter)
 	v2 := counterView(mFakeCounter)
 	assert.Equal(v, v2)

--- a/internal/telemetry/stackdriver.go
+++ b/internal/telemetry/stackdriver.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package monitoring
+package telemetry
 
 import (
 	"contrib.go.opencensus.io/exporter/stackdriver"
@@ -23,12 +23,12 @@ import (
 )
 
 func bindStackDriver(cfg config.View) func() {
-	if !cfg.GetBool("monitoring.stackdriver.enable") {
+	if !cfg.GetBool("telemetry.stackdriver.enable") {
 		logger.Info("StackDriver Metrics: Disabled")
 		return func() {}
 	}
-	gcpProjectID := cfg.GetString("monitoring.stackdriver.gcpProjectId")
-	metricPrefix := cfg.GetString("monitoring.stackdriver.metricPrefix")
+	gcpProjectID := cfg.GetString("telemetry.stackdriver.gcpProjectId")
+	metricPrefix := cfg.GetString("telemetry.stackdriver.metricPrefix")
 	sd, err := stackdriver.NewExporter(stackdriver.Options{
 		ProjectID: gcpProjectID,
 		// MetricPrefix helps uniquely identify your metrics.

--- a/internal/telemetry/zipkin.go
+++ b/internal/telemetry/zipkin.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package monitoring
+package telemetry
 
 //https://opencensus.io/quickstart/go/tracing/
 
@@ -27,12 +27,12 @@ import (
 )
 
 func bindZipkin(cfg config.View) {
-	if !cfg.GetBool("monitoring.zipkin.enable") {
+	if !cfg.GetBool("telemetry.zipkin.enable") {
 		logger.Info("Zipkin Tracing: Disabled")
 		return
 	}
-	zipkinEndpoint := cfg.GetString("monitoring.zipkin.endpoint")
-	zipkinReporterEndpoint := cfg.GetString("monitoring.zipkin.reporterEndpoint")
+	zipkinEndpoint := cfg.GetString("telemetry.zipkin.endpoint")
+	zipkinReporterEndpoint := cfg.GetString("telemetry.zipkin.reporterEndpoint")
 	// 1. Configure exporter to export traces to Zipkin.
 	localEndpoint, err := openzipkin.NewEndpoint("open_match", zipkinEndpoint)
 	if err != nil {

--- a/internal/telemetry/zpages.go
+++ b/internal/telemetry/zpages.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package monitoring
+package telemetry
 
 import (
 	"net/http"
@@ -23,7 +23,7 @@ import (
 )
 
 func bindZpages(mux *http.ServeMux, cfg config.View) {
-	if !cfg.GetBool("monitoring.zpages.enable") {
+	if !cfg.GetBool("telemetry.zpages.enable") {
 		logger.Info("zPages: Disabled")
 		return
 	}


### PR DESCRIPTION
Move monitoring/ to telemetry/ and update all the words. This change is to be consistent with OpenCensus vocabulary.