### PR TITLE
Remove unnecesssary properties and filters in demo

### DIFF
--- a/examples/demo/components/clients/clients.go
+++ b/examples/demo/components/clients/clients.go
@@ -25,7 +25,6 @@ import (
 	"open-match.dev/open-match/internal/config"
 	"open-match.dev/open-match/internal/rpc"
 	"open-match.dev/open-match/pkg/pb"
-	"open-match.dev/open-match/pkg/structs"
 )
 
 func Run(ds *components.DemoShared) {
@@ -95,12 +94,7 @@ func runScenario(ctx context.Context, cfg config.View, name string, update updat
 	var ticketId string
 	{
 		req := &pb.CreateTicketRequest{
-			Ticket: &pb.Ticket{
-				Properties: structs.Struct{
-					"name":      structs.String(name),
-					"mode.demo": structs.Number(1),
-				}.S(),
-			},
+			Ticket: &pb.Ticket{},
 		}
 
 		resp, err := fe.CreateTicket(ctx, req)

--- a/examples/demo/components/director/director.go
+++ b/examples/demo/components/director/director.go
@@ -91,13 +91,6 @@ func run(ds *components.DemoShared) {
 					Pools: []*pb.Pool{
 						{
 							Name: "Everyone",
-							FloatRangeFilters: []*pb.FloatRangeFilter{
-								{
-									Attribute: "mode.demo",
-									Min:       -100,
-									Max:       100,
-								},
-							},
 						},
 					},
 				},


### PR DESCRIPTION
This was possible since the move to read all tickets with no filters.  It simplifies the demo
complexity a bit.

Tangential, but useful to moving to the new API proposal: #765