### PR TITLE
Open local TCP ports in tests to prevent firewall dialogs.

### DIFF
--- a/internal/util/netlistener/listener_holder.go
+++ b/internal/util/netlistener/listener_holder.go
@@ -70,7 +70,14 @@ func (lh *ListenerHolder) Close() error {
 
 // NewFromPortNumber opens a TCP listener based on the port number provided.
 func NewFromPortNumber(portNumber int) (*ListenerHolder, error) {
-	addr := fmt.Sprintf(":%d", portNumber)
+	addr := ""
+	// port 0 actually means random port which should only be used in tests.
+	if portNumber == 0 {
+		// Only accept connections from localhost in test mode.
+		addr = fmt.Sprintf("localhost:%d", portNumber)
+	} else {
+		addr = fmt.Sprintf(":%d", portNumber)
+	}
 	conn, err := net.Listen("tcp", addr)
 	if err != nil {
 		return nil, err
@@ -86,5 +93,4 @@ func NewFromPortNumber(portNumber int) (*ListenerHolder, error) {
 		listener: conn,
 		addr:     conn.Addr().String(),
 	}, nil
-
 }

--- a/tools/reaper/internal/internal_test.go
+++ b/tools/reaper/internal/internal_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestServeAndClose(t *testing.T) {
-	conn, err := net.Listen("tcp", ":0")
+	conn, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
 		t.Fatalf("cannot open TCP port, %s", err)
 	}


### PR DESCRIPTION
In unit tests, Open Match serves on random TCP ports that accept traffic anywhere. This causes a lot of firewall alerts to popup when running the unit tests. This change causes Open Match to serve on `localhost:$PORT` when running in unit test mode. (Really when a random port is used.)