### PR TITLE
Disable Jaeger in the Deployment, it'll be enabled in 0.7.0. (#672)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -349,7 +349,7 @@ install-large-chart: build/toolchain/bin/helm$(EXE_EXTENSION) install/helm/open-
 		--set openmatch.image.registry=$(REGISTRY) \
 		--set openmatch.image.tag=$(TAG) \
 		--set grafana.enabled=true \
-		--set jaeger.enabled=true \
+		--set jaeger.enabled=false \
 		--set prometheus.enabled=true \
 		--set redis.enabled=true \
 		--set openmatch.telemetry.stackdriver.enabled=true \
@@ -501,7 +501,7 @@ install/yaml/install.yaml: build/toolchain/bin/helm$(EXE_EXTENSION)
 		--set redis.enabled=true \
 		--set prometheus.enabled=true \
 		--set grafana.enabled=true \
-		--set jaeger.enabled=true \
+		--set jaeger.enabled=false \
 		install/helm/open-match > install/yaml/install.yaml
 
 install/yaml/install-demo.yaml: build/toolchain/bin/helm$(EXE_EXTENSION)

--- a/install/helm/open-match/values.yaml
+++ b/install/helm/open-match/values.yaml
@@ -15,7 +15,7 @@
 openmatch:
   telemetry:
     jaeger:
-      enabled: true
+      enabled: false
       agentEndpoint: "open-match-jaeger-agent:6831"
       collectorEndpoint: "http://open-match-jaeger-collector:14268/api/traces"
     prometheus:


### PR DESCRIPTION
We don't officially support tracing yet so disable Jaeger for now in the deployment configs.