### PR TITLE
Update helm templates to follow k8s spec rules

### DIFF
--- a/install/helm/open-match/subcharts/open-match-test/templates/e2e-job.yaml
+++ b/install/helm/open-match/subcharts/open-match-test/templates/e2e-job.yaml
@@ -9,9 +9,6 @@ metadata:
     component: e2e-job
     release: {{ .Release.Name }}
 spec:
-  selector:
-    app: {{ template "openmatch.name" . }}
-    component: e2e-job
   # Specifies the number of retries before marking this job failed. Defaults to 6 if not specified.
   backoffLimit: 3
   # Specifies the desired number of successfully finished pods the job should be run with.

--- a/install/helm/open-match/templates/service-account.yaml
+++ b/install/helm/open-match/templates/service-account.yaml
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 {{- if index .Values "open-match-core" "enabled" }}
+{{- if index .Values "usingHelmTemplate" }}
 # Include this namespace only when doing `helm template`.
 # helm 2 use namespace to manage its release so `helm install` with this namespace will be broken.
-{{- if index .Values "usingHelmTemplate" }}
 apiVersion: v1
 kind: Namespace
 metadata:


### PR DESCRIPTION
Generally speaking it is a bad practice to include selector for a k8s pod and helm3 will perform a lint check against this rule. This commit removes selector for the job definition and move the comment of the namespace definition to a more appropriate scope.