### PR TITLE
Cache dependency downloads by first adding only go module to Dockerfile

### DIFF
--- a/Dockerfile.base-build
+++ b/Dockerfile.base-build
@@ -16,5 +16,12 @@ FROM golang:latest
 ENV GO111MODULE=on
 
 WORKDIR /go/src/open-match.dev/open-match
-COPY . .
+
+# First copy only the go.sum and go.mod then download dependencies. Docker
+# caching is [in]validated by the input files changes.  So when the dependencies
+# for the project don't change, the previous image layer can be re-used.  go.sum
+# is included as its hashing verifies the expected files are downloaded.
+COPY go.sum go.mod ./
 RUN go mod download
+
+COPY . .


### PR DESCRIPTION
First copy only the go.sum and go.mod then download dependencies. Docker
caching is [in]validated by the input files changes.  So when the dependencies
for the project don't change, the previous image layer can be re-used.  go.sum
is included as its hashing verifies the expected files are downloaded.

I'm ignoring cases where the go.mod is missing a dep for now.  Later go commands will
fetch the missing deps, and they should make their way into go.mod sooner rather than later.
If it's a mess, it can be cleaned up later.

The time comparison of building all images from before and after is:
clean build: 7m22s -> 7m22s
after small change to demo: 5m59 -> 5m7s

So no speed increase for purely fresh builds (as expected), but saves a minute when deps haven't changed from the last build.

