### PR TITLE
Merge all docker RUN commands to improve caching of CI image.

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -14,42 +14,38 @@
 
 FROM debian
 
-RUN apt-get update
-RUN apt-get install -y -qq git make python3 virtualenv curl sudo unzip apt-transport-https ca-certificates curl software-properties-common gnupg2 bc
+ENV GOPATH=/go \
+  PATH=$GOPATH/bin:/usr/local/go/bin:$PATH \
+  OPEN_MATCH_CI_MODE=1 \
+  KUBECONFIG=$HOME/.kube/config
 
-# Docker
-RUN curl -fsSL https://download.docker.com/linux/debian/gpg | sudo apt-key add -
-RUN sudo apt-key fingerprint 0EBFCD88
-RUN  sudo add-apt-repository \
-   "deb [arch=amd64] https://download.docker.com/linux/debian \
-   stretch \
-   stable"
-RUN sudo apt-get update
-RUN sudo apt-get install -y -qq docker-ce docker-ce-cli containerd.io
-
-# Cloud SDK
-RUN export CLOUD_SDK_REPO="cloud-sdk-stretch" && \
-    echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
-    apt-get update -y && apt-get install google-cloud-sdk google-cloud-sdk-app-engine-go -y -qq
-
-# Install Golang
-# https://github.com/docker-library/golang/blob/fd272b2b72db82a0bd516ce3d09bba624651516c/1.12/stretch/Dockerfile
-RUN mkdir -p /toolchain/golang
-WORKDIR /toolchain/golang
-RUN sudo rm -rf /usr/local/go/
-RUN curl -L https://storage.googleapis.com/golang/go1.12.6.linux-amd64.tar.gz | sudo tar -C /usr/local -xz
-
-ENV GOPATH /go
-ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
-
-RUN sudo mkdir -p "$GOPATH/src" "$GOPATH/bin" \
-  && sudo chmod -R 777 "$GOPATH"
-
-# Prepare toolchain and workspace
-RUN mkdir -p /toolchain
+RUN apt-get update \
+  && apt-get install -y -qq git make python3 virtualenv curl sudo unzip \
+      apt-transport-https ca-certificates curl software-properties-common \
+      gnupg2 bc \
+  # Docker
+  && curl -fsSL https://download.docker.com/linux/debian/gpg | sudo apt-key add - \
+  && sudo apt-key fingerprint 0EBFCD88 \
+  && sudo add-apt-repository \
+      "deb [arch=amd64] https://download.docker.com/linux/debian \
+      stretch \
+      stable" \
+  && sudo apt-get update \
+  && sudo apt-get install -y -qq docker-ce docker-ce-cli containerd.io \
+  # Cloud SDK
+  && export CLOUD_SDK_REPO="cloud-sdk-stretch" \
+  && echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
+  && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - \
+  && apt-get update -y \
+  && apt-get install google-cloud-sdk google-cloud-sdk-app-engine-go -y -qq \
+  # Install Golang 
+  # https://github.com/docker-library/golang/blob/fd272b2b72db82a0bd516ce3d09bba624651516c/1.12/stretch/Dockerfile
+  && mkdir -p /toolchain/golang \
+  && sudo rm -rf /usr/local/go/ \
+  && curl -L https://storage.googleapis.com/golang/go1.12.7.linux-amd64.tar.gz | sudo tar -C /usr/local -xz \
+  && mkdir -p $HOME/.kube/ \
+  && sudo mkdir -p "/go/src" "$GOPATH/bin" \
+  && sudo chmod -R 777 "$GOPATH" \
+  && mkdir -p /toolchain
 
 WORKDIR /workspace
-ENV OPEN_MATCH_CI_MODE=1
-ENV KUBECONFIG=$HOME/.kube/config
-RUN mkdir -p $HOME/.kube/


### PR DESCRIPTION
This is an attempt to improve the Kaniko cache step by having having fewer layers in hopes it reduces the number of round trips to verify that the cache is still good.