### PR TITLE
Fix scale test based on the config changes

### DIFF
--- a/install/helm/open-match/subcharts/open-match-scale/templates/scale-configmap.yaml
+++ b/install/helm/open-match/subcharts/open-match-scale/templates/scale-configmap.yaml
@@ -23,14 +23,7 @@ metadata:
     component: config
     release: {{ .Release.Name }}
 data:
-  matchmaker_config.yaml: |-
-    api:
-      frontend:
-        hostname: "{{ .Values.frontend.hostName }}"
-        grpcport: "{{ .Values.frontend.grpcPort }}"
-      backend:
-        hostname: "{{ .Values.backend.hostName }}"
-        grpcport: "{{ .Values.backend.grpcPort }}"
+  matchmaker_config_override.yaml: |-
     testConfig:
       profile: "{{ .Values.testConfig.profile }}"
       concurrentCreates: "{{ .Values.testConfig.concurrentCreates }}"

--- a/install/helm/open-match/subcharts/open-match-scale/values.yaml
+++ b/install/helm/open-match/subcharts/open-match-scale/values.yaml
@@ -25,9 +25,12 @@ scaleBackend:
   image: openmatch-scale-backend
 
 configs:
+  om-configmap-default:
+    volumeName: om-config-volume-default
+    mountPath: /app/config/default
   scale-configmap:
-    mountPath: /app/config/om
     volumeName: scale-config-volume
+    mountPath: /app/config/override
 
 testConfig:
   profile: greedy


### PR DESCRIPTION
This commit updated the scale test helm chart to make it align with the latest config changes.