### PR TITLE
Pin Dockerfile base-build to go version 1.13.1.

### DIFF
--- a/Dockerfile.base-build
+++ b/Dockerfile.base-build
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-// Also update go.mod when changing go version.
+// When updating Go version, update Dockerfile.ci, Dockerfile.base-build, and go.mod
 FROM golang:1.13.1
 ENV GO111MODULE=on
 

--- a/Dockerfile.base-build
+++ b/Dockerfile.base-build
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-// When updating Go version, update Dockerfile.ci, Dockerfile.base-build, and go.mod
+# When updating Go version, update Dockerfile.ci, Dockerfile.base-build, and go.mod
 FROM golang:1.13.1
 ENV GO111MODULE=on
 

--- a/Dockerfile.base-build
+++ b/Dockerfile.base-build
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:latest
+// Also update go.mod when changing go version.
+FROM golang:1.13.1
 ENV GO111MODULE=on
 
 WORKDIR /go/src/open-match.dev/open-match

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -38,7 +38,9 @@ RUN export CLOUD_SDK_REPO="cloud-sdk-stretch" && \
 RUN mkdir -p /toolchain/golang
 WORKDIR /toolchain/golang
 RUN sudo rm -rf /usr/local/go/
-RUN curl -L https://golang.org/dl/go1.13.linux-amd64.tar.gz | sudo tar -C /usr/local -xz
+
+// When updating Go version, update Dockerfile.ci, Dockerfile.base-build, and go.mod
+RUN curl -L https://golang.org/dl/go1.13.1.linux-amd64.tar.gz | sudo tar -C /usr/local -xz
 
 ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -39,7 +39,7 @@ RUN mkdir -p /toolchain/golang
 WORKDIR /toolchain/golang
 RUN sudo rm -rf /usr/local/go/
 
-// When updating Go version, update Dockerfile.ci, Dockerfile.base-build, and go.mod
+# When updating Go version, update Dockerfile.ci, Dockerfile.base-build, and go.mod
 RUN curl -L https://golang.org/dl/go1.13.1.linux-amd64.tar.gz | sudo tar -C /usr/local -xz
 
 ENV GOPATH /go

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ module open-match.dev/open-match
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Also update Dockerfile.base-build  when changing go version.
+// When updating Go version, update Dockerfile.ci, Dockerfile.base-build, and go.mod
 go 1.13.1
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,8 @@ module open-match.dev/open-match
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-go 1.12
+// Also update Dockerfile.base-build  when changing go version.
+go 1.13.1
 
 require (
 	cloud.google.com/go v0.40.0 // indirect


### PR DESCRIPTION
I had a problem just now where my local go test would pass, but docker files would fail to build.  My system had an old version of golang:latest cached, which failed to build properly due to missing a new method.  So instead pin the dockerfile to a specific verison.  This way builds will be more deterministic: If a new version of Go comes out, the new features won't work for anyone until this is updated, at which point everyone's local cache will be invalidated.