### PR TITLE
Add build/cmd to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -797,6 +797,10 @@ CMDS_BUILD_FOLDERS = $(foreach CMD,$(CMDS),build/cmd/$(CMD))
 
 build/cmd: $(CMDS_BUILD_FOLDERS)
 
+# Building a given build/cmd folder is split into two pieces: BUILD_PHONY and
+# COPY_PHONY.  The BUILD_PHONY is the common go build command, which is
+# reusable.  The COPY_PHONY is used by some targets which require additional
+# files to be included in the image.
 $(CMDS_BUILD_FOLDERS): build/cmd/%: build/cmd/%/BUILD_PHONY build/cmd/%/COPY_PHONY
 
 build/cmd/%/BUILD_PHONY: all-protos


### PR DESCRIPTION
This is part of the larger goal of simplifying and speeding up builds.

General strategy here:
1. Add make build/cmd target, to build what is currently in /cmd. <- this PR
2. In the basebuild Dockerfile, run make build/cmd, and replace the seperate Dockerfiles for the services in cmd/ with one Dockerfile (with an arg for which service) which copies from build/cmd/<servicename>/ to the Dockerfile and runs it.
3. Reconcile the Docker images not included in the /cmd to follow this pattern as well (in individual PRs.)
4. Clean up redundant ways to build things.
5. (If it improves speed) add local build variation for faster builds.