### PR TITLE
Improve synchronizer logging

### DIFF
--- a/internal/app/synchronizer/state.go
+++ b/internal/app/synchronizer/state.go
@@ -212,7 +212,7 @@ func (syncState *synchronizerState) trackRegistrationWindow() {
 	time.Sleep(syncState.registrationInterval())
 	syncState.stateMutex.Lock()
 	defer syncState.stateMutex.Unlock()
-	logger.Info("Changing state from requestRegistration to proposalCollection")
+	logger.Infof("Changing state from requestRegistration to proposalCollection after %v", syncState.registrationInterval())
 	syncState.status = statusProposalCollection
 	go syncState.trackProposalWindow()
 }
@@ -221,7 +221,7 @@ func (syncState *synchronizerState) trackProposalWindow() {
 	time.Sleep(syncState.proposalCollectionInterval())
 	syncState.stateMutex.Lock()
 	defer syncState.stateMutex.Unlock()
-	logger.Info("Changing status from proposalCollection to evaluation")
+	logger.Infof("Changing status from proposalCollection to evaluation after %v", syncState.proposalCollectionInterval())
 	syncState.status = statusEvaluation
 	syncState.evaluate(context.Background())
 }

--- a/internal/app/synchronizer/synchronizer_service.go
+++ b/internal/app/synchronizer/synchronizer_service.go
@@ -128,11 +128,6 @@ func (s *synchronizerService) EvaluateProposals(stream ipb.Synchronizer_Evaluate
 
 func (s *synchronizerService) doEvaluateProposals(ctx context.Context, proposals []*pb.Match, id string) ([]*pb.Match, error) {
 	syncState := s.state
-
-	logger.WithFields(logrus.Fields{
-		"id":        id,
-		"proposals": getMatchIds(proposals),
-	}).Info("Received request to evaluate propsals")
 	// pendingRequests keeps track of number of requests pending. This is incremented
 	// in addProposals while holding the state mutex. The count should be decremented
 	// only after this request completes.


### PR DESCRIPTION
Resolves #763. It seems like sychronizer does respect the config changes. This commit also reduce the log spamming in the synchronizer - Psyonix has thousands of proposals being evaluated per evaluation cycle so logging in terms of proposalIds isn't really useful

To verify - with the following logging changes:
1. Deployed Open Match
2. Edit `synchronizer.registrationIntervalMs` in om-configmap.yaml, run `helm template --namespace open-match install/helm/open-match/ -x templates/om-configmap.yaml | kubectl apply -f -`
3. The new config value shows up when running `kubectl logs -n open-match svc/om-synchronizer`