### PR TITLE
Ignore globals when linting everywhere.

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -177,6 +177,7 @@ linters:
     - prealloc
     - gofmt
     - interfacer # deprecated - "A tool that suggests interfaces is prone to bad suggestions"
+    - gochecknoglobals
 
 #linters:
 #  enable-all: true
@@ -191,48 +192,11 @@ issues:
 
   # Excluding configuration per-path, per-linter, per-text and per-source
   exclude-rules:
-    - path: internal[/\\]config[/\\]
-      linters:
-        - gochecknoglobals
-    - path: consts\.go
-      linters:
-        - gochecknoglobals
     # Exclude some linters from running on test files
     - path: _test\.go
       linters:
         - errcheck
         - bodyclose
-    # The following are allowed global variable patterns.
-    # Generally it's ok to have constants or variables that effectively act as constants such as a static logger or flag values.
-    # The filters below specify the source code pattern that's allowed when declaring a global
-    # 'source: "flag."' will match 'var destFlag = flag.String("dest", "", "")'
-    - source: "flag."
-      linters:
-        - gochecknoglobals
-    - source: "telemetry."
-      linters:
-        - gochecknoglobals
-    - source: " Counter"
-      linters:
-        - gochecknoglobals
-    - source: "View."
-      linters:
-        - gochecknoglobals
-    - source: "tag."
-      linters:
-        - gochecknoglobals
-    - source: "logrus."
-      linters:
-        - gochecknoglobals
-    - source: "template.New"
-      linters:
-        - gochecknoglobals
-    - source: "stats."
-      linters:
-        - gochecknoglobals
-    - source: "serviceAddressList"
-      linters:
-        - gochecknoglobals
 
     # Exclude known linters from partially hard-vendored code,
     # which is impossible to exclude via "nolint" comments.


### PR DESCRIPTION
The exclusions list is ever growing because there are many valid
use cases for global variables.  The standard library uses them
all over the place.  Removing the check, and instead relying on
code review to spot bad uses of globals.