### PR TITLE
Initialize go modules and change Dockerfiles accordingly for tutorials

### DIFF
--- a/tutorials/director/Dockerfile
+++ b/tutorials/director/Dockerfile
@@ -14,6 +14,7 @@
 
 FROM golang:alpine as go
 WORKDIR /app
+ENV GO111MODULE=on
 
 COPY . .
 RUN go build -o main .

--- a/tutorials/director/go.mod
+++ b/tutorials/director/go.mod
@@ -1,0 +1,3 @@
+module open-match.dev/open-match/tutorials/director
+
+go 1.13

--- a/tutorials/evaluator/Dockerfile
+++ b/tutorials/evaluator/Dockerfile
@@ -14,6 +14,7 @@
 
 FROM golang:alpine as go
 WORKDIR /app
+ENV GO111MODULE=on
 
 COPY . .
 RUN go build -o main .

--- a/tutorials/evaluator/go.mod
+++ b/tutorials/evaluator/go.mod
@@ -1,0 +1,3 @@
+module open-match.dev/open-match/tutorials/evaluator
+
+go 1.13

--- a/tutorials/gamefrontend/Dockerfile
+++ b/tutorials/gamefrontend/Dockerfile
@@ -14,6 +14,7 @@
 
 FROM golang:alpine as go
 WORKDIR /app
+ENV GO111MODULE=on
 
 COPY . .
 RUN go build -o main .

--- a/tutorials/gamefrontend/go.mod
+++ b/tutorials/gamefrontend/go.mod
@@ -1,0 +1,3 @@
+module open-match.dev/open-match/tutorials/gamefrontend
+
+go 1.13

--- a/tutorials/matchfunction/Dockerfile
+++ b/tutorials/matchfunction/Dockerfile
@@ -14,6 +14,7 @@
 
 FROM golang:alpine as go
 WORKDIR /app
+ENV GO111MODULE=on
 
 COPY . .
 RUN go build -o main .

--- a/tutorials/matchfunction/go.mod
+++ b/tutorials/matchfunction/go.mod
@@ -1,0 +1,3 @@
+module open-match.dev/open-match/tutorials/matchfunction
+
+go 1.13


### PR DESCRIPTION
This allows us to isolate the dependencies requirements on tutorials and open-match.dev. Users don't have to download open-match dependencies in order to use the tutorial codes.