### PR TITLE
Remove cloudbuild artifacts

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -168,12 +168,6 @@ artifacts:
     objects:
         location: gs://open-match-build-artifacts/output/
         paths:
-            - cmd/backend/backend
-            - cmd/frontend/frontend
-            - cmd/mmlogic/mmlogic
-            - cmd/synchronizer/synchronizer
-            - cmd/minimatch/minimatch
-            - cmd/swaggerui/swaggerui
             - install/yaml/install.yaml
             - install/yaml/install-demo.yaml
             - install/yaml/01-redis-chart.yaml
@@ -181,11 +175,6 @@ artifacts:
             - install/yaml/03-prometheus-chart.yaml
             - install/yaml/04-grafana-chart.yaml
             - install/yaml/05-jaeger-chart.yaml
-            - examples/functions/golang/soloduel/soloduel
-            - examples/functions/golang/pool/pool
-            - examples/evaluator/golang/simple/simple
-            - tools/certgen/certgen
-            - tools/reaper/reaper
 
 images:
 - 'gcr.io/$PROJECT_ID/openmatch-backend:${_OM_VERSION}-${SHORT_SHA}'


### PR DESCRIPTION
The binaries generated in cloudbuild can only be used under kubernetes environment as they requires reading `match_maker.yaml` config from `/app/config` directory - which get created by volume mount. Therefore, uploading these artifacts to our gcs bucket only makes our CI slower. This commit removes the step for storing the binary artifacts to speed up our CI.