### PR TITLE
Add HTTP client logging support and flags for test.

### DIFF
--- a/internal/rpc/server.go
+++ b/internal/rpc/server.go
@@ -131,7 +131,7 @@ func NewServerParamsFromConfig(cfg config.View, prefix string) (*ServerParams, e
 	}
 
 	p.enableMetrics = cfg.GetBool(telemetry.ConfigNameEnableMetrics)
-	p.enableRPCLogging = cfg.GetBool(configNameEnableRPCLogging)
+	p.enableRPCLogging = cfg.GetBool(ConfigNameEnableRPCLogging)
 	// TODO: This isn't ideal since telemetry requires config for it to be initialized.
 	// This forces us to initialize readiness probes earlier than necessary.
 	p.closer = telemetry.Setup(p.ServeMux, cfg)

--- a/internal/testing/e2e/cluster.go
+++ b/internal/testing/e2e/cluster.go
@@ -129,8 +129,8 @@ func (com *clusterOM) getGRPCClientFromServiceName(serviceName string) (*grpc.Cl
 	ipAddress, port := com.getGRPCAddressFromServiceName(serviceName)
 	conn, err := rpc.GRPCClientFromParams(&rpc.ClientParams{
 		Address:          fmt.Sprintf("%s:%d", ipAddress, int(port)),
-		EnableRPCLogging: true,
-		EnableMetrics:    false,
+		EnableRPCLogging: *testOnlyEnableRPCLoggingFlag,
+		EnableMetrics:    *testOnlyEnableMetrics,
 	})
 	if err != nil {
 		return nil, errors.Wrapf(err, "cannot connect to gRPC %s:%d", ipAddress, port)

--- a/internal/testing/e2e/common.go
+++ b/internal/testing/e2e/common.go
@@ -16,11 +16,17 @@ package e2e
 
 import (
 	"context"
+	"flag"
 	"log"
 	"os"
 	"testing"
 
 	pb "open-match.dev/open-match/pkg/pb"
+)
+
+var (
+	testOnlyEnableMetrics        = flag.Bool("test_only_metrics", true, "Enables metrics exporting for tests.")
+	testOnlyEnableRPCLoggingFlag = flag.Bool("test_only_rpc_logging", false, "Enables RPC Logging for tests. This output is very verbose.")
 )
 
 // OM is the interface for communicating with Open Match.

--- a/internal/testing/e2e/in_memory.go
+++ b/internal/testing/e2e/in_memory.go
@@ -27,6 +27,7 @@ import (
 	"open-match.dev/open-match/internal/rpc"
 	rpcTesting "open-match.dev/open-match/internal/rpc/testing"
 	statestoreTesting "open-match.dev/open-match/internal/statestore/testing"
+	"open-match.dev/open-match/internal/telemetry"
 	"open-match.dev/open-match/internal/util"
 	evalHarness "open-match.dev/open-match/pkg/harness/evaluator/golang"
 	mmfHarness "open-match.dev/open-match/pkg/harness/function/golang"
@@ -142,6 +143,8 @@ func createMinimatchForTest(t *testing.T, evalTc *rpcTesting.TestContext) *rpcTe
 	cfg.Set("api.evaluator.grpcport", evalTc.GetGRPCPort())
 	cfg.Set("api.evaluator.httpport", evalTc.GetHTTPPort())
 	cfg.Set("synchronizer.enabled", true)
+	cfg.Set(rpc.ConfigNameEnableRPCLogging, *testOnlyEnableRPCLoggingFlag)
+	cfg.Set(telemetry.ConfigNameEnableMetrics, *testOnlyEnableMetrics)
 
 	// TODO: This is very ugly. Need a better story around closing resources.
 	tc.AddCloseFunc(closer)


### PR DESCRIPTION
```yaml
logging:
  rpc: true
```
will now enable HTTP client logging.

Also there's now `--test_only_rpc_logging=true` and `--test_only_metrics=true` for running tests with these options enabled.