### PR TITLE
Create a privileged service account for Redis and disable THP

### DIFF
--- a/install/helm/open-match/subcharts/open-match-test/templates/e2e-job.yaml
+++ b/install/helm/open-match/subcharts/open-match-test/templates/e2e-job.yaml
@@ -30,6 +30,8 @@ spec:
         component: e2e-job
         release: {{ .Release.Name }}
     spec:
+      serviceAccountName: open-match-test-service
+      automountServiceAccountToken: true
       containers:
       - image: "{{ coalesce .Values.global.image.registry .Values.image.registry }}/{{ .Values.e2etest.image }}:{{ coalesce .Values.global.image.tag .Values.image.tag }}"
         name: e2e-job

--- a/install/helm/open-match/templates/podsecuritypolicy.yaml
+++ b/install/helm/open-match/templates/podsecuritypolicy.yaml
@@ -14,10 +14,45 @@
 
 {{- if index .Values "open-match-core" "enabled" }}
 {{- if empty .Values.ci }}
+# om-redis-podsecuritypolicy is the least restricted PSP used to create privileged pods to disable THP in host kernel.
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: om-podsecuritypolicy
+  name: om-redis-podsecuritypolicy
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- include "openmatch.chartmeta" . | nindent 4 }}
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+spec:
+  privileged: true
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - '*'
+  volumes:
+  - '*'
+  hostNetwork: true
+  hostPorts:
+  # Redis
+  - min: 6379
+    max: 6379
+  - min: 9121
+    max: 9121
+  hostIPC: true
+  hostPID: true
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+---
+# om-core-podsecuritypolicy does not allow creating privileged pods and restrict binded pods to use the specified port ranges.
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: om-core-podsecuritypolicy
   namespace: {{ .Release.Namespace }}
   annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
   labels:
@@ -42,11 +77,6 @@ spec:
     max: 50510
   - min: 51500
     max: 51510
-  # Redis
-  - min: 6379
-    max: 6379
-  - min: 9121
-    max: 9121
   # Cassandra
   - min: 7000
     max: 7001

--- a/install/helm/open-match/templates/service-account.yaml
+++ b/install/helm/open-match/templates/service-account.yaml
@@ -25,6 +25,7 @@ metadata:
     release: {{ .Release.Name }}
 {{- end }}
 ---
+# Create a universal service account for open-match-core services.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -34,7 +35,19 @@ metadata:
   labels:
     app: {{ template "openmatch.name" . }}
     release: {{ .Release.Name }}
-automountServiceAccountToken: false
+automountServiceAccountToken: true
+---
+# Create a service account for open-match-test services.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: open-match-test-service
+  namespace: {{ .Release.Namespace }}
+  annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
+  labels:
+    app: {{ template "openmatch.name" . }}
+    release: {{ .Release.Name }}
+automountServiceAccountToken: true
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
@@ -46,16 +59,66 @@ metadata:
     app: {{ template "openmatch.name" . }}
     release: {{ .Release.Name }}
 rules:
+# Define om-service-role to use om-core-podsecuritypolicy
 - apiGroups:
   - extensions
   resources:
   - podsecuritypolicies
   resourceNames:
-  - om-podsecuritypolicy
+  - om-core-podsecuritypolicy
   verbs:
   - use
 ---
-# This applies psp/restricted to all authenticated users
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: om-test-role
+  namespace: {{ .Release.Namespace }}
+  annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
+  labels:
+    app: {{ template "openmatch.name" . }}
+    release: {{ .Release.Name }}
+rules:
+# Define om-test-role to use om-core-podsecuritypolicy
+- apiGroups:
+  - extensions
+  resources:
+  - podsecuritypolicies
+  resourceNames:
+  - om-core-podsecuritypolicy
+  verbs:
+  - use
+# Grant om-test-role get & list permission for k8s endpoints and pods resources
+# Required for e2e in-cluster testing.
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+---
+# This applies om-test-role to the open-match-test-service account under the release namespace. 
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: om-test-role-binding
+  namespace: {{ .Release.Namespace }}
+  annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
+  labels:
+    app: {{ template "openmatch.name" . }}
+    release: {{ .Release.Name }}
+subjects:
+- kind: ServiceAccount
+  name: open-match-test-service
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: om-test-role
+  apiGroup: rbac.authorization.k8s.io
+---
+# This applies om-service-role to the open-match unprivileged service account under the release namespace. 
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -66,11 +129,50 @@ metadata:
     app: {{ template "openmatch.name" . }}
     release: {{ .Release.Name }}
 subjects:
-- kind: Group
-  name: system:authenticated # All authenticated users
-  apiGroup: rbac.authorization.k8s.io
+- kind: ServiceAccount
+  name: {{ .Values.global.kubernetes.serviceAccount }}
+  namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
   name: om-service-role
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: om-redis-role
+  namespace: {{ .Release.Namespace }}
+  annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
+  labels:
+    app: {{ template "openmatch.name" . }}
+    release: {{ .Release.Name }}
+rules:
+# Define om-redis-role to use om-redis-podsecuritypolicy
+- apiGroups:
+  - extensions
+  resources:
+  - podsecuritypolicies
+  resourceNames:
+  - om-redis-podsecuritypolicy
+  verbs:
+  - use
+---
+# This applies om-redis role to the om-redis privileged service account under the release namespace.
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: om-redis-role-binding
+  namespace: {{ .Release.Namespace }}
+  annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
+  labels:
+    app: {{ template "openmatch.name" . }}
+    release: {{ .Release.Name }}
+subjects:
+- kind: ServiceAccount
+  name: {{ .Values.redis.serviceAccount.name }} # Redis service account
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: om-redis-role
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/install/helm/open-match/values.yaml
+++ b/install/helm/open-match/values.yaml
@@ -118,14 +118,22 @@ redis:
     enabled: true
   cluster:
     slaveCount: 2
-  # Redis may require some changes in the kernel of the host machine to work as expected, 
-  # in particular increasing the somaxconn value and disabling transparent huge pages.
-  # TODO: disable THP - requires priviledged service account, blocked by current PSP setup.
-  # https://github.com/helm/charts/tree/master/stable/redis#host-kernel-settings
-  securityContext:
-    sysctls:
-    - name: net.core.somaxconn
-      value: "10000"
+  serviceAccount:
+    create: true
+    name: open-match-redis-service
+  sysctlImage:
+    enabled: true
+    mountHostSys: true
+    # Redis may require some changes in the kernel of the host machine to work as expected, 
+    # in particular increasing the somaxconn value and disabling transparent huge pages.
+    # https://github.com/helm/charts/tree/master/stable/redis#host-kernel-settings
+    command:
+      - /bin/sh
+      - -c
+      - |-
+        install_packages procps
+        sysctl -w net.core.somaxconn=10000
+        echo never > /host-sys/kernel/mm/transparent_hugepage/enabled
 
 ###############################################################################################################################
 #                               Open Match configurations for the subcharts


### PR DESCRIPTION
THP could lead to potential memory leaks and introduce extra query latency to Redis.

This commit aims to disable Transparent Huge Pages (THP) support on the node that is running Redis. 

This requires having a privileged initContainer to access the `/sys` directory in the node. Our current PodSecurityPolicy doesn't allow creating privileged pods so I created a new PSP along with the role bindings just for Redis.