### PR TITLE
Replace context.Background() in tests to prepare for multi-tenancy.

### DIFF
--- a/internal/app/backend/backend_service_test.go
+++ b/internal/app/backend/backend_service_test.go
@@ -27,6 +27,7 @@ import (
 	"open-match.dev/open-match/internal/rpc"
 	"open-match.dev/open-match/internal/statestore"
 	statestoreTesting "open-match.dev/open-match/internal/statestore/testing"
+	utilTesting "open-match.dev/open-match/internal/util/testing"
 	"open-match.dev/open-match/pkg/pb"
 	"open-match.dev/open-match/pkg/structs"
 	certgenTesting "open-match.dev/open-match/tools/certgen/testing"
@@ -93,9 +94,10 @@ func TestDoFetchMatchesInChannel(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
+			ctx := utilTesting.NewContext(t)
 			cc := rpc.NewClientCache(test.cfg)
 			resultChan := make(chan mmfResult, len(test.req.GetProfiles()))
-			err := doFetchMatchesReceiveMmfResult(context.Background(), cc, test.req, resultChan)
+			err := doFetchMatchesReceiveMmfResult(ctx, cc, test.req, resultChan)
 			assert.Equal(t, test.wantErr, err)
 		})
 	}
@@ -150,8 +152,9 @@ func TestDoFetchMatchesFilterChannel(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
+			ctx := utilTesting.NewContext(t)
 			resultChan := make(chan mmfResult, 2)
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx, cancel := context.WithCancel(ctx)
 			defer cancel()
 
 			test.preAction(resultChan, cancel)
@@ -251,7 +254,7 @@ func TestDoAssignTickets(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx, cancel := context.WithCancel(utilTesting.NewContext(t))
 			cfg := viper.New()
 			cfg.Set("ticketIndices", []string{fakeProperty})
 			store, closer := statestoreTesting.NewStoreServiceForTesting(t, cfg)

--- a/internal/app/synchronizer/synchronizer_service_test.go
+++ b/internal/app/synchronizer/synchronizer_service_test.go
@@ -15,7 +15,6 @@
 package synchronizer
 
 import (
-	"context"
 	"sync"
 	"testing"
 	"time"
@@ -27,6 +26,7 @@ import (
 	"google.golang.org/grpc/status"
 	ipb "open-match.dev/open-match/internal/pb"
 	statestoreTesting "open-match.dev/open-match/internal/statestore/testing"
+	utilTesting "open-match.dev/open-match/internal/util/testing"
 	"open-match.dev/open-match/pkg/pb"
 )
 
@@ -237,7 +237,7 @@ func runEvaluationTest(t *testing.T, tc *testData) {
 	for _, c := range tc.testCalls {
 		c := c
 		go func(c *testCallData) {
-			ctx := context.Background()
+			ctx := utilTesting.NewContext(t)
 			defer w.Done()
 			time.Sleep(time.Duration(c.registerDelay) * time.Millisecond)
 			rResp, err := s.Register(ctx, &ipb.RegisterRequest{})

--- a/internal/rpc/clients_test.go
+++ b/internal/rpc/clients_test.go
@@ -15,7 +15,6 @@
 package rpc
 
 import (
-	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -30,6 +29,7 @@ import (
 	"open-match.dev/open-match/internal/telemetry"
 	shellTesting "open-match.dev/open-match/internal/testing"
 	netlistenerTesting "open-match.dev/open-match/internal/util/netlistener/testing"
+	utilTesting "open-match.dev/open-match/internal/util/testing"
 	"open-match.dev/open-match/pkg/pb"
 	certgenTesting "open-match.dev/open-match/tools/certgen/testing"
 )
@@ -40,7 +40,7 @@ func TestSecureGRPCFromConfig(t *testing.T) {
 	cfg, rpcParams, closer := configureConfigAndKeysForTesting(assert, true)
 	defer closer()
 
-	runGrpcClientTests(assert, cfg, rpcParams)
+	runGrpcClientTests(t, assert, cfg, rpcParams)
 }
 
 func TestInsecureGRPCFromConfig(t *testing.T) {
@@ -49,7 +49,7 @@ func TestInsecureGRPCFromConfig(t *testing.T) {
 	cfg, rpcParams, closer := configureConfigAndKeysForTesting(assert, false)
 	defer closer()
 
-	runGrpcClientTests(assert, cfg, rpcParams)
+	runGrpcClientTests(t, assert, cfg, rpcParams)
 }
 
 func TestHTTPSFromConfig(t *testing.T) {
@@ -97,7 +97,7 @@ func TestSanitizeHTTPAddress(t *testing.T) {
 	}
 }
 
-func runGrpcClientTests(assert *assert.Assertions, cfg config.View, rpcParams *ServerParams) {
+func runGrpcClientTests(t *testing.T, assert *assert.Assertions, cfg config.View, rpcParams *ServerParams) {
 	// Serve a fake frontend server and wait for its full start up
 	ff := &shellTesting.FakeFrontend{}
 	rpcParams.AddHandleFunc(func(s *grpc.Server) {
@@ -116,7 +116,7 @@ func runGrpcClientTests(assert *assert.Assertions, cfg config.View, rpcParams *S
 	assert.NotNil(grpcConn)
 
 	// Confirm the client works as expected
-	ctx := context.Background()
+	ctx := utilTesting.NewContext(t)
 	feClient := pb.NewFrontendClient(grpcConn)
 	grpcResp, err := feClient.CreateTicket(ctx, &pb.CreateTicketRequest{})
 	assert.Nil(err)

--- a/internal/rpc/insecure_test.go
+++ b/internal/rpc/insecure_test.go
@@ -52,5 +52,5 @@ func TestInsecureStartStop(t *testing.T) {
 	httpClient := &http.Client{
 		Timeout: time.Second,
 	}
-	runGrpcWithProxyTests(assert, s, conn, httpClient, endpoint)
+	runGrpcWithProxyTests(t, assert, s, conn, httpClient, endpoint)
 }

--- a/internal/rpc/server_test.go
+++ b/internal/rpc/server_test.go
@@ -15,7 +15,6 @@
 package rpc
 
 import (
-	"context"
 	"fmt"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
@@ -24,6 +23,7 @@ import (
 	"open-match.dev/open-match/internal/telemetry"
 	shellTesting "open-match.dev/open-match/internal/testing"
 	netlistenerTesting "open-match.dev/open-match/internal/util/netlistener/testing"
+	utilTesting "open-match.dev/open-match/internal/util/testing"
 	"open-match.dev/open-match/pkg/pb"
 	"strings"
 	"testing"
@@ -55,7 +55,7 @@ func TestStartStopServer(t *testing.T) {
 		Timeout: time.Second,
 	}
 
-	runGrpcWithProxyTests(assert, s.serverWithProxy, conn, httpClient, endpoint)
+	runGrpcWithProxyTests(t, assert, s.serverWithProxy, conn, httpClient, endpoint)
 }
 
 func TestMustServeForever(t *testing.T) {
@@ -81,8 +81,8 @@ func TestMustServeForever(t *testing.T) {
 	// This test will intentionally deadlock if the stop function is not respected.
 }
 
-func runGrpcWithProxyTests(assert *assert.Assertions, s grpcServerWithProxy, conn *grpc.ClientConn, httpClient *http.Client, endpoint string) {
-	ctx := context.Background()
+func runGrpcWithProxyTests(t *testing.T, assert *assert.Assertions, s grpcServerWithProxy, conn *grpc.ClientConn, httpClient *http.Client, endpoint string) {
+	ctx := utilTesting.NewContext(t)
 	feClient := pb.NewFrontendClient(conn)
 	grpcResp, err := feClient.CreateTicket(ctx, &pb.CreateTicketRequest{})
 	assert.Nil(err)

--- a/internal/rpc/tls_server_test.go
+++ b/internal/rpc/tls_server_test.go
@@ -129,5 +129,5 @@ func runTestStartStopTLSServer(t *testing.T, tp *tlsServerTestParams) {
 		Timeout:   time.Second * 10,
 		Transport: tlsTransport,
 	}
-	runGrpcWithProxyTests(assert, s, conn, httpClient, httpsEndpoint)
+	runGrpcWithProxyTests(t, assert, s, conn, httpClient, httpsEndpoint)
 }

--- a/internal/telemetry/metrics_test.go
+++ b/internal/telemetry/metrics_test.go
@@ -15,17 +15,18 @@
 package telemetry
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"go.opencensus.io/stats"
+	utilTesting "open-match.dev/open-match/internal/util/testing"
 )
 
 func TestIncrementCounter(t *testing.T) {
+	ctx := utilTesting.NewContext(t)
 	c := Counter("telemetry/fake_metric", "fake")
-	IncrementCounter(context.Background(), c)
-	IncrementCounter(context.Background(), c)
+	IncrementCounter(ctx, c)
+	IncrementCounter(ctx, c)
 }
 
 func TestDoubleMetric(t *testing.T) {

--- a/internal/util/testing/context.go
+++ b/internal/util/testing/context.go
@@ -12,31 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package testing provides utility methods for testing.
 package testing
 
 import (
+	"context"
 	"testing"
-
-	"github.com/spf13/viper"
-	"github.com/stretchr/testify/assert"
-	"open-match.dev/open-match/internal/statestore"
-	utilTesting "open-match.dev/open-match/internal/util/testing"
-	"open-match.dev/open-match/pkg/pb"
 )
 
-func TestFakeStatestore(t *testing.T) {
-	assert := assert.New(t)
-	cfg := viper.New()
-	closer := New(t, cfg)
-	defer closer()
-	s := statestore.New(cfg)
-	ctx := utilTesting.NewContext(t)
+type contextTestKey string
 
-	ticket := &pb.Ticket{
-		Id: "abc",
-	}
-	assert.Nil(s.CreateTicket(ctx, ticket))
-	retrievedTicket, err := s.GetTicket(ctx, "abc")
-	assert.Nil(err)
-	assert.Equal(ticket.Id, retrievedTicket.Id)
+// NewContext returns a context appropriate for calling a gRPC service that
+// is not hosted on a cluster or in Minimatch, (ie: tests not in test/e2e/).
+// For those tests use OM.Context() method.
+func NewContext(t *testing.T) context.Context {
+	return context.WithValue(context.Background(), contextTestKey("testing.T"), t)
 }

--- a/test/e2e/match_test.go
+++ b/test/e2e/match_test.go
@@ -17,11 +17,12 @@
 package e2e
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"open-match.dev/open-match/internal/testing/e2e"
-	"testing"
 
 	"open-match.dev/open-match/pkg/pb"
 )
@@ -71,8 +72,9 @@ func TestFetchMatches(t *testing.T) {
 			test := test
 			t.Run(test.description, func(t *testing.T) {
 				t.Parallel()
+				ctx := om.Context()
 
-				resp, err := be.FetchMatches(om.Context(), &pb.FetchMatchesRequest{Config: test.fc, Profiles: test.profile})
+				resp, err := be.FetchMatches(ctx, &pb.FetchMatchesRequest{Config: test.fc, Profiles: test.profile})
 				assert.Equal(t, test.wantCode, status.Convert(err).Code())
 
 				if err == nil {

--- a/test/e2e/minimatch_test.go
+++ b/test/e2e/minimatch_test.go
@@ -17,6 +17,7 @@
 package e2e
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"math"
@@ -128,11 +129,12 @@ func TestMinimatch(t *testing.T) {
 
 				fe := om.MustFrontendGRPC()
 				mml := om.MustMmLogicGRPC()
+				ctx := om.Context()
 
 				// Create all the tickets and validate ticket creation succeeds. Also populate ticket ids
 				// to expected player pools.
 				for i, td := range testTickets {
-					resp, err := fe.CreateTicket(om.Context(), &pb.CreateTicketRequest{Ticket: &pb.Ticket{
+					resp, err := fe.CreateTicket(ctx, &pb.CreateTicketRequest{Ticket: &pb.Ticket{
 						Properties: structs.Struct{
 							e2e.SkillAttribute: structs.Number(td.skill),
 							td.mapValue:        structs.Number(float64(time.Now().Unix())),
@@ -149,7 +151,7 @@ func TestMinimatch(t *testing.T) {
 
 				// Query tickets for each pool
 				for _, pool := range testPools {
-					qtstr, err := mml.QueryTickets(om.Context(), &pb.QueryTicketsRequest{Pool: pool})
+					qtstr, err := mml.QueryTickets(ctx, &pb.QueryTicketsRequest{Pool: pool})
 					assert.Nil(t, err)
 					assert.NotNil(t, qtstr)
 
@@ -182,17 +184,17 @@ func TestMinimatch(t *testing.T) {
 					assert.Equal(t, poolTickets[pool.Name], want)
 				}
 
-				testFetchMatches(t, poolTickets, testProfiles, om, fc)
+				testFetchMatches(ctx, t, poolTickets, testProfiles, om, fc)
 			})
 		}
 	})
 }
 
-func testFetchMatches(t *testing.T, poolTickets map[string][]string, testProfiles []testProfile, om e2e.OM, fc *pb.FunctionConfig) {
+func testFetchMatches(ctx context.Context, t *testing.T, poolTickets map[string][]string, testProfiles []testProfile, om e2e.OM, fc *pb.FunctionConfig) {
 	// Fetch Matches for each test profile.
 	be := om.MustBackendGRPC()
 	for _, profile := range testProfiles {
-		br, err := be.FetchMatches(om.Context(), &pb.FetchMatchesRequest{
+		br, err := be.FetchMatches(ctx, &pb.FetchMatchesRequest{
 			Config:   fc,
 			Profiles: []*pb.MatchProfile{{Name: profile.name, Pools: profile.pools}},
 		})


### PR DESCRIPTION
Calls to Open Match may have HTTP headers or gRPC metadata now and for that to work each test will produce randomized headers to confirm that calls are made appropriately.