### PR TITLE
 Configure Open Match to improve scaling

### DIFF
--- a/install/helm/open-match/templates/_helpers.tpl
+++ b/install/helm/open-match/templates/_helpers.tpl
@@ -119,6 +119,6 @@ readinessProbe:
 
 {{- define "openmatch.HorizontalPodAutoscaler.spec.common" -}}
 minReplicas: 1
-maxReplicas: 10
+maxReplicas: 30
 targetCPUUtilizationPercentage: 50
 {{- end -}}

--- a/install/helm/open-match/templates/om-configmap.yaml
+++ b/install/helm/open-match/templates/om-configmap.yaml
@@ -90,7 +90,7 @@ data:
       passwordPath: {{ .Values.redis.secretMountPath }}/redis-password
 {{- end }}
       pool:
-        maxIdle: 3
+        maxIdle: 5000
         maxActive: 0
         idleTimeout: 60s
         healthCheckTimeout: 100ms

--- a/install/helm/open-match/values.yaml
+++ b/install/helm/open-match/values.yaml
@@ -47,7 +47,7 @@ swaggerui: &swaggerui
   hostName: om-swaggerui
   httpPort: 51500
   portType: ClusterIP
-  replicas: 3
+  replicas: 1
   image: openmatch-swaggerui
 mmlogic: &mmlogic
   hostName: om-mmlogic
@@ -116,6 +116,16 @@ redis:
     disableCommands: [] # don't disable 'FLUSH-' commands
   metrics:
     enabled: true
+  cluster:
+    slaveCount: 2
+  # Redis may require some changes in the kernel of the host machine to work as expected, 
+  # in particular increasing the somaxconn value and disabling transparent huge pages.
+  # TODO: disable THP - requires priviledged service account, blocked by current PSP setup.
+  # https://github.com/helm/charts/tree/master/stable/redis#host-kernel-settings
+  securityContext:
+    sysctls:
+    - name: net.core.somaxconn
+      value: "10000"
 
 ###############################################################################################################################
 #                               Open Match configurations for the subcharts


### PR DESCRIPTION
This commit:
1. Changed the maxReplica setting in HorizontalAutoScaler to 30. Otherwise even if we manually override the deployment replica, the actual pod number would still be capped at 10.
2. Changed the swaggerui replica to 1. We don't really need 3 replicas for the swaggerui service.
3. Specified Redis slaveCount explicitly and increase `somaxconn` in host kernel settings when initializing Redis.
4. Increased the max number of Redis idle connections to 5000 so that the redigo pool could reuse more existing idle connections.