### PR TITLE
Update resource yamls to use k8s v1.16 API

### DIFF
--- a/install/helm/open-match/subcharts/open-match-customize/templates/evaluator.yaml
+++ b/install/helm/open-match/subcharts/open-match-customize/templates/evaluator.yaml
@@ -48,12 +48,12 @@ metadata:
   annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
 spec:
   scaleTargetRef:
-    apiVersion: extensions/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     name: {{ .Values.evaluator.hostName }}
   {{- include "openmatch.HorizontalPodAutoscaler.spec.common" . | nindent 2 }}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.evaluator.hostName }}

--- a/install/helm/open-match/subcharts/open-match-customize/templates/matchfunctions.yaml
+++ b/install/helm/open-match/subcharts/open-match-customize/templates/matchfunctions.yaml
@@ -48,12 +48,12 @@ metadata:
   annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
 spec:
   scaleTargetRef:
-    apiVersion: extensions/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     name: {{ .Values.function.hostName }}
   {{- include "openmatch.HorizontalPodAutoscaler.spec.common" . | nindent 2 }}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.function.hostName }}

--- a/install/helm/open-match/subcharts/open-match-demo/templates/demo.yaml
+++ b/install/helm/open-match/subcharts/open-match-demo/templates/demo.yaml
@@ -32,7 +32,7 @@ spec:
     protocol: TCP
     port: {{ .Values.demo.httpPort }}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.demo.hostName }}

--- a/install/helm/open-match/subcharts/open-match-scale/templates/scale-backend.yaml
+++ b/install/helm/open-match/subcharts/open-match-scale/templates/scale-backend.yaml
@@ -31,7 +31,7 @@ spec:
     protocol: TCP
     port: {{ .Values.scaleBackend.httpPort }}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.scaleBackend.hostName }}

--- a/install/helm/open-match/subcharts/open-match-scale/templates/scale-frontend.yaml
+++ b/install/helm/open-match/subcharts/open-match-scale/templates/scale-frontend.yaml
@@ -31,7 +31,7 @@ spec:
     protocol: TCP
     port: {{ .Values.scaleFrontend.httpPort }}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.scaleFrontend.hostName }}

--- a/install/helm/open-match/subcharts/open-match-test/templates/stress-master.yaml
+++ b/install/helm/open-match/subcharts/open-match-test/templates/stress-master.yaml
@@ -42,7 +42,7 @@ spec:
     targetPort: loc-master-p2
     protocol: TCP
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}

--- a/install/helm/open-match/subcharts/open-match-test/templates/stress-slaves.yaml
+++ b/install/helm/open-match/subcharts/open-match-test/templates/stress-slaves.yaml
@@ -14,7 +14,7 @@
 
 {{- if .Values.stresstest.enabled }}
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: {{ .Values.stresstest.slavesName }}
   namespace: {{ .Release.Namespace }}

--- a/install/helm/open-match/templates/backend.yaml
+++ b/install/helm/open-match/templates/backend.yaml
@@ -48,12 +48,12 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   scaleTargetRef:
-    apiVersion: extensions/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     name: {{ .Values.backend.hostName }}
   {{- include "openmatch.HorizontalPodAutoscaler.spec.common" . | nindent 2 }}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.backend.hostName }}

--- a/install/helm/open-match/templates/frontend.yaml
+++ b/install/helm/open-match/templates/frontend.yaml
@@ -48,12 +48,12 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   scaleTargetRef:
-    apiVersion: extensions/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     name: {{ .Values.frontend.hostName }}
   {{- include "openmatch.HorizontalPodAutoscaler.spec.common" . | nindent 2 }}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.frontend.hostName }}

--- a/install/helm/open-match/templates/mmlogic.yaml
+++ b/install/helm/open-match/templates/mmlogic.yaml
@@ -48,12 +48,12 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   scaleTargetRef:
-    apiVersion: extensions/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     name: {{ .Values.mmlogic.hostName }}
   {{- include "openmatch.HorizontalPodAutoscaler.spec.common" . | nindent 2 }}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.mmlogic.hostName }}

--- a/install/helm/open-match/templates/podsecuritypolicy.yaml
+++ b/install/helm/open-match/templates/podsecuritypolicy.yaml
@@ -14,7 +14,7 @@
 
 {{- if index .Values "open-match-core" "enabled" }}
 {{- if empty .Values.ci }}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: om-podsecuritypolicy

--- a/install/helm/open-match/templates/swaggerui.yaml
+++ b/install/helm/open-match/templates/swaggerui.yaml
@@ -33,7 +33,7 @@ spec:
     protocol: TCP
     port: {{ .Values.swaggerui.httpPort }}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.swaggerui.hostName }}

--- a/install/helm/open-match/templates/synchronizer.yaml
+++ b/install/helm/open-match/templates/synchronizer.yaml
@@ -37,7 +37,7 @@ spec:
     protocol: TCP
     port: {{ .Values.synchronizer.httpPort }}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Values.synchronizer.hostName }}


### PR DESCRIPTION
The k8s v1.16 release will stop serving the some deprecated API versions in favor of newer and more stable API versions, this commit: 

Migrate PodSecurityPolicy to use the policy/v1beta1 API, available since v1.10.
Migrate Deployment to use the apps/v1 API, available since v1.9.