### PR TITLE
Update tutorial READMEs with more concrete steps

### DIFF
--- a/tutorials/director/README.md
+++ b/tutorials/director/README.md
@@ -1,16 +1,22 @@
 This folder provides a minimal Dockerfile and k8s resource definition to build a sample director for Open Match tutorials.
 
+Run the command below to define a variable for your personal container registry in your current terminal session
+```
+# Example - replace open-match-public-images with your personal registry ID
+YOUR_PERSONAL_REGISTRY=gcr.io/open-match-public-images
+```
+
 To build your director image, run:
 ```
-docker build -t $(YOUR_PERSONAL_REGISTRY)/om-director .
+docker build -t $YOUR_PERSONAL_REGISTRY/om-director .
 ```
 
 To push your director image, run:
 ```
-docker push $(YOUR_PERSONAL_REGISTRY)/om-director
+docker push $YOUR_PERSONAL_REGISTRY/om-director
 ```
 
 To deploy your Docker image into your Kubernetes cluster, run:
 ```
-kubectl apply -f om-director.yaml
+sed "s|registry_placeholder|$YOUR_PERSONAL_REGISTRY|g" om-director.yaml | kubectl apply -f -
 ```

--- a/tutorials/director/README.md
+++ b/tutorials/director/README.md
@@ -2,21 +2,21 @@ This folder provides a minimal Dockerfile and k8s resource definition to build a
 
 Run the command below to define a variable for your personal container registry in your current terminal session
 ```
-# Example - replace open-match-public-images with your personal registry ID
-YOUR_PERSONAL_REGISTRY=gcr.io/open-match-public-images
+# Specify your Registry URL here.
+REGISTRY=[YOUR_REGISTRY_URL]
 ```
 
 To build your director image, run:
 ```
-docker build -t $YOUR_PERSONAL_REGISTRY/om-director .
+docker build -t $REGISTRY/om-director .
 ```
 
 To push your director image, run:
 ```
-docker push $YOUR_PERSONAL_REGISTRY/om-director
+docker push $REGISTRY/om-director
 ```
 
 To deploy your Docker image into your Kubernetes cluster, run:
 ```
-sed "s|registry_placeholder|$YOUR_PERSONAL_REGISTRY|g" om-director.yaml | kubectl apply -f -
+sed "s|registry_placeholder|$REGISTRY|g" om-director.yaml | kubectl apply -f -
 ```

--- a/tutorials/director/om-director.yaml
+++ b/tutorials/director/om-director.yaml
@@ -20,6 +20,6 @@ metadata:
 spec:
   containers:
   - name: om-director
-    image: "some public images"
+    image: registry_placeholder/om-director:latest
     imagePullPolicy: Always
   hostname: om-director

--- a/tutorials/evaluator/README.md
+++ b/tutorials/evaluator/README.md
@@ -2,21 +2,21 @@ This folder provides a minimal Dockerfile and k8s resource definition to build a
 
 Run the command below to define a variable for your personal container registry in your current terminal session
 ```
-# Example - replace open-match-public-images with your personal registry ID
-YOUR_PERSONAL_REGISTRY=gcr.io/open-match-public-images
+# Specify your Registry URL here.
+REGISTRY=[YOUR_REGISTRY_URL]
 ```
 
 To build your evaluator image, run:
 ```
-docker build -t $YOUR_PERSONAL_REGISTRY/om-evaluator .
+docker build -t $REGISTRY/om-evaluator .
 ```
 
 To push your evaluator image, run:
 ```
-docker push $YOUR_PERSONAL_REGISTRY/om-evaluator
+docker push $REGISTRY/om-evaluator
 ```
 
 To deploy your Docker image into your Kubernetes cluster, run:
 ```
-sed "s|registry_placeholder|$YOUR_PERSONAL_REGISTRY|g" om-evaluator.yaml | kubectl apply -f -
+sed "s|registry_placeholder|$REGISTRY|g" om-evaluator.yaml | kubectl apply -f -
 ```

--- a/tutorials/evaluator/README.md
+++ b/tutorials/evaluator/README.md
@@ -1,16 +1,22 @@
 This folder provides a minimal Dockerfile and k8s resource definition to build a sample evaluator for Open Match tutorials.
 
-To build your director image, run:
+Run the command below to define a variable for your personal container registry in your current terminal session
 ```
-docker build -t $(YOUR_PERSONAL_REGISTRY)/om-evaluator .
+# Example - replace open-match-public-images with your personal registry ID
+YOUR_PERSONAL_REGISTRY=gcr.io/open-match-public-images
 ```
 
-To push your director image, run:
+To build your evaluator image, run:
 ```
-docker push $(YOUR_PERSONAL_REGISTRY)/om-evaluator
+docker build -t $YOUR_PERSONAL_REGISTRY/om-evaluator .
+```
+
+To push your evaluator image, run:
+```
+docker push $YOUR_PERSONAL_REGISTRY/om-evaluator
 ```
 
 To deploy your Docker image into your Kubernetes cluster, run:
 ```
-kubectl apply -f om-evaluator.yaml
+sed "s|registry_placeholder|$YOUR_PERSONAL_REGISTRY|g" om-evaluator.yaml | kubectl apply -f -
 ```

--- a/tutorials/evaluator/om-evaluator.yaml
+++ b/tutorials/evaluator/om-evaluator.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   containers:
   - name: om-evaluator
-    image: "gcr.io/open-match-build/openmatch-evaluator-go-simple"
+    image: registry_placeholder/om-evaluator:latest
     imagePullPolicy: Always
     ports:
     - name: grpc

--- a/tutorials/gamefrontend/README.md
+++ b/tutorials/gamefrontend/README.md
@@ -1,16 +1,22 @@
 This folder provides a minimal Dockerfile and k8s resource definition to build a sample game-frontend for Open Match tutorials.
 
-To build your director image, run:
+Run the command below to define a variable for your personal container registry in your current terminal session
 ```
-docker build -t $(YOUR_PERSONAL_REGISTRY)/om-game-frontend .
+# Example - replace open-match-public-images with your personal registry ID
+YOUR_PERSONAL_REGISTRY=gcr.io/open-match-public-images
 ```
 
-To push your director image, run:
+To build your game-frontend image, run:
 ```
-docker push $(YOUR_PERSONAL_REGISTRY)/om-game-frontend
+docker build -t $YOUR_PERSONAL_REGISTRY/om-game-frontend .
+```
+
+To push your game-frontend image, run:
+```
+docker push $YOUR_PERSONAL_REGISTRY/om-game-frontend
 ```
 
 To deploy your Docker image into your Kubernetes cluster, run:
 ```
-kubectl apply -f om-game-frontend.yaml
+sed "s|registry_placeholder|$YOUR_PERSONAL_REGISTRY|g" om-game-frontend.yaml | kubectl apply -f -
 ```

--- a/tutorials/gamefrontend/README.md
+++ b/tutorials/gamefrontend/README.md
@@ -2,21 +2,21 @@ This folder provides a minimal Dockerfile and k8s resource definition to build a
 
 Run the command below to define a variable for your personal container registry in your current terminal session
 ```
-# Example - replace open-match-public-images with your personal registry ID
-YOUR_PERSONAL_REGISTRY=gcr.io/open-match-public-images
+# Specify your Registry URL here.
+REGISTRY=[YOUR_REGISTRY_URL]
 ```
 
 To build your game-frontend image, run:
 ```
-docker build -t $YOUR_PERSONAL_REGISTRY/om-game-frontend .
+docker build -t $REGISTRY/om-game-frontend .
 ```
 
 To push your game-frontend image, run:
 ```
-docker push $YOUR_PERSONAL_REGISTRY/om-game-frontend
+docker push $REGISTRY/om-game-frontend
 ```
 
 To deploy your Docker image into your Kubernetes cluster, run:
 ```
-sed "s|registry_placeholder|$YOUR_PERSONAL_REGISTRY|g" om-game-frontend.yaml | kubectl apply -f -
+sed "s|registry_placeholder|$REGISTRY|g" om-game-frontend.yaml | kubectl apply -f -
 ```

--- a/tutorials/gamefrontend/om-game-frontend.yaml
+++ b/tutorials/gamefrontend/om-game-frontend.yaml
@@ -20,6 +20,6 @@ metadata:
 spec:
   containers:
   - name: om-game-frontend
-    image: "some public images"
+    image: registry_placeholder/om-game-frontend:latest
     imagePullPolicy: Always
   hostname: om-game-frontend

--- a/tutorials/k8s-resources/matchmaker.yaml
+++ b/tutorials/k8s-resources/matchmaker.yaml
@@ -24,7 +24,7 @@ metadata:
 spec:
   containers:
   - name: om-director
-    image: "some public images"
+    image: registry_placeholder/om-director:latest
     imagePullPolicy: Always
   hostname: om-director
 ---
@@ -36,7 +36,7 @@ metadata:
 spec:
   containers:
   - name: om-game-frontend
-    image: "some public images"
+    image: registry_placeholder/om-game-frontend:latest
     imagePullPolicy: Always
   hostname: om-game-frontend
 ---
@@ -48,7 +48,7 @@ metadata:
 spec:
   containers:
   - name: om-evaluator
-    image: "gcr.io/open-match-build/openmatch-evaluator-go-simple"
+    image: registry_placeholder/om-evaluator:latest
     imagePullPolicy: Always
     ports:
     - name: grpc
@@ -65,7 +65,7 @@ metadata:
 spec:
   containers:
   - name: om-function
-    image: "gcr.io/open-match-build/openmatch-mmf-go-soloduel"
+    image: registry_placeholder/om-function:latest
     imagePullPolicy: Always
     ports:
     - name: grpc

--- a/tutorials/matchfunction/README.md
+++ b/tutorials/matchfunction/README.md
@@ -1,16 +1,22 @@
 This folder provides a minimal Dockerfile and k8s resource definition to build a sample match function for Open Match tutorials.
 
-To build your director image, run:
+Run the command below to define a variable for your personal container registry in your current terminal session
 ```
-docker build -t $(YOUR_PERSONAL_REGISTRY)/om-function .
+# Example - replace open-match-public-images with your personal registry ID
+YOUR_PERSONAL_REGISTRY=gcr.io/open-match-public-images
 ```
 
-To push your director image, run:
+To build your match function image, run:
 ```
-docker push $(YOUR_PERSONAL_REGISTRY)/om-function
+docker build -t $YOUR_PERSONAL_REGISTRY/om-function .
+```
+
+To push your match function image, run:
+```
+docker push $YOUR_PERSONAL_REGISTRY/om-function
 ```
 
 To deploy your Docker image into your Kubernetes cluster, run:
 ```
-kubectl apply -f om-function.yaml
+sed "s|registry_placeholder|$YOUR_PERSONAL_REGISTRY|g" om-function.yaml | kubectl apply -f -
 ```

--- a/tutorials/matchfunction/README.md
+++ b/tutorials/matchfunction/README.md
@@ -2,21 +2,21 @@ This folder provides a minimal Dockerfile and k8s resource definition to build a
 
 Run the command below to define a variable for your personal container registry in your current terminal session
 ```
-# Example - replace open-match-public-images with your personal registry ID
-YOUR_PERSONAL_REGISTRY=gcr.io/open-match-public-images
+# Specify your Registry URL here.
+REGISTRY=[YOUR_REGISTRY_URL]
 ```
 
 To build your match function image, run:
 ```
-docker build -t $YOUR_PERSONAL_REGISTRY/om-function .
+docker build -t $REGISTRY/om-function .
 ```
 
 To push your match function image, run:
 ```
-docker push $YOUR_PERSONAL_REGISTRY/om-function
+docker push $REGISTRY/om-function
 ```
 
 To deploy your Docker image into your Kubernetes cluster, run:
 ```
-sed "s|registry_placeholder|$YOUR_PERSONAL_REGISTRY|g" om-function.yaml | kubectl apply -f -
+sed "s|registry_placeholder|$REGISTRY|g" om-function.yaml | kubectl apply -f -
 ```

--- a/tutorials/matchfunction/om-function.yaml
+++ b/tutorials/matchfunction/om-function.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   containers:
   - name: om-function
-    image: "gcr.io/open-match-build/openmatch-mmf-go-soloduel"
+    image: registry_placeholder/om-function:latest
     imagePullPolicy: Always
     ports:
     - name: grpc


### PR DESCRIPTION
This commit allows users to copy/paste the commands in the README to build, push, and deploy Open Match tutorial examples.