### PR TITLE
Simplify HTTP client construction.

### DIFF
--- a/internal/rpc/testing/helpers.go
+++ b/internal/rpc/testing/helpers.go
@@ -143,10 +143,8 @@ func (tc *TestContext) MustHTTP() (*http.Client, string) {
 }
 
 func (tc *TestContext) newClientParams(address string) *rpc.ClientParams {
-	hostname, port := hostnameAndPort(tc.t, address)
 	return &rpc.ClientParams{
-		Hostname:           hostname,
-		Port:               port,
+		Address:            address,
 		TrustedCertificate: tc.trustedCertificate,
 		EnableRPCLogging:   true,
 		EnableMetrics:      false,

--- a/internal/testing/e2e/cluster.go
+++ b/internal/testing/e2e/cluster.go
@@ -19,6 +19,7 @@ package e2e
 import (
 	"context"
 	"flag"
+	"fmt"
 	"log"
 	"os"
 	"os/user"
@@ -127,8 +128,7 @@ func (com *clusterOM) getHTTPAddressFromServiceName(serviceName string) (string,
 func (com *clusterOM) getGRPCClientFromServiceName(serviceName string) (*grpc.ClientConn, error) {
 	ipAddress, port := com.getGRPCAddressFromServiceName(serviceName)
 	conn, err := rpc.GRPCClientFromParams(&rpc.ClientParams{
-		Hostname:         ipAddress,
-		Port:             int(port),
+		Address:          fmt.Sprintf("%s:%d", ipAddress, int(port)),
 		EnableRPCLogging: true,
 		EnableMetrics:    false,
 	})


### PR DESCRIPTION
Replace `Hostname` and `Port` from `ClientParams` with `Address` field to simplify and reduce the amount of transforms between each.