### PR TITLE
Remove unnecessary dependencies to speed up CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -322,7 +322,6 @@ print-chart: build/toolchain/bin/helm$(EXE_EXTENSION)
 
 build/chart/open-match-$(BASE_VERSION).tgz: build/toolchain/bin/helm$(EXE_EXTENSION) lint-chart
 	mkdir -p $(BUILD_DIR)/chart/
-	$(HELM) init --client-only
 	$(HELM) package -d $(BUILD_DIR)/chart/ --version $(BASE_VERSION) $(REPOSITORY_ROOT)/install/helm/open-match
 
 build/chart/index.yaml: build/toolchain/bin/helm$(EXE_EXTENSION) gcloud build/chart/open-match-$(BASE_VERSION).tgz
@@ -881,9 +880,6 @@ release: build/release/
 clean-secrets:
 	rm -rf $(OPEN_MATCH_SECRETS_DIR)
 
-clean-release:
-	rm -rf $(BUILD_DIR)/release/
-
 clean-protos:
 	rm -rf $(REPOSITORY_ROOT)/pkg/pb/
 	rm -rf $(REPOSITORY_ROOT)/internal/pb/
@@ -904,8 +900,11 @@ clean-binaries:
 clean-terraform:
 	rm -rf $(REPOSITORY_ROOT)/install/terraform/.terraform/
 
-clean-build: clean-toolchain clean-archives clean-release
+clean-build: clean-toolchain clean-archives clean-release clean-chart
 	rm -rf $(BUILD_DIR)/
+
+clean-release:
+	rm -rf $(BUILD_DIR)/release/
 
 clean-toolchain:
 	rm -rf $(TOOLCHAIN_DIR)/
@@ -929,10 +928,7 @@ clean-swagger-docs:
 clean-third-party:
 	rm -rf $(REPOSITORY_ROOT)/third_party/
 
-clean-swaggerui:
-	rm -rf $(REPOSITORY_ROOT)/third_party/swaggerui/
-
-clean: clean-images clean-binaries clean-release clean-chart clean-build clean-protos clean-swagger-docs clean-install-yaml clean-stress-test-tools clean-secrets clean-swaggerui clean-terraform clean-third-party
+clean: clean-images clean-binaries clean-build clean-install-yaml clean-stress-test-tools clean-secrets clean-terraform clean-third-party clean-protos clean-swagger-docs
 
 proxy-frontend: build/toolchain/bin/kubectl$(EXE_EXTENSION)
 	@echo "Frontend Health: http://localhost:$(FRONTEND_PORT)/healthz"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -54,7 +54,7 @@ steps:
 
 - id: 'Build: Clean'
   name: 'gcr.io/$PROJECT_ID/open-match-build'
-  args: ['make', 'clean']
+  args: ['make', 'clean-third-party', 'clean-protos', 'clean-swagger-docs']
   waitFor: ['Docker Image: open-match-build']
 
 - id: 'Test: Markdown'
@@ -70,13 +70,23 @@ steps:
     path: '/go'
   waitFor: ['Build: Clean']
 
-- id: 'Build: Install Toolchain'
+- id: 'Build: Initialize Toolchain'
   name: 'gcr.io/$PROJECT_ID/open-match-build'
-  args: ['make', 'install-toolchain']
+  args: ['make', 'install-toolchain', 'push-helm-ci']
   volumes:
   - name: 'go-vol'
     path: '/go'
   waitFor: ['Setup: Download Dependencies']
+
+- id: 'Test: Terraform Configuration'
+  name: 'gcr.io/$PROJECT_ID/open-match-build'
+  args: ['make', 'terraform-test']
+  waitFor: ['Build: Initialize Toolchain']
+
+- id: 'Build: Deployment Configs'
+  name: 'gcr.io/$PROJECT_ID/open-match-build'
+  args: ['make', 'SHORT_SHA=${SHORT_SHA}', 'update-chart-deps', 'install/yaml/']
+  waitFor: ['Build: Initialize Toolchain']
 
 - id: 'Build: Assets'
   name: 'gcr.io/$PROJECT_ID/open-match-build'
@@ -84,7 +94,7 @@ steps:
   volumes:
   - name: 'go-vol'
     path: '/go'
-  waitFor: ['Build: Install Toolchain']
+  waitFor: ['Build: Initialize Toolchain']
 
 - id: 'Build: Binaries'
   name: 'gcr.io/$PROJECT_ID/open-match-build'
@@ -107,16 +117,6 @@ steps:
   args: ['make', '_GCB_POST_SUBMIT=${_GCB_POST_SUBMIT}', '_GCB_LATEST_VERSION=${_GCB_LATEST_VERSION}', 'SHORT_SHA=${SHORT_SHA}', 'BRANCH_NAME=${BRANCH_NAME}', 'push-images', '-j8']
   waitFor: ['Build: Assets']
 
-- id: 'Test: Terraform Configuration'
-  name: 'gcr.io/$PROJECT_ID/open-match-build'
-  args: ['make', 'terraform-test']
-  waitFor: ['Build: Install Toolchain']
-
-- id: 'Build: Deployment Configs'
-  name: 'gcr.io/$PROJECT_ID/open-match-build'
-  args: ['make', 'SHORT_SHA=${SHORT_SHA}', 'push-helm-ci', 'update-chart-deps', 'clean-install-yaml', 'install/yaml/']
-  waitFor: ['Build: Install Toolchain']
-
 - id: 'Lint: Format, Vet, Charts'
   name: 'gcr.io/$PROJECT_ID/open-match-build'
   args: ['make', 'lint']
@@ -128,7 +128,7 @@ steps:
 - id: 'Test: Deploy Open Match'
   name: 'gcr.io/$PROJECT_ID/open-match-build'
   args: ['make', 'SHORT_SHA=${SHORT_SHA}', 'auth-gke-cluster', 'delete-chart', 'ci-reap-namespaces', 'install-ci-chart']
-  waitFor: ['Build: Install Toolchain', 'Build: Docker Images']
+  waitFor: ['Build: Docker Images']
 
 - id: 'Deploy: Deployment Configs'
   name: 'gcr.io/$PROJECT_ID/open-match-build'


### PR DESCRIPTION
This commit cleans up the Makefile and removes some duplicated dependencies from cloudbuild to speed up CI.