### PR TITLE
Store indexes used for a ticket, and use them to deindex

### DIFF
--- a/internal/statestore/redis.go
+++ b/internal/statestore/redis.go
@@ -340,8 +340,6 @@ func (rb *redisBackend) DeindexTicket(ctx context.Context, id string) error {
 		return status.Errorf(codes.Internal, "%v", err)
 	}
 
-	fmt.Println("LOOK HERE", id, len(indices), indices) // DO NOT SUBMIT
-
 	if len(indices) == 0 {
 		return nil
 	}

--- a/internal/statestore/redis_indices_test.go
+++ b/internal/statestore/redis_indices_test.go
@@ -70,7 +70,7 @@ func TestExtractIndexedFields(t *testing.T) {
 
 			actual := extractIndexedFields(cfg, &pb.Ticket{Properties: test.ticket})
 
-			assert.Equal(t, test.expectedValues, actual.values)
+			assert.Equal(t, test.expectedValues, actual)
 		})
 	}
 }
@@ -118,31 +118,6 @@ func TestExtractIndexFilters(t *testing.T) {
 			actual := extractIndexFilters(test.pool)
 
 			assert.Equal(t, test.expected, actual)
-		})
-	}
-}
-
-func TestExtractDeindexFilters(t *testing.T) {
-	tests := []struct {
-		description string
-		indices     []string
-		expected    []string
-	}{
-		{
-			description: "range",
-			indices:     []string{"foo"},
-			expected:    []string{"ri$foo", "allTickets"},
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.description, func(t *testing.T) {
-			cfg := viper.New()
-			cfg.Set("ticketIndices", test.indices)
-
-			actual := extractDeindexFilters(cfg)
-
-			assert.ElementsMatch(t, test.expected, actual)
 		})
 	}
 }

--- a/internal/statestore/redis_test.go
+++ b/internal/statestore/redis_test.go
@@ -220,7 +220,6 @@ func TestTicketIndexing(t *testing.T) {
 		"ticket.no.7",
 		"ticket.no.8",
 	}
-	fmt.Println(found) // DO NOT SUBMIT
 	assert.ElementsMatch(expected, found)
 }
 

--- a/internal/statestore/redis_test.go
+++ b/internal/statestore/redis_test.go
@@ -188,7 +188,7 @@ func TestTicketIndexing(t *testing.T) {
 	err = service.DeindexTicket(ctx, "ticket.no.6")
 	assert.Nil(err)
 
-	found := make(map[string]struct{})
+	found := []string{}
 
 	pool := &pb.Pool{
 		Filters: []*pb.Filter{
@@ -208,17 +208,20 @@ func TestTicketIndexing(t *testing.T) {
 	err = service.FilterTickets(ctx, pool, 2, func(tickets []*pb.Ticket) error {
 		assert.True(len(tickets) <= 2)
 		for _, ticket := range tickets {
-			found[ticket.Id] = struct{}{}
+			found = append(found, ticket.Id)
 		}
 		return nil
 	})
 	assert.Nil(err)
 
-	assert.Equal(len(found), 4)
-	assert.Contains(found, "ticket.no.3")
-	assert.Contains(found, "ticket.no.4")
-	assert.Contains(found, "ticket.no.7")
-	assert.Contains(found, "ticket.no.8")
+	expected := []string{
+		"ticket.no.3",
+		"ticket.no.4",
+		"ticket.no.7",
+		"ticket.no.8",
+	}
+	fmt.Println(found) // DO NOT SUBMIT
+	assert.ElementsMatch(expected, found)
 }
 
 func TestGetAssignmentBeforeSet(t *testing.T) {


### PR DESCRIPTION
This has two primary advantages:
The redis key of the index can be decided at ticket index / query time.  This is important for string equal indexing, where the plan is to concatenate the OM index name and the string value to form the redis key.
Improved correctness when indexes are changed:  The ticket will now clean up the indexes it was created with, preventing old indices from existing after all the tickets that used them are gone.

This does add an extra read when deindexing a ticket, but I think the correctness improvement alone is worth that.

Other notes:
Turns out the indexes need to be in a list of interface{} to concatenate with the redis key for the cache, so I changed my mind about computing the list in extractIndexedFields.  So extractIndexedFields instead just returns the map of index to values.

Improved a test's assertions by using ElementsMatch.