### PR TITLE
Modify statestore API to improve context propagation

### DIFF
--- a/internal/app/backend/backend_service.go
+++ b/internal/app/backend/backend_service.go
@@ -281,13 +281,13 @@ func (s *backendService) AssignTickets(ctx context.Context, req *pb.AssignTicket
 }
 
 func doAssignTickets(ctx context.Context, req *pb.AssignTicketsRequest, store statestore.Service) error {
-	err := store.UpdateAssignments(ctx, req.GetTicketIds(), req.GetAssignment())
+	ctx, err := store.UpdateAssignments(ctx, req.GetTicketIds(), req.GetAssignment())
 	if err != nil {
 		logger.WithError(err).Error("failed to update assignments")
 		return err
 	}
 	for _, id := range req.GetTicketIds() {
-		err = store.DeindexTicket(ctx, id)
+		ctx, err = store.DeindexTicket(ctx, id)
 		// Try to deindex all input tickets. Log without returning an error if the deindexing operation failed.
 		// TODO: consider retry the index operation
 		if err != nil {
@@ -295,7 +295,7 @@ func doAssignTickets(ctx context.Context, req *pb.AssignTicketsRequest, store st
 		}
 	}
 
-	if err = store.DeleteTicketsFromIgnoreList(ctx, req.GetTicketIds()); err != nil {
+	if _, err = store.DeleteTicketsFromIgnoreList(ctx, req.GetTicketIds()); err != nil {
 		logger.WithFields(logrus.Fields{
 			"ticket_ids": req.GetTicketIds(),
 		}).Error(err)

--- a/internal/app/backend/backend_service_test.go
+++ b/internal/app/backend/backend_service_test.go
@@ -238,7 +238,7 @@ func TestDoAssignTickets(t *testing.T) {
 				pool := &pb.Pool{
 					DoubleRangeFilters: []*pb.DoubleRangeFilter{{DoubleArg: fakeProperty, Min: 0, Max: 3}},
 				}
-				err := store.FilterTickets(ctx, pool, 10, func(filterTickets []*pb.Ticket) error {
+				_, err := store.FilterTickets(ctx, pool, 10, func(filterTickets []*pb.Ticket) error {
 					wantFilteredTickets = filterTickets
 					return nil
 				})
@@ -273,7 +273,7 @@ func TestDoAssignTickets(t *testing.T) {
 
 			if err == nil {
 				for _, id := range test.req.GetTicketIds() {
-					ticket, err := store.GetTicket(ctx, id)
+					_, ticket, err := store.GetTicket(ctx, id)
 					assert.Nil(t, err)
 					assert.Equal(t, test.wantAssignment, ticket.GetAssignment())
 				}

--- a/internal/app/frontend/frontend_service_test.go
+++ b/internal/app/frontend/frontend_service_test.go
@@ -117,12 +117,14 @@ func TestDoGetAssignments(t *testing.T) {
 		{
 			description: "expect two assignment reads from preAction writes and fail in grpc aborted code",
 			preAction: func(ctx context.Context, t *testing.T, store statestore.Service, wantAssignments []*pb.Assignment, wg *sync.WaitGroup) {
-				assert.Nil(t, store.CreateTicket(ctx, testTicket))
+				_, err := store.CreateTicket(ctx, testTicket)
+				assert.Nil(t, err)
 
 				go func(wg *sync.WaitGroup) {
 					for i := 0; i < len(wantAssignments); i++ {
 						time.Sleep(50 * time.Millisecond)
-						assert.Nil(t, store.UpdateAssignments(ctx, []string{testTicket.GetId()}, wantAssignments[i]))
+						_, err := store.UpdateAssignments(ctx, []string{testTicket.GetId()}, wantAssignments[i])
+						assert.Nil(t, err)
 						wg.Done()
 					}
 				}(wg)

--- a/internal/app/mmlogic/mmlogic_service.go
+++ b/internal/app/mmlogic/mmlogic_service.go
@@ -67,7 +67,7 @@ func (s *mmlogicService) QueryTickets(req *pb.QueryTicketsRequest, responseServe
 
 func doQueryTickets(ctx context.Context, pool *pb.Pool, pageSize int, sender func(tickets []*pb.Ticket) error, store statestore.Service) error {
 	// Send requests to the storage service
-	err := store.FilterTickets(ctx, pool, pageSize, sender)
+	_, err := store.FilterTickets(ctx, pool, pageSize, sender)
 	if err != nil {
 		logger.WithError(err).Error("Failed to retrieve result from storage service.")
 		return err

--- a/internal/app/mmlogic/mmlogic_service_test.go
+++ b/internal/app/mmlogic/mmlogic_service_test.go
@@ -96,8 +96,10 @@ func TestDoQueryTickets(t *testing.T) {
 			100,
 			func(ctx context.Context, t *testing.T, store statestore.Service) {
 				for _, testTicket := range testTickets {
-					assert.Nil(t, store.CreateTicket(ctx, testTicket))
-					assert.Nil(t, store.IndexTicket(ctx, testTicket))
+					_, err := store.CreateTicket(ctx, testTicket)
+					assert.Nil(t, err)
+					_, err = store.IndexTicket(ctx, testTicket)
+					assert.Nil(t, err)
 				}
 			},
 			nil,
@@ -121,8 +123,10 @@ func TestDoQueryTickets(t *testing.T) {
 			100,
 			func(ctx context.Context, t *testing.T, store statestore.Service) {
 				for _, testTicket := range testTickets {
-					assert.Nil(t, store.CreateTicket(ctx, testTicket))
-					assert.Nil(t, store.IndexTicket(ctx, testTicket))
+					_, err := store.CreateTicket(ctx, testTicket)
+					assert.Nil(t, err)
+					_, err = store.IndexTicket(ctx, testTicket)
+					assert.Nil(t, err)
 				}
 			},
 			status.Errorf(codes.Internal, "%v", fakeErr),

--- a/internal/app/synchronizer/evaluator_client.go
+++ b/internal/app/synchronizer/evaluator_client.go
@@ -87,7 +87,7 @@ func newGrpcEvaluator(cfg config.View) (evaluator, error) {
 	grpcAddr := fmt.Sprintf("%s:%d", cfg.GetString("api.evaluator.hostname"), cfg.GetInt64("api.evaluator.grpcport"))
 	conn, err := rpc.GRPCClientFromEndpoint(cfg, grpcAddr)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to create grpc evaluator client: %w", err)
+		return nil, fmt.Errorf("Failed to create grpc evaluator client: %v", err)
 	}
 
 	evaluatorClientLogger.WithFields(logrus.Fields{
@@ -141,7 +141,7 @@ func newHTTPEvaluator(cfg config.View) (evaluator, error) {
 	httpAddr := fmt.Sprintf("%s:%d", cfg.GetString("api.evaluator.hostname"), cfg.GetInt64("api.evaluator.httpport"))
 	client, baseURL, err := rpc.HTTPClientFromEndpoint(cfg, httpAddr)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get a HTTP client from the endpoint %v: %w", httpAddr, err)
+		return nil, fmt.Errorf("failed to get a HTTP client from the endpoint %v: %v", httpAddr, err)
 	}
 
 	evaluatorClientLogger.WithFields(logrus.Fields{

--- a/internal/app/synchronizer/synchronizer_service.go
+++ b/internal/app/synchronizer/synchronizer_service.go
@@ -151,7 +151,7 @@ func (s *synchronizerService) doEvaluateProposals(ctx context.Context, proposals
 			ids = append(ids, ticket.GetId())
 		}
 	}
-	err = syncState.store.AddTicketsToIgnoreList(ctx, ids)
+	_, err = syncState.store.AddTicketsToIgnoreList(ctx, ids)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/statestore/public.go
+++ b/internal/statestore/public.go
@@ -28,34 +28,34 @@ type Service interface {
 	HealthCheck(ctx context.Context) error
 
 	// CreateTicket creates a new Ticket in the state storage. If the id already exists, it will be overwritten.
-	CreateTicket(ctx context.Context, ticket *pb.Ticket) error
+	CreateTicket(ctx context.Context, ticket *pb.Ticket) (context.Context, error)
 
 	// GetTicket gets the Ticket with the specified id from state storage. This method fails if the Ticket does not exist.
-	GetTicket(ctx context.Context, id string) (*pb.Ticket, error)
+	GetTicket(ctx context.Context, id string) (context.Context, *pb.Ticket, error)
 
 	// DeleteTicket removes the Ticket with the specified id from state storage. This method succeeds if the Ticket does not exist.
-	DeleteTicket(ctx context.Context, id string) error
+	DeleteTicket(ctx context.Context, id string) (context.Context, error)
 
 	// IndexTicket indexes the Ticket id for the configured index fields.
-	IndexTicket(ctx context.Context, ticket *pb.Ticket) error
+	IndexTicket(ctx context.Context, ticket *pb.Ticket) (context.Context, error)
 
 	// DeindexTicket removes the indexing for the specified Ticket. Only the indexes are removed but the Ticket continues to exist.
-	DeindexTicket(ctx context.Context, id string) error
+	DeindexTicket(ctx context.Context, id string) (context.Context, error)
 
 	// FilterTickets returns the Ticket ids for the Tickets meeting the specified filtering criteria.
-	FilterTickets(ctx context.Context, pool *pb.Pool, pageSize int, callback func([]*pb.Ticket) error) error
+	FilterTickets(ctx context.Context, pool *pb.Pool, pageSize int, callback func([]*pb.Ticket) error) (context.Context, error)
 
 	// UpdateAssignments update the match assignments for the input ticket ids
-	UpdateAssignments(ctx context.Context, ids []string, assignment *pb.Assignment) error
+	UpdateAssignments(ctx context.Context, ids []string, assignment *pb.Assignment) (context.Context, error)
 
 	// GetAssignments returns the assignment associated with the input ticket id
-	GetAssignments(ctx context.Context, id string, callback func(*pb.Assignment) error) error
+	GetAssignments(ctx context.Context, id string, callback func(*pb.Assignment) error) (context.Context, error)
 
 	// AddProposedTickets appends new proposed tickets to the proposed sorted set with current timestamp
-	AddTicketsToIgnoreList(ctx context.Context, ids []string) error
+	AddTicketsToIgnoreList(ctx context.Context, ids []string) (context.Context, error)
 
 	// DeleteTicketsFromIgnoreList deletes tickets from the proposed sorted set
-	DeleteTicketsFromIgnoreList(ctx context.Context, ids []string) error
+	DeleteTicketsFromIgnoreList(ctx context.Context, ids []string) (context.Context, error)
 
 	// Closes the connection to the underlying storage.
 	Close() error

--- a/internal/statestore/testing/fake_redis_test.go
+++ b/internal/statestore/testing/fake_redis_test.go
@@ -35,8 +35,9 @@ func TestFakeStatestore(t *testing.T) {
 	ticket := &pb.Ticket{
 		Id: "abc",
 	}
-	assert.Nil(s.CreateTicket(ctx, ticket))
-	retrievedTicket, err := s.GetTicket(ctx, "abc")
+	_, err := s.CreateTicket(ctx, ticket)
+	assert.Nil(err)
+	_, retrievedTicket, err := s.GetTicket(ctx, "abc")
 	assert.Nil(err)
 	assert.Equal(ticket.Id, retrievedTicket.Id)
 }

--- a/pkg/matchfunction/matchfunction.go
+++ b/pkg/matchfunction/matchfunction.go
@@ -27,7 +27,7 @@ import (
 func QueryPool(ctx context.Context, mml pb.MmLogicClient, pool *pb.Pool) ([]*pb.Ticket, error) {
 	query, err := mml.QueryTickets(ctx, &pb.QueryTicketsRequest{Pool: pool})
 	if err != nil {
-		return nil, fmt.Errorf("Error calling mmlogic.QueryTickets: %w", err)
+		return nil, fmt.Errorf("Error calling mmlogic.QueryTickets: %s", err.Error())
 	}
 
 	var tickets []*pb.Ticket
@@ -38,7 +38,7 @@ func QueryPool(ctx context.Context, mml pb.MmLogicClient, pool *pb.Pool) ([]*pb.
 		}
 
 		if err != nil {
-			return nil, fmt.Errorf("Error receiving tickets from mmlogic.QueryTickets: %w", err)
+			return nil, fmt.Errorf("Error receiving tickets from mmlogic.QueryTickets: %s", err.Error())
 		}
 
 		tickets = append(tickets, resp.Tickets...)
@@ -73,7 +73,7 @@ func QueryPools(ctx context.Context, mml pb.MmLogicClient, pools []*pb.Pool) (ma
 	for i := 0; i < len(pools); i++ {
 		select {
 		case <-ctx.Done():
-			return nil, fmt.Errorf("Context canceled while querying pools: %w", ctx.Err())
+			return nil, fmt.Errorf("Context canceled while querying pools: %s", ctx.Err())
 		case r := <-results:
 			if r.err != nil {
 				return nil, r.err


### PR DESCRIPTION
OpenConcensus's tracing story is based on context propagation - it will inject a span into the current context and use this modified context for tracing. However, this method doesn't work quite well with Open Match's current statestore implementation - For example, instead of creating a span with two sub-spans, `frontend.CreateTicket` will create two different spans under different contexts, which doesn't make sense.
```
# A span with two-subspans
frontend.CreateTicket(A)
 |                                                                         
 -------- statetstore.CreateTicket(A)              
 |
 -------- statestore.IndexTicket(A)

# Two spans with different contexts
frontend.CreateTicket(A) ---- statestore.CreateTicket(A)
frontend.CreateTicket(A) ---- statestore.IndexTicket(A)              
```

This commit have all statestore APIs return a context to improve context propagation for tracing purpose.