### PR TITLE
Define Makefile and RBAC rules for open-match-demo namespace migration

### DIFF
--- a/examples/demo/components/director/director.go
+++ b/examples/demo/components/director/director.go
@@ -17,10 +17,11 @@ package director
 import (
 	"context"
 	"fmt"
-	"google.golang.org/grpc"
 	"io"
 	"math/rand"
 	"time"
+
+	"google.golang.org/grpc"
 
 	"open-match.dev/open-match/examples/demo/components"
 	"open-match.dev/open-match/pkg/pb"
@@ -82,7 +83,7 @@ func run(ds *components.DemoShared) {
 	{
 		req := &pb.FetchMatchesRequest{
 			Config: &pb.FunctionConfig{
-				Host: "om-function.open-match.svc.cluster.local",
+				Host: "om-function.open-match-demo.svc.cluster.local",
 				Port: 50502,
 				Type: pb.FunctionConfig_GRPC,
 			},

--- a/install/helm/open-match/subcharts/open-match-demo/templates/demo-podsecuritypolicy.yaml
+++ b/install/helm/open-match/subcharts/open-match-demo/templates/demo-podsecuritypolicy.yaml
@@ -1,0 +1,57 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# om-demo-podsecuritypolicy does not allow creating privileged pods and restrict binded pods to use the specified port ranges.
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: om-demo-podsecuritypolicy
+  namespace: {{ .Release.Namespace }}
+  annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
+  labels:
+    app: {{ template "openmatch.name" . }}
+    release: {{ .Release.Name }}
+spec:
+  allowPrivilegeEscalation: false
+  defaultAllowPrivilegeEscalation: false
+  forbiddenSysctls:
+  - "*"
+  fsGroup:
+    rule: "MustRunAs"
+    ranges:
+    - min: 1
+      max: 65535
+  hostIPC: false
+  hostNetwork: false
+  hostPID: false
+  hostPorts:
+  # Open Match Services
+  - min: 50500
+    max: 50510
+  - min: 51500
+    max: 51510
+  privileged: false  # Prevents creation of privileged Pods
+  readOnlyRootFilesystem: false
+  runAsUser:
+    rule: "RunAsAny"
+    # Blocked on isolating the open match services from dependencies (Redis, Prometheus, etc.)
+    # Require the container to run without root privileges.
+    #rule: 'MustRunAsNonRoot'
+  seLinux:
+    # This policy assumes the nodes are using AppArmor rather than SELinux.
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+    - 'configMap'

--- a/install/helm/open-match/subcharts/open-match-demo/templates/demo-role.yaml
+++ b/install/helm/open-match/subcharts/open-match-demo/templates/demo-role.yaml
@@ -1,0 +1,33 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: om-demo-role
+  namespace: {{ .Release.Namespace }}
+  annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
+  labels:
+    app: {{ template "openmatch.name" . }}
+    release: {{ .Release.Name }}
+rules:
+# Define om-demo-role to use om-demo-podsecuritypolicy
+- apiGroups:
+  - extensions
+  resources:
+  - podsecuritypolicies
+  resourceNames:
+  - om-demo-podsecuritypolicy
+  verbs:
+  - use

--- a/install/helm/open-match/subcharts/open-match-demo/templates/demo-rolebinding.yaml
+++ b/install/helm/open-match/subcharts/open-match-demo/templates/demo-rolebinding.yaml
@@ -1,0 +1,32 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This applies om-test-role to the open-match-test-service account under the release namespace. 
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: om-demo-role-binding
+  namespace: {{ .Release.Namespace }}
+  annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
+  labels:
+    app: {{ template "openmatch.name" . }}
+    release: {{ .Release.Name }}
+subjects:
+- kind: ServiceAccount
+  name: open-match-demo-service
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: om-demo-role
+  apiGroup: rbac.authorization.k8s.io

--- a/install/helm/open-match/subcharts/open-match-demo/templates/demo-serviceaccount.yaml
+++ b/install/helm/open-match/subcharts/open-match-demo/templates/demo-serviceaccount.yaml
@@ -1,0 +1,25 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Create a service account for open-match-demo services.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: open-match-demo-service
+  namespace: {{ .Release.Namespace }}
+  annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
+  labels:
+    app: {{ template "openmatch.name" . }}
+    release: {{ .Release.Name }}
+automountServiceAccountToken: true


### PR DESCRIPTION
This commit created a new Makefile target `install-demo` for the demo used in the getting started step and modified the existing Makefile targets to incorporate this change. It also defined the RBAC rules that are necessary to create resources under the `open-match-demo` namespace.

The demo will be broken until we check in the next PR.