### PR TITLE
Config change first step

### DIFF
--- a/install/helm/open-match/subcharts/open-match-customize/values.yaml
+++ b/install/helm/open-match/subcharts/open-match-customize/values.yaml
@@ -32,6 +32,10 @@ image:
   pullPolicy: Always
 
 configs:
+  # TODO: Remove this bit after deprecating the harness dependency on configmap
+  om-configmap-default:
+    volumeName: om-config-volume-default
+    mountPath: /app/config/default
   customize-configmap:
-    mountPath: /app/config/om
     volumeName: customize-config-volume
+    mountPath: /app/config/override

--- a/install/helm/open-match/templates/om-configmap-default.yaml
+++ b/install/helm/open-match/templates/om-configmap-default.yaml
@@ -16,7 +16,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: om-configmap
+  name: om-configmap-default
   namespace: {{ .Release.Namespace }}
   annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
   labels:
@@ -24,7 +24,7 @@ metadata:
     component: config
     release: {{ .Release.Name }}
 data:
-  matchmaker_config.yaml: |-
+  matchmaker_config_default.yaml: |-
     logging:
       level: debug
       {{- if .Values.global.telemetry.stackdriver.enabled }}
@@ -97,4 +97,33 @@ data:
       ignoreLists:
         ttl: {{ .Values.redis.ignoreLists.ttl }}
       expiration: 43200
+
+    telemetry:
+      zpages:
+        enable: "{{ .Values.global.telemetry.zpages.enabled }}"
+      jaeger:
+        enable: "{{ .Values.global.telemetry.jaeger.enabled }}"
+        agentEndpoint: "{{ .Values.global.telemetry.jaeger.agentEndpoint }}"
+        collectorEndpoint: "{{ .Values.global.telemetry.jaeger.collectorEndpoint }}"
+      prometheus:
+        enable: "{{ .Values.global.telemetry.prometheus.enabled }}"
+        endpoint: "{{ .Values.global.telemetry.prometheus.endpoint }}"
+        serviceDiscovery: "{{ .Values.global.telemetry.prometheus.serviceDiscovery }}"
+      stackdriver:
+        enable: "{{ .Values.global.telemetry.stackdriver.enabled }}"
+        gcpProjectId: "{{ .Values.global.gcpProjectId }}"
+        metricPrefix: "{{ .Values.global.telemetry.stackdriver.metricPrefix }}"
+      zipkin:
+        enable: "{{ .Values.global.telemetry.zipkin.enabled }}"
+        endpoint: "{{ .Values.global.telemetry.zipkin.endpoint }}"
+        reporterEndpoint: "{{ .Values.global.telemetry.zipkin.reporterEndpoint }}"
+      reportingPeriod: "{{ .Values.global.telemetry.reportingPeriod }}"
+{{- if .Values.global.tls.enabled }}
+    api:
+      tls:
+        trustedCertificatePath: "{{.Values.global.tls.rootca.mountPath}}/public.cert"
+        certificatefile: "{{.Values.global.tls.server.mountPath}}/public.cert"
+        privatekey: "{{.Values.global.tls.server.mountPath}}/private.key"
+        rootcertificatefile: "{{.Values.global.tls.rootca.mountPath}}/public.cert"
+{{- end -}}
 {{- end }}

--- a/install/helm/open-match/templates/om-configmap-override.yaml
+++ b/install/helm/open-match/templates/om-configmap-override.yaml
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+{{- if index .Values "open-match-core" "enabled" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: customize-configmap
+  name: om-configmap-override
   namespace: {{ .Release.Namespace }}
   annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
   labels:
@@ -23,18 +24,10 @@ metadata:
     component: config
     release: {{ .Release.Name }}
 data:
+  # TODO: Make this override configmap optional.
+  # Kubernetes doesn't allow having a configmap with empty key.
+  # Using logging setting at here as a placeholder.
   matchmaker_config_override.yaml: |-
-    api:
-      mmlogic:
-        hostname: "{{ .Values.mmlogic.hostName }}"
-        grpcport: "{{ .Values.mmlogic.grpcPort }}"
-      
-      functions:
-        hostname: "{{ .Values.function.hostName }}"
-        grpcport: "{{ .Values.function.grpcPort }}"
-        httpport: "{{ .Values.function.httpPort }}"
-      
-      evaluator:
-        hostname: "{{ .Values.evaluator.hostName }}"
-        grpcport: "{{ .Values.evaluator.grpcPort }}"
-        httpport: "{{ .Values.evaluator.httpPort }}"
+    logging:
+      level: debug
+{{- end }}}

--- a/install/helm/open-match/values.yaml
+++ b/install/helm/open-match/values.yaml
@@ -97,9 +97,12 @@ image:
 # Specifies the location and name of the Open Match application-level config volumes.
   # Used in template: `openmatch.volumemounts.configs` and `openmatch.volumes.configs` under `templates/_helpers.tpl` file.
 configs:
-  om-configmap:
-    volumeName: om-config-volume
-    mountPath: /app/config/om
+  om-configmap-default:
+    volumeName: om-config-volume-default
+    mountPath: /app/config/default
+  om-configmap-override:
+    volumeName: om-config-volume-override
+    mountPath: /app/config/override
 
 # Override Redis settings
 # https://hub.helm.sh/charts/stable/redis


### PR DESCRIPTION
This commit is the first step of the Open Match config changes. The goal of the config change is to provide a wrapper for Open Match users such that they don't need to start from a verbose config file to draft their OM settings. The internal config library now requires having a `/app/config/default/matchmaker_config_default.yaml` and `/app/config/override/matchmaker_config_override.yaml` to startup. It will first read from the default yaml, use it's bindings as the default variables and applies the overrides to the config.