### PR TITLE
Split out MMF and Evaluator install from open-match-demo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -341,6 +341,8 @@ install-large-chart: install-chart-prerequisite build/toolchain/bin/helm$(EXE_EX
 		--set open-match-telemetry.enabled=true \
 		--set open-match-demo.enabled=true \
 		--set open-match-customize.enabled=true \
+		--set open-match-customize.function.enabled=true \
+		--set open-match-customize.evaluator.enabled=true \
 		--set global.telemetry.grafana.enabled=true \
 		--set global.telemetry.jaeger.enabled=true \
 		--set global.telemetry.prometheus.enabled=true \
@@ -350,13 +352,17 @@ install-large-chart: install-chart-prerequisite build/toolchain/bin/helm$(EXE_EX
 install-chart: install-chart-prerequisite build/toolchain/bin/helm$(EXE_EXTENSION) install/helm/open-match/secrets/
 	$(HELM) upgrade $(OPEN_MATCH_RELEASE_NAME) $(HELM_UPGRADE_FLAGS) install/helm/open-match $(HELM_IMAGE_FLAGS) \
 		--set open-match-demo.enabled=true \
-		--set open-match-customize.enabled=true
+		--set open-match-customize.enabled=true \
+		--set open-match-customize.function.enabled=true \
+		--set open-match-customize.evaluator.enabled=true
 
 # install-scale-chart will wait for installing open-match-core with telemetry supports then install open-match-scale chart.
 install-scale-chart: install-chart-prerequisite build/toolchain/bin/helm$(EXE_EXTENSION) install/helm/open-match/secrets/
 	$(HELM) upgrade $(OPEN_MATCH_RELEASE_NAME) $(HELM_UPGRADE_FLAGS) install/helm/open-match $(HELM_IMAGE_FLAGS) \
 		--set open-match-telemetry.enabled=true \
 		--set open-match-customize.enabled=true \
+		--set open-match-customize.function.enabled=true \
+		--set open-match-customize.evaluator.enabled=true \
 		--set open-match-customize.function.image=openmatch-mmf-go-rosterbased \
 		--set global.telemetry.grafana.enabled=true \
 		--set global.telemetry.jaeger.enabled=true \
@@ -375,6 +381,8 @@ install-ci-chart: install-chart-prerequisite build/toolchain/bin/helm$(EXE_EXTEN
 		--set redis.ignoreLists.ttl=1000ms \
 		--set open-match-test.enabled=true \
 		--set open-match-customize.enabled=true \
+		--set open-match-customize.function.enabled=true \
+		--set open-match-customize.evaluator.enabled=true \
 		--set open-match-customize.function.image=openmatch-mmf-go-pool \
 		--set ci=true
 
@@ -386,7 +394,7 @@ delete-chart: build/toolchain/bin/helm$(EXE_EXTENSION) build/toolchain/bin/kubec
 	-$(KUBECTL) --ignore-not-found=true delete crd prometheusrules.monitoring.coreos.com
 	-$(KUBECTL) delete namespace $(OPEN_MATCH_KUBERNETES_NAMESPACE)
 
-install/yaml/: update-chart-deps install/yaml/install.yaml install/yaml/01-open-match-core.yaml install/yaml/02-open-match-demo.yaml install/yaml/03-prometheus-chart.yaml install/yaml/04-grafana-chart.yaml install/yaml/05-jaeger-chart.yaml install/yaml/06-open-match-override-configmap.yaml
+install/yaml/: update-chart-deps install/yaml/install.yaml install/yaml/01-open-match-core.yaml install/yaml/02-open-match-demo.yaml install/yaml/03-prometheus-chart.yaml install/yaml/04-grafana-chart.yaml install/yaml/05-jaeger-chart.yaml install/yaml/06-open-match-override-configmap.yaml install/yaml/07-open-match-default-evaluator.yaml
 
 install/yaml/01-open-match-core.yaml: build/toolchain/bin/helm$(EXE_EXTENSION)
 	mkdir -p install/yaml/
@@ -399,6 +407,7 @@ install/yaml/02-open-match-demo.yaml: build/toolchain/bin/helm$(EXE_EXTENSION)
 		--set open-match-core.enabled=false \
 		--set open-match-demo.enabled=true \
 		--set open-match-customize.enabled=true \
+		--set open-match-customize.function.enabled=true \
 		install/helm/open-match > install/yaml/02-open-match-demo.yaml
 
 install/yaml/03-prometheus-chart.yaml: build/toolchain/bin/helm$(EXE_EXTENSION)
@@ -433,10 +442,20 @@ install/yaml/06-open-match-override-configmap.yaml: build/toolchain/bin/helm$(EX
 		-s templates/om-configmap-override.yaml \
 		install/helm/open-match > install/yaml/06-open-match-override-configmap.yaml
 
+install/yaml/07-open-match-default-evaluator.yaml: build/toolchain/bin/helm$(EXE_EXTENSION)
+	mkdir -p install/yaml/
+	$(HELM) template $(OPEN_MATCH_RELEASE_NAME) $(HELM_TEMPLATE_FLAGS) $(HELM_IMAGE_FLAGS) \
+		--set open-match-core.enabled=false \
+		--set open-match-customize.enabled=true \
+		--set open-match-customize.evaluator.enabled=true \
+		install/helm/open-match > install/yaml/07-open-match-default-evaluator.yaml
+
 install/yaml/install.yaml: build/toolchain/bin/helm$(EXE_EXTENSION)
 	mkdir -p install/yaml/
 	$(HELM) template $(OPEN_MATCH_RELEASE_NAME) $(HELM_TEMPLATE_FLAGS) $(HELM_IMAGE_FLAGS) \
 		--set open-match-customize.enabled=true \
+		--set open-match-customize.function.enabled=true \
+		--set open-match-customize.evaluator.enabled=true \
 		--set open-match-demo.enabled=true \
 		--set open-match-telemetry.enabled=true \
 		--set global.telemetry.jaeger.enabled=true \

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,6 @@ require (
 	github.com/aws/aws-sdk-go v1.25.27 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/fsnotify/fsnotify v1.4.7
-	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/gogo/protobuf v1.3.1 // indirect
 	github.com/golang/groupcache v0.0.0-20191027212112-611e8accdfc9 // indirect
 	github.com/golang/protobuf v1.3.2
@@ -42,8 +41,6 @@ require (
 	github.com/imdario/mergo v0.3.8 // indirect
 	github.com/json-iterator/go v1.1.8 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/openzipkin/zipkin-go v0.2.2
 	github.com/pelletier/go-toml v1.6.0 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect

--- a/install/helm/open-match/subcharts/open-match-customize/templates/evaluator.yaml
+++ b/install/helm/open-match/subcharts/open-match-customize/templates/evaluator.yaml
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Ugly workaround to split out MMF and evaluator
+# TODO: Reconsider helm chart structure and move things out after v0.8 release
+{{- if index .Values "evaluator" "enabled" }}
 kind: Service
 apiVersion: v1
 metadata:
@@ -95,3 +98,4 @@ spec:
         - name: http
           containerPort: {{ .Values.evaluator.httpPort }}
         {{- include "openmatch.container.common" . | nindent 8 }}
+{{- end }}

--- a/install/helm/open-match/subcharts/open-match-customize/templates/matchfunctions.yaml
+++ b/install/helm/open-match/subcharts/open-match-customize/templates/matchfunctions.yaml
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Ugly workaround to split out MMF and evaluator
+# TODO: Reconsider helm chart structure and move things out after v0.8 release
+{{- if index .Values "function" "enabled" }}
 kind: Service
 apiVersion: v1
 metadata:
@@ -96,3 +99,4 @@ spec:
         - name: http
           containerPort: {{ .Values.function.httpPort }}
         {{- include "openmatch.container.common" . | nindent 8 }}
+{{- end }}

--- a/install/helm/open-match/subcharts/open-match-customize/values.yaml
+++ b/install/helm/open-match/subcharts/open-match-customize/values.yaml
@@ -17,11 +17,13 @@
 # Declare variables to be passed into your templates.
 
 function:
+  enabled: false
   replicas: 3
   portType: ClusterIP
   image: openmatch-mmf-go-soloduel
 
 evaluator:
+  enabled: false
   replicas: 3
   portType: ClusterIP
   image: openmatch-evaluator-go-simple


### PR DESCRIPTION
This commit is part of the user experience Getting Started change, it splits out MMF and Evaluator from open-match-demo installation so that users can see Open Match up and running with the default evaluator when they worked through the Installation steps.

The next step is to migrate the Open Match Demo resources to a different namespace other than Open Match so that users are able to `kubectl delete namespace open-match-demo` and reuse Open Match core services for the tutorials.