### PR TITLE
Added open-match namespace in yaml installation files 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -408,6 +408,7 @@ install/yaml/01-open-match-core.yaml: build/toolchain/bin/helm$(EXE_EXTENSION)
 		--set open-match-customize.enabled=false \
 		--set open-match-telemetry.enabled=false \
 		--set open-match-demo.enabled=false \
+		--set template=true \
 		install/helm/open-match > install/yaml/01-open-match-core.yaml
 
 install/yaml/02-open-match-demo.yaml: build/toolchain/bin/helm$(EXE_EXTENSION)
@@ -417,6 +418,7 @@ install/yaml/02-open-match-demo.yaml: build/toolchain/bin/helm$(EXE_EXTENSION)
 		--set global.image.tag=$(TAG) \
 		--set open-match-core.enabled=false \
 		--set open-match-telemetry.enabled=false \
+		--set template=true \
 		install/helm/open-match > install/yaml/02-open-match-demo.yaml
 
 install/yaml/03-prometheus-chart.yaml: build/toolchain/bin/helm$(EXE_EXTENSION)
@@ -428,6 +430,7 @@ install/yaml/03-prometheus-chart.yaml: build/toolchain/bin/helm$(EXE_EXTENSION)
 		--set open-match-demo.enabled=false \
 		--set open-match-core.enabled=false \
 		--set global.telemetry.prometheus.enabled=true \
+		--set template=true \
 		install/helm/open-match > install/yaml/03-prometheus-chart.yaml
 
 install/yaml/04-grafana-chart.yaml: build/toolchain/bin/helm$(EXE_EXTENSION)
@@ -439,6 +442,7 @@ install/yaml/04-grafana-chart.yaml: build/toolchain/bin/helm$(EXE_EXTENSION)
 		--set open-match-demo.enabled=false \
 		--set open-match-core.enabled=false \
 		--set global.telemetry.grafana.enabled=true \
+		--set template=true \
 		install/helm/open-match > install/yaml/04-grafana-chart.yaml
 
 install/yaml/05-jaeger-chart.yaml: build/toolchain/bin/helm$(EXE_EXTENSION)
@@ -450,6 +454,7 @@ install/yaml/05-jaeger-chart.yaml: build/toolchain/bin/helm$(EXE_EXTENSION)
 		--set open-match-demo.enabled=false \
 		--set open-match-core.enabled=false \
 		--set global.telemetry.jaeger.enabled=true \
+		--set template=true \
 		install/helm/open-match > install/yaml/05-jaeger-chart.yaml
 
 install/yaml/install.yaml: build/toolchain/bin/helm$(EXE_EXTENSION)
@@ -462,6 +467,7 @@ install/yaml/install.yaml: build/toolchain/bin/helm$(EXE_EXTENSION)
 		--set global.telemetry.jaeger.enabled=true \
 		--set global.telemetry.grafana.enabled=true \
 		--set global.telemetry.prometheus.enabled=true \
+		--set template=true \
 		install/helm/open-match > install/yaml/install.yaml
 
 set-redis-password:

--- a/Makefile
+++ b/Makefile
@@ -408,7 +408,7 @@ install/yaml/01-open-match-core.yaml: build/toolchain/bin/helm$(EXE_EXTENSION)
 		--set open-match-customize.enabled=false \
 		--set open-match-telemetry.enabled=false \
 		--set open-match-demo.enabled=false \
-		--set template=true \
+		--set usingHelmTemplate=true \
 		install/helm/open-match > install/yaml/01-open-match-core.yaml
 
 install/yaml/02-open-match-demo.yaml: build/toolchain/bin/helm$(EXE_EXTENSION)
@@ -418,7 +418,7 @@ install/yaml/02-open-match-demo.yaml: build/toolchain/bin/helm$(EXE_EXTENSION)
 		--set global.image.tag=$(TAG) \
 		--set open-match-core.enabled=false \
 		--set open-match-telemetry.enabled=false \
-		--set template=true \
+		--set usingHelmTemplate=true \
 		install/helm/open-match > install/yaml/02-open-match-demo.yaml
 
 install/yaml/03-prometheus-chart.yaml: build/toolchain/bin/helm$(EXE_EXTENSION)
@@ -430,7 +430,7 @@ install/yaml/03-prometheus-chart.yaml: build/toolchain/bin/helm$(EXE_EXTENSION)
 		--set open-match-demo.enabled=false \
 		--set open-match-core.enabled=false \
 		--set global.telemetry.prometheus.enabled=true \
-		--set template=true \
+		--set usingHelmTemplate=true \
 		install/helm/open-match > install/yaml/03-prometheus-chart.yaml
 
 install/yaml/04-grafana-chart.yaml: build/toolchain/bin/helm$(EXE_EXTENSION)
@@ -442,7 +442,7 @@ install/yaml/04-grafana-chart.yaml: build/toolchain/bin/helm$(EXE_EXTENSION)
 		--set open-match-demo.enabled=false \
 		--set open-match-core.enabled=false \
 		--set global.telemetry.grafana.enabled=true \
-		--set template=true \
+		--set usingHelmTemplate=true \
 		install/helm/open-match > install/yaml/04-grafana-chart.yaml
 
 install/yaml/05-jaeger-chart.yaml: build/toolchain/bin/helm$(EXE_EXTENSION)
@@ -454,7 +454,7 @@ install/yaml/05-jaeger-chart.yaml: build/toolchain/bin/helm$(EXE_EXTENSION)
 		--set open-match-demo.enabled=false \
 		--set open-match-core.enabled=false \
 		--set global.telemetry.jaeger.enabled=true \
-		--set template=true \
+		--set usingHelmTemplate=true \
 		install/helm/open-match > install/yaml/05-jaeger-chart.yaml
 
 install/yaml/install.yaml: build/toolchain/bin/helm$(EXE_EXTENSION)
@@ -467,7 +467,7 @@ install/yaml/install.yaml: build/toolchain/bin/helm$(EXE_EXTENSION)
 		--set global.telemetry.jaeger.enabled=true \
 		--set global.telemetry.grafana.enabled=true \
 		--set global.telemetry.prometheus.enabled=true \
-		--set template=true \
+		--set usingHelmTemplate=true \
 		install/helm/open-match > install/yaml/install.yaml
 
 set-redis-password:

--- a/install/helm/open-match/templates/service-account.yaml
+++ b/install/helm/open-match/templates/service-account.yaml
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 {{- if index .Values "open-match-core" "enabled" }}
-{{- if index .Values "template" }}
+# Include this namespace only when doing `helm template`.
+# helm 2 use namespace to manage its release so `helm install` with this namespace will be broken.
+{{- if index .Values "usingHelmTemplate" }}
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/install/helm/open-match/templates/service-account.yaml
+++ b/install/helm/open-match/templates/service-account.yaml
@@ -13,6 +13,16 @@
 # limitations under the License.
 
 {{- if index .Values "open-match-core" "enabled" }}
+{{- if index .Values "template" }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "openmatch.name" . }}
+    release: {{ .Release.Name }}
+{{- end }}
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
Auto-create open-match namespace when open-match-core is enabled. This can slightly improve the user experience by `kubectl apply -f 01-open-match-core.yaml -n open-match` directly without having to manually create the namespace.