### PR TITLE
Add placeholder components for Open Match scale benchmarking

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -121,6 +121,7 @@ cmd/swaggerui/swaggerui
 tools/certgen/certgen
 examples/demo/demo
 examples/functions/golang/soloduel/soloduel
+examples/functions/golang/rosterbased/rosterbased
 examples/functions/golang/pool/pool
 examples/evaluator/golang/simple/simple
 tools/reaper/reaper

--- a/.gitignore
+++ b/.gitignore
@@ -118,6 +118,7 @@ cmd/swaggerui/swaggerui
 tools/certgen/certgen
 examples/demo/demo
 examples/functions/golang/soloduel/soloduel
+examples/functions/golang/rosterbased/rosterbased
 examples/functions/golang/pool/pool
 examples/evaluator/golang/simple/simple
 tools/reaper/reaper

--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,7 @@ ALL_PROTOS = $(GOLANG_PROTOS) $(SWAGGER_JSON_DOCS)
 CMDS = $(notdir $(wildcard cmd/*))
 
 # Names of the individual images, ommiting the openmatch prefix.
-IMAGES = $(CMDS) mmf-go-soloduel mmf-go-pool evaluator-go-simple reaper stress-frontend base-build
+IMAGES = $(CMDS) mmf-go-soloduel mmf-go-pool mmf-go-rosterbased evaluator-go-simple reaper stress-frontend base-build
 
 help:
 	@cat Makefile | grep ^\#\# | grep -v ^\#\#\# |cut -c 4-
@@ -213,7 +213,7 @@ local-cloud-build: gcloud
 
 ################################################################################
 ## #############################################################################
-## Image commands: 
+## Image commands:
 ## These commands are auto-generated based on a complete list of images.  All
 ## folders in cmd/ are turned into an image using Dockerfile.cmd.  Additional
 ## images are specified by the IMAGES variable.  Image commands ommit the
@@ -241,6 +241,9 @@ $(foreach CMD,$(CMDS),build-$(CMD)-image): build-%-image: docker build-base-buil
 
 build-mmf-go-soloduel-image: docker build-base-build-image
 	docker build -f examples/functions/golang/soloduel/Dockerfile -t $(REGISTRY)/openmatch-mmf-go-soloduel:$(TAG) -t $(REGISTRY)/openmatch-mmf-go-soloduel:$(ALTERNATE_TAG) .
+
+build-mmf-go-rosterbased-image: docker build-base-build-image
+	docker build -f examples/functions/golang/rosterbased/Dockerfile -t $(REGISTRY)/openmatch-mmf-go-rosterbased:$(TAG) -t $(REGISTRY)/openmatch-mmf-go-rosterbased:$(ALTERNATE_TAG) .
 
 build-mmf-go-pool-image: docker build-base-build-image
 	docker build -f examples/functions/golang/pool/Dockerfile -t $(REGISTRY)/openmatch-mmf-go-pool:$(TAG) -t $(REGISTRY)/openmatch-mmf-go-pool:$(ALTERNATE_TAG) .
@@ -277,7 +280,7 @@ endif
 #######################################
 ## retag-images / retag-<image name>-image: publishes images on the public
 ## container registry.  Used for publishing releases.
-## 
+##
 retag-images: $(foreach IMAGE,$(IMAGES),retag-$(IMAGE)-image)
 
 retag-%-image: SOURCE_REGISTRY = gcr.io/$(OPEN_MATCH_BUILD_PROJECT_ID)
@@ -343,6 +346,24 @@ install-chart: install-chart-prerequisite build/toolchain/bin/helm$(EXE_EXTENSIO
 		--namespace=$(OPEN_MATCH_KUBERNETES_NAMESPACE) \
 		--set global.image.registry=$(REGISTRY) \
 		--set global.image.tag=$(TAG) \
+		--set global.gcpProjectId=$(GCP_PROJECT_ID)
+
+install-scale-chart: build/toolchain/bin/helm$(EXE_EXTENSION) install/helm/open-match/secrets/
+	$(HELM) upgrade $(OPEN_MATCH_RELEASE_NAME) --install --wait --debug install/helm/open-match \
+		--timeout=600 \
+		--namespace=$(OPEN_MATCH_KUBERNETES_NAMESPACE) \
+		--set global.image.registry=$(REGISTRY) \
+		--set global.image.tag=$(TAG) \
+		--set open-match-core.enabled=true \
+		--set open-match-telemetry.enabled=true \
+		--set open-match-demo.enabled=false \
+		--set open-match-customize.enabled=true \
+		--set open-match-customize.function.image=openmatch-mmf-go-rosterbased\
+		--set global.telemetry.grafana.enabled=true \
+		--set global.telemetry.jaeger.enabled=true \
+		--set global.telemetry.prometheus.enabled=true \
+		--set open-match-scale.enabled=true \
+		--set global.logging.rpc.enabled=true \
 		--set global.gcpProjectId=$(GCP_PROJECT_ID)
 
 install-ci-chart: install-chart-prerequisite build/toolchain/bin/helm$(EXE_EXTENSION) install/helm/open-match/secrets/
@@ -542,7 +563,7 @@ build/toolchain/bin/certgen$(EXE_EXTENSION): tools/certgen/certgen$(EXE_EXTENSIO
 build/toolchain/bin/reaper$(EXE_EXTENSION): tools/reaper/reaper$(EXE_EXTENSION)
 	mkdir -p $(TOOLCHAIN_BIN)
 	cp -f $(REPOSITORY_ROOT)/tools/reaper/reaper$(EXE_EXTENSION) $(TOOLCHAIN_BIN)/reaper$(EXE_EXTENSION)
- 
+
 push-helm-ci: build/toolchain/bin/helm$(EXE_EXTENSION) build/toolchain/bin/kubectl$(EXE_EXTENSION)
 	$(HELM) init --service-account tiller --force-upgrade --client-only
 
@@ -681,7 +702,7 @@ internal/ipb/synchronizer.pb.go: pkg/pb/messages.pb.go
 
 build: assets
 	$(GO) build ./...
-	$(GO) build -tags e2ecluster ./... 
+	$(GO) build -tags e2ecluster ./...
 
 test: $(ALL_PROTOS) tls-certs third_party/
 	$(GO) test -cover -test.count $(GOLANG_TEST_COUNT) -race ./...
@@ -743,11 +764,14 @@ service-binaries: cmd/backend/backend$(EXE_EXTENSION) cmd/frontend/frontend$(EXE
 service-binaries: cmd/mmlogic/mmlogic$(EXE_EXTENSION) cmd/synchronizer/synchronizer$(EXE_EXTENSION)
 
 example-binaries: example-mmf-binaries example-evaluator-binaries
-example-mmf-binaries: examples/functions/golang/soloduel/soloduel$(EXE_EXTENSION) examples/functions/golang/pool/pool$(EXE_EXTENSION)
+example-mmf-binaries: examples/functions/golang/soloduel/soloduel$(EXE_EXTENSION) examples/functions/golang/pool/pool$(EXE_EXTENSION)  examples/functions/golang/rosterbased/rosterbased$(EXE_EXTENSION)
 example-evaluator-binaries: examples/evaluator/golang/simple/simple$(EXE_EXTENSION)
 
 examples/functions/golang/soloduel/soloduel$(EXE_EXTENSION): pkg/pb/mmlogic.pb.go pkg/pb/mmlogic.pb.gw.go api/mmlogic.swagger.json pkg/pb/matchfunction.pb.go pkg/pb/matchfunction.pb.gw.go api/matchfunction.swagger.json
 	cd $(REPOSITORY_ROOT)/examples/functions/golang/soloduel; $(GO_BUILD_COMMAND)
+
+examples/functions/golang/rosterbased/rosterbased$(EXE_EXTENSION): pkg/pb/mmlogic.pb.go pkg/pb/mmlogic.pb.gw.go api/mmlogic.swagger.json pkg/pb/matchfunction.pb.go pkg/pb/matchfunction.pb.gw.go api/matchfunction.swagger.json
+	cd $(REPOSITORY_ROOT)/examples/functions/golang/rosterbased; $(GO_BUILD_COMMAND)
 
 examples/functions/golang/pool/pool$(EXE_EXTENSION): pkg/pb/mmlogic.pb.go pkg/pb/mmlogic.pb.gw.go api/mmlogic.swagger.json pkg/pb/matchfunction.pb.go pkg/pb/matchfunction.pb.gw.go api/matchfunction.swagger.json
 	cd $(REPOSITORY_ROOT)/examples/functions/golang/pool; $(GO_BUILD_COMMAND)
@@ -884,6 +908,7 @@ clean-binaries:
 	rm -rf $(REPOSITORY_ROOT)/cmd/mmlogic/mmlogic$(EXE_EXTENSION)
 	rm -rf $(REPOSITORY_ROOT)/cmd/minimatch/minimatch$(EXE_EXTENSION)
 	rm -rf $(REPOSITORY_ROOT)/examples/functions/golang/soloduel/soloduel$(EXE_EXTENSION)
+	rm -rf $(REPOSITORY_ROOT)/examples/functions/golang/rosterbased/rosterbased$(EXE_EXTENSION)
 	rm -rf $(REPOSITORY_ROOT)/examples/functions/golang/pool/pool$(EXE_EXTENSION)
 	rm -rf $(REPOSITORY_ROOT)/examples/functions/golang/simple/evaluator$(EXE_EXTENSION)
 	rm -rf $(REPOSITORY_ROOT)/cmd/swaggerui/swaggerui$(EXE_EXTENSION)

--- a/cmd/scale-backend/main.go
+++ b/cmd/scale-backend/main.go
@@ -1,0 +1,23 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"open-match.dev/open-match/examples/scale/backend"
+)
+
+func main() {
+	backend.Run()
+}

--- a/cmd/scale-frontend/main.go
+++ b/cmd/scale-frontend/main.go
@@ -1,0 +1,23 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"open-match.dev/open-match/examples/scale/frontend"
+)
+
+func main() {
+	frontend.Run()
+}

--- a/examples/functions/golang/rosterbased/Dockerfile
+++ b/examples/functions/golang/rosterbased/Dockerfile
@@ -1,0 +1,24 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM open-match-base-build as builder
+
+WORKDIR /go/src/open-match.dev/open-match/examples/functions/golang/rosterbased
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o matchfunction .
+
+FROM gcr.io/distroless/static:nonroot
+WORKDIR /app/
+COPY --from=builder --chown=nonroot /go/src/open-match.dev/open-match/examples/functions/golang/rosterbased/matchfunction /app/
+
+ENTRYPOINT ["/app/matchfunction"]

--- a/examples/functions/golang/rosterbased/main.go
+++ b/examples/functions/golang/rosterbased/main.go
@@ -1,0 +1,35 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package main defines a sample match function that uses the GRPC harness to set up
+// the match making function as a service. This sample is a reference
+// to demonstrate the usage of the GRPC harness and should only be used as
+// a starting point for your match function. You will need to modify the
+// matchmaking logic in this function based on your game's requirements.
+package main
+
+import (
+	rosterbased "open-match.dev/open-match/examples/functions/golang/rosterbased/mmf"
+	mmfHarness "open-match.dev/open-match/pkg/harness/function/golang"
+)
+
+func main() {
+	// Invoke the harness to setup a GRPC service that handles requests to run the
+	// match function. The harness itself queries open match for player pools for
+	// the specified request and passes the pools to the match function to generate
+	// proposals.
+	mmfHarness.RunMatchFunction(&mmfHarness.FunctionSettings{
+		Func: rosterbased.MakeMatches,
+	})
+}

--- a/examples/functions/golang/rosterbased/mmf/matchfunction.go
+++ b/examples/functions/golang/rosterbased/mmf/matchfunction.go
@@ -1,0 +1,39 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package mmf provides a sample match function that uses the GRPC harness to set up 1v1 matches.
+// This sample is a reference to demonstrate the usage of the GRPC harness and should only be used as
+// a starting point for your match function. You will need to modify the
+// matchmaking logic in this function based on your game's requirements.
+package mmf
+
+import (
+	"github.com/sirupsen/logrus"
+	mmfHarness "open-match.dev/open-match/pkg/harness/function/golang"
+	"open-match.dev/open-match/pkg/pb"
+)
+
+var (
+	matchName = "roster-based-matchfunction"
+	logger    = logrus.WithFields(logrus.Fields{
+		"app":       "openmatch",
+		"component": "mmf.rosterbased",
+	})
+)
+
+// MakeMatches is where your custom matchmaking logic lives.
+func MakeMatches(p *mmfHarness.MatchFunctionParams) ([]*pb.Match, error) {
+	logger.Infof("MakeMatches called for Profile:%v", p.ProfileName)
+	return []*pb.Match{}, nil
+}

--- a/examples/scale/backend/backend.go
+++ b/examples/scale/backend/backend.go
@@ -1,0 +1,46 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backend
+
+import (
+	"github.com/sirupsen/logrus"
+	"open-match.dev/open-match/examples/scale/profiles"
+	"open-match.dev/open-match/internal/config"
+	"open-match.dev/open-match/internal/logging"
+)
+
+var (
+	logger = logrus.WithFields(logrus.Fields{
+		"app":       "openmatch",
+		"component": "scale.backend",
+	})
+)
+
+// Run triggers execution of the scale backend component that fetches
+// matches at scale from Open Match.
+func Run() {
+	cfg, err := config.Read()
+	if err != nil {
+		logger.WithFields(logrus.Fields{
+			"error": err.Error(),
+		}).Fatalf("cannot read configuration.")
+	}
+
+	logging.ConfigureLogging(cfg)
+
+	// TODO: This is a placeholder - add the actual implementation.
+	mprofiles := profiles.Generate(cfg)
+	logger.Infof("Generated Profiles: %v", mprofiles)
+}

--- a/examples/scale/frontend/frontend.go
+++ b/examples/scale/frontend/frontend.go
@@ -1,0 +1,48 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package frontend
+
+import (
+	"github.com/sirupsen/logrus"
+	"open-match.dev/open-match/examples/scale/tickets"
+	"open-match.dev/open-match/internal/config"
+	"open-match.dev/open-match/internal/logging"
+)
+
+var (
+	logger = logrus.WithFields(logrus.Fields{
+		"app":       "openmatch",
+		"component": "scale.frontend",
+	})
+)
+
+// Run triggers execution of the scale frontend component that creates
+// tickets at scale in Open Match.
+func Run() {
+	cfg, err := config.Read()
+	if err != nil {
+		logger.WithFields(logrus.Fields{
+			"error": err.Error(),
+		}).Fatal("cannot read configuration.")
+	}
+
+	logging.ConfigureLogging(cfg)
+
+	// TODO: This is a placeholder - add the actual implementation.
+	concurrent := cfg.GetInt("testConfig.concurrent-creates")
+	for i := 0; i <= concurrent; i++ {
+		_ = tickets.Ticket(cfg)
+	}
+}

--- a/examples/scale/profiles/greedy.go
+++ b/examples/scale/profiles/greedy.go
@@ -1,0 +1,26 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profiles
+
+import (
+	"open-match.dev/open-match/internal/config"
+	"open-match.dev/open-match/pkg/pb"
+)
+
+func greedyProfiles(cfg config.View) []*pb.MatchProfile {
+	// TODO - Implement logic to generate profiles
+	_ = cfg
+	return []*pb.MatchProfile{}
+}

--- a/examples/scale/profiles/multifilter.go
+++ b/examples/scale/profiles/multifilter.go
@@ -1,0 +1,26 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profiles
+
+import (
+	"open-match.dev/open-match/internal/config"
+	"open-match.dev/open-match/pkg/pb"
+)
+
+func multifilterProfiles(cfg config.View) []*pb.MatchProfile {
+	// TODO - Implement logic to generate profiles
+	_ = cfg
+	return []*pb.MatchProfile{}
+}

--- a/examples/scale/profiles/multipool.go
+++ b/examples/scale/profiles/multipool.go
@@ -1,0 +1,26 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profiles
+
+import (
+	"open-match.dev/open-match/internal/config"
+	"open-match.dev/open-match/pkg/pb"
+)
+
+func multipoolProfiles(cfg config.View) []*pb.MatchProfile {
+	// TODO - Implement logic to generate profiles
+	_ = cfg
+	return []*pb.MatchProfile{}
+}

--- a/examples/scale/profiles/profiles.go
+++ b/examples/scale/profiles/profiles.go
@@ -1,0 +1,51 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package profiles
+
+import (
+	"github.com/sirupsen/logrus"
+	"open-match.dev/open-match/internal/config"
+	"open-match.dev/open-match/pkg/pb"
+)
+
+var (
+	logger = logrus.WithFields(logrus.Fields{
+		"app":       "openmatch",
+		"component": "scale-backend.profiles",
+	})
+
+	// Greedy config type is used to pick profiles that pull in all players.
+	Greedy = "greedy"
+	// MultiFilter config type is used to pick profiles that have a Pool that uses multiple filters.
+	MultiFilter = "multifilter"
+	// MultiPool config type is used to pick profiles that have multiple Pools with multiple filters each.
+	MultiPool = "multipool"
+)
+
+// Generate generates test profiles for scale demo
+func Generate(cfg config.View) []*pb.MatchProfile {
+	profile := cfg.GetString("testConfig.profile")
+	switch profile {
+	case Greedy:
+		return greedyProfiles(cfg)
+	case MultiFilter:
+		return multifilterProfiles(cfg)
+	case MultiPool:
+		return multipoolProfiles(cfg)
+	}
+
+	logger.Warningf("Unexpected profile name %s, not returning any profiles", profile)
+	return nil
+}

--- a/examples/scale/tickets/tickets.go
+++ b/examples/scale/tickets/tickets.go
@@ -1,0 +1,37 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tickets
+
+import (
+	"open-match.dev/open-match/internal/config"
+
+	"github.com/sirupsen/logrus"
+	"open-match.dev/open-match/pkg/pb"
+)
+
+var (
+	logger = logrus.WithFields(logrus.Fields{
+		"app":       "openmatch",
+		"component": "scale-frontend.tickets",
+	})
+)
+
+// Ticket generates a ticket based on the config for scale testing
+func Ticket(cfg config.View) *pb.Ticket {
+	// TODO: Add implementation for generating a fake ticket.
+	_ = cfg
+	logger.Info("Tickets.Ticket() invoked")
+	return &pb.Ticket{}
+}

--- a/install/helm/open-match/subcharts/open-match-scale/Chart.yaml
+++ b/install/helm/open-match/subcharts/open-match-scale/Chart.yaml
@@ -1,0 +1,19 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: open-match-scale
+version: 0.0.0-dev

--- a/install/helm/open-match/subcharts/open-match-scale/templates/scale-backend.yaml
+++ b/install/helm/open-match/subcharts/open-match-scale/templates/scale-backend.yaml
@@ -1,0 +1,73 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ .Values.scaleBackend.hostName }}
+  namespace: {{ .Release.Namespace }}
+  annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
+  labels:
+    app: {{ template "openmatch.name" . }}
+    component: scaleBackend
+    release: {{ .Release.Name }}
+spec:
+  selector:
+    app: {{ template "openmatch.name" . }}
+    component: scaleBackend
+  ports:
+  - name: http
+    protocol: TCP
+    port: {{ .Values.scaleBackend.httpPort }}
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ .Values.scaleBackend.hostName }}
+  namespace: {{ .Release.Namespace }}
+  annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
+  labels:
+    app: {{ template "openmatch.name" . }}
+    component: scaleBackend
+    release: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.scaleBackend.replicas }}
+  selector:
+    matchLabels:
+      app: {{ template "openmatch.name" . }}
+      component: scaleBackend
+  template:
+    metadata:
+      namespace: {{ .Release.Namespace }}
+      annotations:
+        {{- include "openmatch.chartmeta" . | nindent 8 }}
+      labels:
+        app: {{ template "openmatch.name" . }}
+        component: scaleBackend
+        release: {{ .Release.Name }}
+    spec:
+      volumes:
+        {{- include "openmatch.volumes.configs" . | nindent 8}}
+        {{- include "openmatch.volumes.tls" . | nindent 8}}
+      serviceAccountName: {{ .Values.global.kubernetes.serviceAccount }}
+      containers:
+      - name: {{ .Values.scaleBackend.hostName }}
+        volumeMounts:
+          {{- include "openmatch.volumemounts.configs" . | nindent 10 }}
+          {{- include "openmatch.volumemounts.tls" . | nindent 10 }}
+        image: "{{ coalesce .Values.global.image.registry .Values.image.registry }}/{{ .Values.scaleBackend.image}}:{{ coalesce .Values.global.image.tag .Values.image.tag }}"
+        ports:
+        - name: http
+          containerPort: {{ .Values.scaleBackend.httpPort }}
+        {{- include "openmatch.container.common" . | nindent 8 }}

--- a/install/helm/open-match/subcharts/open-match-scale/templates/scale-configmap.yaml
+++ b/install/helm/open-match/subcharts/open-match-scale/templates/scale-configmap.yaml
@@ -1,0 +1,36 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: scale-configmap
+  namespace: {{ .Release.Namespace }}
+  annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
+  labels:
+    app: {{ template "openmatch.name" . }}
+    component: config
+    release: {{ .Release.Name }}
+data:
+  matchmaker_config.yaml: |-
+    api:
+      frontend:
+        hostname: "{{ .Values.frontend.hostName }}"
+        grpcport: "{{ .Values.frontend.grpcPort }}"
+      backend:
+        hostname: "{{ .Values.backend.hostName }}"
+        grpcport: "{{ .Values.backend.grpcPort }}"
+    testConfig:
+      profile: "{{ .Values.testConfig.profile }}"
+      concurrentCreates: "{{ .Values.testConfig.concurrentCreates }}"

--- a/install/helm/open-match/subcharts/open-match-scale/templates/scale-frontend.yaml
+++ b/install/helm/open-match/subcharts/open-match-scale/templates/scale-frontend.yaml
@@ -1,0 +1,73 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ .Values.scaleFrontend.hostName }}
+  namespace: {{ .Release.Namespace }}
+  annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
+  labels:
+    app: {{ template "openmatch.name" . }}
+    component: scaleFrontend
+    release: {{ .Release.Name }}
+spec:
+  selector:
+    app: {{ template "openmatch.name" . }}
+    component: scaleFrontend
+  ports:
+  - name: http
+    protocol: TCP
+    port: {{ .Values.scaleFrontend.httpPort }}
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ .Values.scaleFrontend.hostName }}
+  namespace: {{ .Release.Namespace }}
+  annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
+  labels:
+    app: {{ template "openmatch.name" . }}
+    component: scaleFrontend
+    release: {{ .Release.Name }}
+spec:
+  replicas: {{ .Values.scaleFrontend.replicas }}
+  selector:
+    matchLabels:
+      app: {{ template "openmatch.name" . }}
+      component: scaleFrontend
+  template:
+    metadata:
+      namespace: {{ .Release.Namespace }}
+      annotations:
+        {{- include "openmatch.chartmeta" . | nindent 8 }}
+      labels:
+        app: {{ template "openmatch.name" . }}
+        component: scaleFrontend
+        release: {{ .Release.Name }}
+    spec:
+      volumes:
+        {{- include "openmatch.volumes.configs" . | nindent 8}}
+        {{- include "openmatch.volumes.tls" . | nindent 8}}
+      serviceAccountName: {{ .Values.global.kubernetes.serviceAccount }}
+      containers:
+      - name: {{ .Values.scaleFrontend.hostName }}
+        volumeMounts:
+          {{- include "openmatch.volumemounts.configs" . | nindent 10 }}
+          {{- include "openmatch.volumemounts.tls" . | nindent 10 }}
+        image: "{{ coalesce .Values.global.image.registry .Values.image.registry }}/{{ .Values.scaleFrontend.image}}:{{ coalesce .Values.global.image.tag .Values.image.tag }}"
+        ports:
+        - name: http
+          containerPort: {{ .Values.scaleFrontend.httpPort }}
+        {{- include "openmatch.container.common" . | nindent 8 }}

--- a/install/helm/open-match/subcharts/open-match-scale/values.yaml
+++ b/install/helm/open-match/subcharts/open-match-scale/values.yaml
@@ -1,0 +1,39 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+scaleFrontend:
+  hostName: om-scale-frontend
+  httpPort: 51509
+  replicas: 1
+  image: openmatch-scale-frontend
+
+scaleBackend:
+  hostName: om-scale-backend
+  httpPort: 51510
+  replicas: 1
+  image: openmatch-scale-backend
+
+image:
+  registry: gcr.io/open-match-public-images
+  tag: 0.0.0-dev
+  pullPolicy: Always
+
+configs:
+  scale-configmap:
+    mountPath: /app/config/om
+    volumeName: scale-config-volume
+
+testConfig:
+  profile: greedy
+  concurrentCreates: 500

--- a/install/helm/open-match/values.yaml
+++ b/install/helm/open-match/values.yaml
@@ -19,7 +19,7 @@
 # Open Match Cluster Config
 # The configurations defined here will be applied when deploying Open Match to a Kubernetes cluster.
 # You may choose to override these values to tailor Open Match for your needs.
-# 
+#
 # Begins the configuration section for `mmlogic` component in Open Match.
 # mmlogic:
 #
@@ -140,7 +140,7 @@ redis:
 #
 # Open Match uses subcharts to control its `functional granularity`.
 # You are able to override configurations in a subchart by having a key-value pair under its corresponding subchart section.
-# For example, the settings below overrides the `image.pullPolicy` field in `open-match/subcharts/open-match-demo/values.yaml` file. 
+# For example, the settings below overrides the `image.pullPolicy` field in `open-match/subcharts/open-match-demo/values.yaml` file.
 # open-match-demo:
 #   image:
 #     pullPolicy: SOME_PULL_POLICY
@@ -163,6 +163,13 @@ open-match-demo:
   frontend: *frontend
   backend: *backend
 
+# Contols if users need to install scale testing setup for Open Match.
+open-match-scale:
+  # Switch the value between true/false to turn on/off this subchart
+  enabled: false
+  frontend: *frontend
+  backend: *backend
+
 # Contols if users need to install the monitoring tools in Open Match.
 # By default, the stackdriver is enabled such that users are able to see the logs in a GKE cluster.
 open-match-telemetry:
@@ -177,7 +184,7 @@ open-match-customize:
   function: *function
   mmlogic: *mmlogic
   # You can enable the open-match-customize subchart
-  # and override the evaluator/mmf image 
+  # and override the evaluator/mmf image
   # image:
   #   registry: [YOUR_COMPONENT_REGISTRY]
   #   tag: [YOUR_COMPONENT_IMAGE_VERSION]
@@ -203,17 +210,17 @@ global:
     # Use this field if you need to override the port type for all services defined in this chart
     service:
       portType:
-  
+
   gcpProjectId: "replace_with_your_project_id"
-  
+
   # Defines if Open Match needs to serve secure traffic
-  tls: 
+  tls:
     enabled: false
     server:
       mountPath: /app/secrets/tls/server
     rootca:
       mountPath: /app/secrets/tls/rootca
-  
+
   logging:
     rpc:
       enabled: false
@@ -224,13 +231,13 @@ global:
     global-configmap:
       volumeName: global-config-volume
       mountPath: /app/config/global
-  
+
   # Use this field if you need to override the image registry and image tag for all services defined in this chart
   image:
     registry:
     tag:
-  
-  # Expose the telemetry configurations to all subcharts because prometheus, for example, 
+
+  # Expose the telemetry configurations to all subcharts because prometheus, for example,
   # requires pod-level annotation to customize its scrape path.
   # See definitions in templates/_helpers.tpl - "prometheus.annotations" section for details
   telemetry:
@@ -251,7 +258,7 @@ global:
     zipkin:
       enabled: false
       endpoint: "/zipkin"
-      reporterEndpoint: "zipkin" 
+      reporterEndpoint: "zipkin"
     grafana:
       enabled: false
     reportingPeriod: "1m"

--- a/third_party/protoc-gen-swagger/options/openapiv2.proto
+++ b/third_party/protoc-gen-swagger/options/openapiv2.proto
@@ -5,6 +5,7 @@ package grpc.gateway.protoc_gen_swagger.options;
 option go_package = "github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger/options";
 
 import "google/protobuf/any.proto";
+import "google/protobuf/struct.proto";
 
 // `Swagger` is a representation of OpenAPI v2 specification's Swagger object.
 //
@@ -45,6 +46,7 @@ message Swagger {
   // service objects into OpenAPI v2 Tag objects.
   reserved 13;
   ExternalDocumentation external_docs = 14;
+  map<string, google.protobuf.Value> extensions = 15;
 }
 
 // `Operation` is a representation of OpenAPI v2 specification's Operation object.
@@ -66,6 +68,7 @@ message Operation {
   repeated string schemes = 10;
   bool deprecated = 11;
   repeated SecurityRequirement security = 12;
+  map<string, google.protobuf.Value> extensions = 13;
 }
 
 // `Response` is a representation of OpenAPI v2 specification's Response object.
@@ -83,6 +86,7 @@ message Response {
   reserved 3;
   // field 3 is reserved for 'example'.
   reserved 4;
+  map<string, google.protobuf.Value> extensions = 5;
 }
 
 // `Info` is a representation of OpenAPI v2 specification's Info object.
@@ -97,6 +101,7 @@ message Info {
   Contact contact = 4;
   License license = 5;
   string version = 6;
+  map<string, google.protobuf.Value> extensions = 7;
 }
 
 // `Contact` is a representation of OpenAPI v2 specification's Contact object.
@@ -334,6 +339,7 @@ message SecurityScheme {
   //
   // Valid for oauth2.
   Scopes scopes = 8;
+  map<string, google.protobuf.Value> extensions = 9;
 }
 
 // `SecurityRequirement` is a representation of OpenAPI v2 specification's


### PR DESCRIPTION
This PR only adds the placeholders for core components and libraries for scale testing Open Match. Subsequent PRs will add implementation for each component. 