### PR TITLE
Let config.Read() reads from two files

### DIFF
--- a/examples/demo/main.go
+++ b/examples/demo/main.go
@@ -19,9 +19,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
+
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/websocket"
-	"net/http"
 	"open-match.dev/open-match/examples/demo/bytesub"
 	"open-match.dev/open-match/examples/demo/components"
 	"open-match.dev/open-match/examples/demo/components/clients"
@@ -41,12 +42,8 @@ var (
 )
 
 func main() {
-	cfg, err := config.Read()
-	if err != nil {
-		logger.WithFields(logrus.Fields{
-			"error": err.Error(),
-		}).Fatalf("cannot read configuration.")
-	}
+	cfg := config.Read()
+
 	logging.ConfigureLogging(cfg)
 
 	logger.Info("Initializing Server")
@@ -83,7 +80,7 @@ func main() {
 	go startComponents(cfg, u)
 
 	address := fmt.Sprintf(":%d", cfg.GetInt("api.demo.httpport"))
-	err = http.ListenAndServe(address, nil)
+	err := http.ListenAndServe(address, nil)
 	logger.WithError(err).Warning("HTTP server closed.")
 }
 

--- a/internal/app/backend/backend.go
+++ b/internal/app/backend/backend.go
@@ -25,12 +25,8 @@ import (
 
 // RunApplication creates a server.
 func RunApplication() {
-	cfg, err := config.Read()
-	if err != nil {
-		logger.WithFields(logrus.Fields{
-			"error": err.Error(),
-		}).Fatalf("cannot read configuration.")
-	}
+	cfg := config.Read()
+
 	p, err := rpc.NewServerParamsFromConfig(cfg, "api.backend")
 	if err != nil {
 		logger.WithFields(logrus.Fields{

--- a/internal/app/frontend/frontend.go
+++ b/internal/app/frontend/frontend.go
@@ -25,12 +25,8 @@ import (
 
 // RunApplication creates a server.
 func RunApplication() {
-	cfg, err := config.Read()
-	if err != nil {
-		logger.WithFields(logrus.Fields{
-			"error": err.Error(),
-		}).Fatalf("cannot read configuration.")
-	}
+	cfg := config.Read()
+
 	p, err := rpc.NewServerParamsFromConfig(cfg, "api.frontend")
 	if err != nil {
 		logger.WithFields(logrus.Fields{

--- a/internal/app/minimatch/minimatch.go
+++ b/internal/app/minimatch/minimatch.go
@@ -33,12 +33,8 @@ var (
 
 // RunApplication creates a server.
 func RunApplication() {
-	cfg, err := config.Read()
-	if err != nil {
-		logger.WithFields(logrus.Fields{
-			"error": err.Error(),
-		}).Fatalf("cannot read configuration.")
-	}
+	cfg := config.Read()
+
 	p, err := rpc.NewServerParamsFromConfig(cfg, "api.frontend")
 	if err != nil {
 		logger.WithFields(logrus.Fields{

--- a/internal/app/mmlogic/mmlogic.go
+++ b/internal/app/mmlogic/mmlogic.go
@@ -25,12 +25,8 @@ import (
 
 // RunApplication creates a server.
 func RunApplication() {
-	cfg, err := config.Read()
-	if err != nil {
-		logger.WithFields(logrus.Fields{
-			"error": err.Error(),
-		}).Fatalf("cannot read configuration.")
-	}
+	cfg := config.Read()
+
 	p, err := rpc.NewServerParamsFromConfig(cfg, "api.mmlogic")
 	if err != nil {
 		logger.WithFields(logrus.Fields{

--- a/internal/app/swaggerui/swaggerui.go
+++ b/internal/app/swaggerui/swaggerui.go
@@ -39,14 +39,7 @@ var (
 
 // RunApplication is the main for swagger ui http reverse proxy.
 func RunApplication() {
-	cfg, err := config.Read()
-	if err != nil {
-		logger.WithFields(logrus.Fields{
-			"error": err.Error(),
-		}).Fatalf("cannot read configuration.")
-	}
-
-	serve(cfg)
+	serve(config.Read())
 }
 
 func serve(cfg config.View) {

--- a/internal/app/synchronizer/synchronizer.go
+++ b/internal/app/synchronizer/synchronizer.go
@@ -25,12 +25,7 @@ import (
 
 // RunApplication creates a server.
 func RunApplication() {
-	cfg, err := config.Read()
-	if err != nil {
-		logger.WithFields(logrus.Fields{
-			"error": err.Error(),
-		}).Fatalf("cannot read configuration.")
-	}
+	cfg := config.Read()
 
 	p, err := rpc.NewServerParamsFromConfig(cfg, "api.synchronizer")
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -76,16 +76,17 @@ func Read() View {
 	cfg.AddConfigPath("config")
 
 	// Read in config file using Viper
+	// Worth to panic if cannot read the config on startup.
 	cfg.SetConfigName("global_config")
 	err := cfg.ReadInConfig()
 	if err != nil {
-		logger.WithError(err).Fatal("failed to read from global_config file")
+		panic(err)
 	}
 
 	cfg.SetConfigName("matchmaker_config")
 	err = cfg.MergeInConfig()
 	if err != nil {
-		logger.WithError(err).Fatal("failed to read from matchmaker_config file")
+		panic(err)
 	}
 
 	// Bind this envvars to viper config vars.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -68,21 +68,24 @@ var (
 
 // Read reads a config file into a viper.Viper instance and associates environment vars defined in
 // config.envMappings
-func Read() (View, error) {
+func Read() View {
 	cfg := viper.New()
 	// Viper config management initialization
-	// Support either json or yaml file types (json for backwards compatibility
-	// with previous versions)
-	cfg.SetConfigType("json")
 	cfg.SetConfigType("yaml")
-	cfg.SetConfigName("matchmaker_config")
 	cfg.AddConfigPath(".")
 	cfg.AddConfigPath("config")
 
 	// Read in config file using Viper
+	cfg.SetConfigName("global_config")
 	err := cfg.ReadInConfig()
 	if err != nil {
-		logger.WithError(err).Fatal("Fatal error reading config file")
+		logger.WithError(err).Fatal("failed to read from global_config file")
+	}
+
+	cfg.SetConfigName("matchmaker_config")
+	err = cfg.MergeInConfig()
+	if err != nil {
+		logger.WithError(err).Fatal("failed to read from matchmaker_config file")
 	}
 
 	// Bind this envvars to viper config vars.
@@ -122,5 +125,5 @@ func Read() (View, error) {
 			"operation": event.Op,
 		}).Info("Server configuration changed.")
 	})
-	return cfg, err
+	return cfg
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -30,13 +30,17 @@ func TestReadConfigIgnoreRace(t *testing.T) {
 	}
 	defer os.Remove("matchmaker_config.yaml")
 
-	cfg, err := Read()
-	if err != nil {
-		t.Fatalf("cannot load config, %s", err)
+	if err := ioutil.WriteFile("global_config.yaml", []byte(`metrics.path: om-config`), 0666); err != nil {
+		t.Fatalf("could not create config file: %s", err)
 	}
+	defer os.Remove("global_config.yaml")
 
+	cfg := Read()
 	if cfg.GetString("metrics.endpoint") != "/metrics" {
-		t.Errorf("av.GetString('metrics.endpoint') = %s, expected '/metrics'", cfg.GetString("metrics.endpoint"))
+		t.Errorf("cfg.GetString('metrics.endpoint') = %s, expected '/metrics'", cfg.GetString("metrics.endpoint"))
+	}
+	if cfg.GetString("metrics.path") != "om-config" {
+		t.Errorf("cfg.GetString('metrics.path') = %s, expected 'om-config'", cfg.GetString("metrics.path"))
 	}
 
 	yaml = []byte(`metrics.endpoint: ''`)

--- a/pkg/harness/evaluator/golang/harness.go
+++ b/pkg/harness/evaluator/golang/harness.go
@@ -26,12 +26,7 @@ import (
 
 // RunEvaluator is a hook for the main() method in the main executable.
 func RunEvaluator(eval Evaluator) {
-	cfg, err := config.Read()
-	if err != nil {
-		logger.WithFields(logrus.Fields{
-			"error": err.Error(),
-		}).Fatalf("cannot read configuration.")
-	}
+	cfg := config.Read()
 
 	p, err := rpc.NewServerParamsFromConfig(cfg, "api.evaluator")
 	if err != nil {

--- a/pkg/harness/function/golang/harness.go
+++ b/pkg/harness/function/golang/harness.go
@@ -31,12 +31,8 @@ type FunctionSettings struct {
 
 // RunMatchFunction is a hook for the main() method in the main executable.
 func RunMatchFunction(settings *FunctionSettings) {
-	cfg, err := config.Read()
-	if err != nil {
-		logger.WithFields(logrus.Fields{
-			"error": err.Error(),
-		}).Fatalf("cannot read configuration.")
-	}
+	cfg := config.Read()
+
 	p, err := rpc.NewServerParamsFromConfig(cfg, "api.functions")
 	if err != nil {
 		logger.WithFields(logrus.Fields{


### PR DESCRIPTION
This commit does two things:
1. config.Read() already provides verbose error logs and is used once per service so I cleaned up the logging from service level to reduce the log spam.
2. Let config.Read() reads from `matchmaker_config.yaml` and `global_config.yaml` such that we are able to throw monitoring and tls configs into `global_config.yaml` and keep `matchmaker_config.yaml` clean