### PR TITLE
Remane bindStackdriver to bindStackdriverMetrics

### DIFF
--- a/install/helm/open-match/templates/om-configmap-default.yaml
+++ b/install/helm/open-match/templates/om-configmap-default.yaml
@@ -27,7 +27,7 @@ data:
   matchmaker_config_default.yaml: |-
     logging:
       level: debug
-      {{- if .Values.global.telemetry.stackdriver.enabled }}
+      {{- if .Values.global.telemetry.stackdriverMetrics.enabled }}
       format: stackdriver
       {{- else }}
       format: text
@@ -107,10 +107,10 @@ data:
         enable: "{{ .Values.global.telemetry.prometheus.enabled }}"
         endpoint: "{{ .Values.global.telemetry.prometheus.endpoint }}"
         serviceDiscovery: "{{ .Values.global.telemetry.prometheus.serviceDiscovery }}"
-      stackdriver:
-        enable: "{{ .Values.global.telemetry.stackdriver.enabled }}"
+      stackdriverMetrics:
+        enable: "{{ .Values.global.telemetry.stackdriverMetrics.enabled }}"
         gcpProjectId: "{{ .Values.global.gcpProjectId }}"
-        metricPrefix: "{{ .Values.global.telemetry.stackdriver.metricPrefix }}"
+        prefix: "{{ .Values.global.telemetry.stackdriverMetrics.prefix }}"
       zipkin:
         enable: "{{ .Values.global.telemetry.zipkin.enabled }}"
         endpoint: "{{ .Values.global.telemetry.zipkin.endpoint }}"

--- a/install/helm/open-match/values.yaml
+++ b/install/helm/open-match/values.yaml
@@ -158,7 +158,7 @@ redis:
 open-match-core:
   enabled: true
 
-# Contols if users need to install the demo in Open Match.
+# Controls if users need to install the demo in Open Match.
 open-match-demo:
   # Switch the value between true/false to turn on/off this subchart
   enabled: true
@@ -166,18 +166,17 @@ open-match-demo:
   frontend: *frontend
   backend: *backend
 
-# Contols if users need to install scale testing setup for Open Match.
+# Controls if users need to install scale testing setup for Open Match.
 open-match-scale:
   # Switch the value between true/false to turn on/off this subchart
   enabled: false
   frontend: *frontend
   backend: *backend
 
-# Contols if users need to install the monitoring tools in Open Match.
-# By default, the stackdriver is enabled such that users are able to see the logs in a GKE cluster.
+# Controls if users need to install the monitoring tools in Open Match.
 open-match-telemetry:
   # Switch the value between true/false to turn on/off this subchart
-  enabled: true
+  enabled: false
 
 # Controls if users need to install their own MMFs and Evaluator in Open Match.
 open-match-customize:
@@ -247,10 +246,9 @@ global:
       enabled: false
       endpoint: "/metrics"
       serviceDiscovery: true
-    # By default, the stackdriver is enabled such that users are able to see the logs in a GKE cluster.
-    stackdriver:
-      enabled: true
-      metricPrefix: "open_match"
+    stackdriverMetrics:
+      enabled: false
+      prefix: "open_match"
     zipkin:
       enabled: false
       endpoint: "/zipkin"

--- a/internal/telemetry/public.go
+++ b/internal/telemetry/public.go
@@ -46,7 +46,7 @@ func Setup(mux *http.ServeMux, cfg config.View) func() {
 
 	bindJaeger(cfg)
 	bindPrometheus(mux, cfg)
-	mc.AddCloseFunc(bindStackDriver(cfg))
+	mc.AddCloseFunc(bindStackDriverMetrics(cfg))
 	mc.AddCloseWithErrorFunc(bindOpenCensusAgent(cfg))
 	bindZipkin(cfg)
 	bindZpages(mux, cfg)

--- a/internal/telemetry/stackdriver.go
+++ b/internal/telemetry/stackdriver.go
@@ -22,13 +22,13 @@ import (
 	"open-match.dev/open-match/internal/config"
 )
 
-func bindStackDriver(cfg config.View) func() {
-	if !cfg.GetBool("telemetry.stackdriver.enable") {
+func bindStackDriverMetrics(cfg config.View) func() {
+	if !cfg.GetBool("telemetry.stackdriverMetrics.enable") {
 		logger.Info("StackDriver Metrics: Disabled")
 		return func() {}
 	}
-	gcpProjectID := cfg.GetString("telemetry.stackdriver.gcpProjectId")
-	metricPrefix := cfg.GetString("telemetry.stackdriver.metricPrefix")
+	gcpProjectID := cfg.GetString("telemetry.stackdriverMetrics.gcpProjectId")
+	metricPrefix := cfg.GetString("telemetry.stackdriverMetrics.prefix")
 	sd, err := stackdriver.NewExporter(stackdriver.Options{
 		ProjectID: gcpProjectID,
 		// MetricPrefix helps uniquely identify your metrics.


### PR DESCRIPTION
This commit renames `bindStackdriver` to `bindStackdriverMetrics` and turn off stackdriver integration by default. It also change the config names accordingly in `value.yaml` file. Previous comments about the stackdriver integration is off. What we defined in Open Match wouldn't affect the actual logging behavior in GKE, disabling it only affects the stackdriver's metrics/tracing functionalities.