### PR TITLE
Bump default ignore list ttl to 60 seconds.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,6 @@ require (
 	github.com/alicebob/miniredis/v2 v2.8.1-0.20190618082157-e29950035715
 	github.com/cenkalti/backoff v2.1.1+incompatible
 	github.com/fsnotify/fsnotify v1.4.7
-	github.com/go-logfmt/logfmt v0.4.0 // indirect
 	github.com/golang/protobuf v1.3.2
 	github.com/gomodule/redigo v1.7.1-0.20190322064113-39e2c31b7ca3
 	github.com/google/gofuzz v1.0.0 // indirect

--- a/install/helm/open-match/templates/om-configmap.yaml
+++ b/install/helm/open-match/templates/om-configmap.yaml
@@ -77,11 +77,11 @@ data:
       enabled: true
       registrationIntervalMs: 3000ms
       proposalCollectionIntervalMs: 2000ms
-    
+
     storage:
       page:
         size: 10000
-    
+
     redis:
       hostname: {{ .Values.redis.fullnameOverride }}-master.{{ .Release.Namespace }}.svc.cluster.local
       port: {{ .Values.redis.redisPort }}
@@ -95,9 +95,9 @@ data:
         idleTimeout: 60s
         healthCheckTimeout: 100ms
       ignoreLists:
-        ttl: 1000ms
+        ttl: 60000ms
       expiration: 43200
-    
+
     ticketIndices:
     {{- range .Values.ticketIndices }}
       - {{ . }}


### PR DESCRIPTION
This gives the backend sufficient time to allocate DGS.