### PR TITLE
Optimize deployment workflow

### DIFF
--- a/install/helm/open-match/templates/podsecuritypolicy.yaml
+++ b/install/helm/open-match/templates/podsecuritypolicy.yaml
@@ -23,6 +23,9 @@ metadata:
   annotations:
     {{- include "openmatch.chartmeta" . | nindent 4 }}
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+  labels:
+    app: {{ template "openmatch.name" . }}
+    release: {{ .Release.Name }}
 spec:
   privileged: true
   allowPrivilegeEscalation: true


### PR DESCRIPTION
When `helm upgrade` failed, helm won't clean up all of the deployed resources properly. The resources mentioned above which are not namespace scoped will be leaked and prevent us from running `install-chart` again. This commit added a `kubectl delete` operation in `make delete-chart` to force delete the PodSecurityPolicy, ClusterRole, and ClusterRolebindings from the cluster.

Also fixed a Makefile target when deploying scale chart.