### PR TITLE
Remove k8s probes in example mmfs and evaluator

### DIFF
--- a/install/helm/open-match/subcharts/open-match-customize/templates/evaluator.yaml
+++ b/install/helm/open-match/subcharts/open-match-customize/templates/evaluator.yaml
@@ -95,4 +95,3 @@ spec:
         - name: http
           containerPort: {{ .Values.evaluator.httpPort }}
         {{- include "openmatch.container.common" . | nindent 8 }}
-        {{- include "kubernetes.probe" (dict "port" .Values.evaluator.httpPort "isHTTPS" .Values.global.tls.enabled) | nindent 8 }}

--- a/install/helm/open-match/subcharts/open-match-customize/templates/matchfunctions.yaml
+++ b/install/helm/open-match/subcharts/open-match-customize/templates/matchfunctions.yaml
@@ -96,4 +96,3 @@ spec:
         - name: http
           containerPort: {{ .Values.function.httpPort }}
         {{- include "openmatch.container.common" . | nindent 8 }}
-        {{- include "kubernetes.probe" (dict "port" .Values.function.httpPort "isHTTPS" .Values.global.tls.enabled) | nindent 8 }}


### PR DESCRIPTION
After the harness rewrite in v0.8, we decides to stop using the internal server package for the MMF and Evaluator harness. Since the new serve function under `examples/functions/rosterbased/mmf/server.go` does not contain health check handler anymore, I started to seeing it falls into CrashLoopBackOff status because of the registered k8s probes. This commit removed the k8s probes until we come up with a better story for the harness.