### PR TITLE
Have MMF and Evaluator in customize chart use different configs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -352,7 +352,8 @@ install-chart: install-chart-prerequisite install-demo build/toolchain/bin/helm$
 		--set open-match-customize.enabled=true \
 		--set open-match-customize.evaluator.enabled=true
 
-install-demo: OPEN_MATCH_KUBERNETES_NAMESPACE=open-match-demo OPEN_MATCH_RELEASE_NAME=open-match-demo
+install-demo: OPEN_MATCH_KUBERNETES_NAMESPACE=open-match-demo
+install-demo: OPEN_MATCH_RELEASE_NAME=open-match-demo
 install-demo: install-chart-prerequisite build/toolchain/bin/helm$(EXE_EXTENSION) install/helm/open-match/secrets/
 	-$(KUBECTL) create namespace open-match-demo
 	$(HELM) upgrade $(OPEN_MATCH_RELEASE_NAME) $(HELM_UPGRADE_FLAGS) install/helm/open-match $(HELM_IMAGE_FLAGS) \
@@ -407,6 +408,8 @@ install/yaml/01-open-match-core.yaml: build/toolchain/bin/helm$(EXE_EXTENSION)
 	$(HELM) template $(OPEN_MATCH_RELEASE_NAME) $(HELM_TEMPLATE_FLAGS) $(HELM_IMAGE_FLAGS) \
 		install/helm/open-match > install/yaml/01-open-match-core.yaml
 
+install/yaml/02-open-match-demo.yaml: OPEN_MATCH_KUBERNETES_NAMESPACE=open-match-demo 
+install/yaml/02-open-match-demo.yaml: OPEN_MATCH_RELEASE_NAME=open-match-demo
 install/yaml/02-open-match-demo.yaml: build/toolchain/bin/helm$(EXE_EXTENSION)
 	mkdir -p install/yaml/
 	$(HELM) template $(OPEN_MATCH_RELEASE_NAME) $(HELM_TEMPLATE_FLAGS) $(HELM_IMAGE_FLAGS) \
@@ -414,6 +417,7 @@ install/yaml/02-open-match-demo.yaml: build/toolchain/bin/helm$(EXE_EXTENSION)
 		--set open-match-demo.enabled=true \
 		--set open-match-customize.enabled=true \
 		--set open-match-customize.function.enabled=true \
+		--set global.kubernetes.serviceAccount=open-match-demo-service \
 		install/helm/open-match > install/yaml/02-open-match-demo.yaml
 
 install/yaml/03-prometheus-chart.yaml: build/toolchain/bin/helm$(EXE_EXTENSION)

--- a/install/helm/open-match/subcharts/open-match-customize/templates/customize-configmap.yaml
+++ b/install/helm/open-match/subcharts/open-match-customize/templates/customize-configmap.yaml
@@ -23,12 +23,8 @@ metadata:
     component: config
     release: {{ .Release.Name }}
 data:
-  matchmaker_config_override.yaml: |-
+  matchmaker_config_default.yaml: |-
     api:
-      mmlogic:
-        hostname: "{{ .Values.mmlogic.hostName }}"
-        grpcport: "{{ .Values.mmlogic.grpcPort }}"
-      
       functions:
         hostname: "{{ .Values.function.hostName }}"
         grpcport: "{{ .Values.function.grpcPort }}"
@@ -37,4 +33,9 @@ data:
       evaluator:
         hostname: "{{ .Values.evaluator.hostName }}"
         grpcport: "{{ .Values.evaluator.grpcPort }}"
-        httpport: "{{ .Values.evaluator.httpPort }}"
+        httpport: "{{ .Values.evaluator.httpPort }}"    
+  matchmaker_config_override.yaml: |-
+    api:
+      mmlogic:
+        hostname: "{{ .Values.mmlogic.hostName }}.open-match.svc.cluster.local"
+        grpcport: "{{ .Values.mmlogic.grpcPort }}"

--- a/install/helm/open-match/subcharts/open-match-customize/templates/evaluator.yaml
+++ b/install/helm/open-match/subcharts/open-match-customize/templates/evaluator.yaml
@@ -83,13 +83,13 @@ spec:
         release: {{ .Release.Name }}
     spec:
       volumes:
-        {{- include "openmatch.volumes.configs" . | nindent 8}}
+        {{- include "openmatch.volumes.configs" (dict "configs" .Values.evaluatorConfigs) | nindent 8}}
         {{- include "openmatch.volumes.tls" . | nindent 8}}
       serviceAccountName: {{ .Values.global.kubernetes.serviceAccount }}
       containers:
       - name: {{ .Values.evaluator.hostName }}
         volumeMounts:
-          {{- include "openmatch.volumemounts.configs" . | nindent 10 }}
+          {{- include "openmatch.volumemounts.configs" (dict "configs" .Values.evaluatorConfigs) | nindent 10 }}
           {{- include "openmatch.volumemounts.tls" . | nindent 10 }}
         image: "{{ .Values.global.image.registry }}/{{ .Values.evaluator.image}}:{{ .Values.global.image.tag }}"
         ports:

--- a/install/helm/open-match/subcharts/open-match-customize/templates/matchfunctions.yaml
+++ b/install/helm/open-match/subcharts/open-match-customize/templates/matchfunctions.yaml
@@ -84,13 +84,13 @@ spec:
         release: {{ .Release.Name }}
     spec:
       volumes:
-        {{- include "openmatch.volumes.configs" . | nindent 8}}
+        {{- include "openmatch.volumes.configs" (dict "configs" .Values.mmfConfigs) | nindent 8}}
         {{- include "openmatch.volumes.tls" . | nindent 8}}
       serviceAccountName: {{ .Values.global.kubernetes.serviceAccount }}
       containers:
       - name: {{ .Values.function.hostName }}
         volumeMounts:
-          {{- include "openmatch.volumemounts.configs" . | nindent 10 }}
+          {{- include "openmatch.volumemounts.configs" (dict "configs" .Values.mmfConfigs) | nindent 10 }}
           {{- include "openmatch.volumemounts.tls" . | nindent 10 }}
         image: "{{ .Values.global.image.registry }}/{{ .Values.function.image}}:{{ .Values.global.image.tag }}"
         ports:

--- a/install/helm/open-match/subcharts/open-match-customize/values.yaml
+++ b/install/helm/open-match/subcharts/open-match-customize/values.yaml
@@ -28,11 +28,28 @@ evaluator:
   portType: ClusterIP
   image: openmatch-evaluator-go-simple
 
-configs:
+evaluatorConfigs: 
+  # We use harness to implement the MMFs. MMF itself only requires one configmap but harness expects two,
+  # so we mount the same configmap twice to bypass this restriction.
   # TODO: Remove this bit after deprecating the harness dependency on configmap
-  om-configmap-default:
+  default:
     volumeName: om-config-volume-default
     mountPath: /app/config/default
-  customize-configmap:
+    configName: customize-configmap
+  customize:
     volumeName: customize-config-volume
     mountPath: /app/config/override
+    configName: customize-configmap
+
+mmfConfigs:
+  # We use harness to implement the MMFs. MMF itself only requires one configmap but harness expects two,
+  # so we mount the same configmap twice to bypass this restriction.
+  # TODO: Remove this bit after deprecating the harness dependency on configmap
+  default:
+    volumeName: om-config-volume-default
+    mountPath: /app/config/default
+    configName: customize-configmap
+  customize:
+    volumeName: customize-config-volume
+    mountPath: /app/config/override
+    configName: customize-configmap

--- a/install/helm/open-match/subcharts/open-match-demo/values.yaml
+++ b/install/helm/open-match/subcharts/open-match-demo/values.yaml
@@ -33,6 +33,7 @@ image:
 # to create a new evaluator and mmf. We should create a global configmap for the security settings for all subcharts 
 # under the /install/helm/open-match directory to avoid copy&paste files around.
 configs:
-  demo-configmap:
+  demoConfig:
     mountPath: /app/config/om
     volumeName: demo-config-volume
+    configName: demo-configmap

--- a/install/helm/open-match/subcharts/open-match-scale/templates/scale-backend.yaml
+++ b/install/helm/open-match/subcharts/open-match-scale/templates/scale-backend.yaml
@@ -58,13 +58,13 @@ spec:
         release: {{ .Release.Name }}
     spec:
       volumes:
-        {{- include "openmatch.volumes.configs" . | nindent 8}}
+        {{- include "openmatch.volumes.configs" (dict "configs" .Values.configs) | nindent 8}}
         {{- include "openmatch.volumes.tls" . | nindent 8}}
       serviceAccountName: {{ .Values.global.kubernetes.serviceAccount }}
       containers:
       - name: {{ .Values.scaleBackend.hostName }}
         volumeMounts:
-          {{- include "openmatch.volumemounts.configs" . | nindent 10 }}
+          {{- include "openmatch.volumemounts.configs" (dict "configs" .Values.configs) | nindent 10 }}
           {{- include "openmatch.volumemounts.tls" . | nindent 10 }}
         image: "{{ .Values.global.image.registry }}/{{ .Values.scaleBackend.image}}:{{ .Values.global.image.tag }}"
         ports:

--- a/install/helm/open-match/subcharts/open-match-scale/templates/scale-frontend.yaml
+++ b/install/helm/open-match/subcharts/open-match-scale/templates/scale-frontend.yaml
@@ -58,13 +58,13 @@ spec:
         release: {{ .Release.Name }}
     spec:
       volumes:
-        {{- include "openmatch.volumes.configs" . | nindent 8}}
+        {{- include "openmatch.volumes.configs" (dict "configs" .Values.configs) | nindent 8}}
         {{- include "openmatch.volumes.tls" . | nindent 8}}
       serviceAccountName: {{ .Values.global.kubernetes.serviceAccount }}
       containers:
       - name: {{ .Values.scaleFrontend.hostName }}
         volumeMounts:
-          {{- include "openmatch.volumemounts.configs" . | nindent 10 }}
+          {{- include "openmatch.volumemounts.configs" (dict "configs" .Values.configs) | nindent 10 }}
           {{- include "openmatch.volumemounts.tls" . | nindent 10 }}
         image: "{{ .Values.global.image.registry }}/{{ .Values.scaleFrontend.image}}:{{ .Values.global.image.tag }}"
         ports:

--- a/install/helm/open-match/subcharts/open-match-scale/values.yaml
+++ b/install/helm/open-match/subcharts/open-match-scale/values.yaml
@@ -25,12 +25,14 @@ scaleBackend:
   image: openmatch-scale-backend
 
 configs:
-  om-configmap-default:
+  default:
     volumeName: om-config-volume-default
     mountPath: /app/config/default
+    configName: scale-configmap
   scale-configmap:
     volumeName: scale-config-volume
     mountPath: /app/config/override
+    configName: scale-configmap
 
 testConfig:
   profile: greedy

--- a/install/helm/open-match/templates/_helpers.tpl
+++ b/install/helm/open-match/templates/_helpers.tpl
@@ -49,17 +49,17 @@ resources:
 {{- end -}}
 
 {{- define "openmatch.volumemounts.configs" -}}
-{{- range $configName, $configValues := .Values.configs }}
+{{- range $configIndex, $configValues := .configs }}
 - name: {{ $configValues.volumeName }}
   mountPath: {{ $configValues.mountPath }}
 {{- end }}
 {{- end -}}
 
 {{- define "openmatch.volumes.configs" -}}
-{{- range $configName, $configValues := .Values.configs }}
+{{- range $configIndex, $configValues := .configs }}
 - name: {{ $configValues.volumeName }}
   configMap:
-    name: {{ $configName }}
+    name: {{ $configValues.configName }}
 {{- end }}
 {{- end -}}
 

--- a/install/helm/open-match/templates/backend.yaml
+++ b/install/helm/open-match/templates/backend.yaml
@@ -81,14 +81,14 @@ spec:
         release: {{ .Release.Name }}
     spec:
       volumes:
-        {{- include "openmatch.volumes.configs" . | nindent 8}}
+        {{- include "openmatch.volumes.configs" (dict "configs" .Values.configs) | nindent 8}}
         {{- include "openmatch.volumes.tls" . | nindent 8}}
         {{- include "openmatch.volumes.withredis" . | nindent 8}}
       serviceAccountName: {{ .Values.global.kubernetes.serviceAccount }}
       containers:
       - name: {{ .Values.backend.hostName }}
         volumeMounts:
-          {{- include "openmatch.volumemounts.configs" . | nindent 10 }}
+          {{- include "openmatch.volumemounts.configs" (dict "configs" .Values.configs) | nindent 10 }}
           {{- include "openmatch.volumemounts.tls" . | nindent 10 }}
           {{- include "openmatch.volumemounts.withredis" . | nindent 10}}
         image: "{{ .Values.global.image.registry }}/{{ .Values.backend.image}}:{{ .Values.global.image.tag }}"

--- a/install/helm/open-match/templates/frontend.yaml
+++ b/install/helm/open-match/templates/frontend.yaml
@@ -81,14 +81,14 @@ spec:
         release: {{ .Release.Name }}
     spec:
       volumes:
-        {{- include "openmatch.volumes.configs" . | nindent 8}}
+        {{- include "openmatch.volumes.configs" (dict "configs" .Values.configs) | nindent 8}}
         {{- include "openmatch.volumes.tls" . | nindent 8}}
         {{- include "openmatch.volumes.withredis" . | nindent 8}}
       serviceAccountName: {{ .Values.global.kubernetes.serviceAccount }}
       containers:
       - name: {{ .Values.frontend.hostName }}
         volumeMounts:
-          {{- include "openmatch.volumemounts.configs" . | nindent 10 }}
+          {{- include "openmatch.volumemounts.configs" (dict "configs" .Values.configs) | nindent 10 }}
           {{- include "openmatch.volumemounts.tls" . | nindent 10 }}
           {{- include "openmatch.volumemounts.withredis" . | nindent 10}}
         image: "{{ .Values.global.image.registry }}/{{ .Values.frontend.image}}:{{ .Values.global.image.tag }}"

--- a/install/helm/open-match/templates/mmlogic.yaml
+++ b/install/helm/open-match/templates/mmlogic.yaml
@@ -81,14 +81,14 @@ spec:
         release: {{ .Release.Name }}
     spec:
       volumes:
-        {{- include "openmatch.volumes.configs" . | nindent 8}}
+        {{- include "openmatch.volumes.configs" (dict "configs" .Values.configs) | nindent 8}}
         {{- include "openmatch.volumes.tls" . | nindent 8}}
         {{- include "openmatch.volumes.withredis" . | nindent 8 }}
       serviceAccountName: {{ .Values.global.kubernetes.serviceAccount }}
       containers:
       - name: {{ .Values.mmlogic.hostName }}
         volumeMounts:
-          {{- include "openmatch.volumemounts.configs" . | nindent 10 }}
+          {{- include "openmatch.volumemounts.configs" (dict "configs" .Values.configs) | nindent 10 }}
           {{- include "openmatch.volumemounts.tls" . | nindent 10 }}
           {{- include "openmatch.volumemounts.withredis" . | nindent 10}}
         image: "{{ .Values.global.image.registry }}/{{ .Values.mmlogic.image}}:{{ .Values.global.image.tag }}"

--- a/install/helm/open-match/templates/swaggerui.yaml
+++ b/install/helm/open-match/templates/swaggerui.yaml
@@ -60,13 +60,13 @@ spec:
         release: {{ .Release.Name }}
     spec:
       volumes:
-        {{- include "openmatch.volumes.configs" . | nindent 8}}
+        {{- include "openmatch.volumes.configs" (dict "configs" .Values.configs) | nindent 8}}
         {{- include "openmatch.volumes.tls" . | nindent 8}}
       serviceAccountName: {{ .Values.global.kubernetes.serviceAccount }}
       containers:
       - name: {{ .Values.swaggerui.hostName }}
         volumeMounts:
-          {{- include "openmatch.volumemounts.configs" . | nindent 10 }}
+          {{- include "openmatch.volumemounts.configs" (dict "configs" .Values.configs) | nindent 10 }}
           {{- include "openmatch.volumemounts.tls" . | nindent 10 }}
         image: "{{ .Values.global.image.registry }}/{{ .Values.swaggerui.image}}:{{ .Values.global.image.tag }}"
         ports:

--- a/install/helm/open-match/templates/synchronizer.yaml
+++ b/install/helm/open-match/templates/synchronizer.yaml
@@ -65,14 +65,14 @@ spec:
         release: {{ .Release.Name }}
     spec:
       volumes:
-        {{- include "openmatch.volumes.configs" . | nindent 8}}
+        {{- include "openmatch.volumes.configs" (dict "configs" .Values.configs) | nindent 8}}
         {{- include "openmatch.volumes.tls" . | nindent 8}}
         {{- include "openmatch.volumes.withredis" . | nindent 8 }}
       serviceAccountName: {{ .Values.global.kubernetes.serviceAccount }}
       containers:
       - name: {{ .Values.synchronizer.hostName }}
         volumeMounts:
-          {{- include "openmatch.volumemounts.configs" . | nindent 10 }}
+          {{- include "openmatch.volumemounts.configs" (dict "configs" .Values.configs) | nindent 10 }}
           {{- include "openmatch.volumemounts.tls" . | nindent 10 }}
           {{- include "openmatch.volumemounts.withredis" . | nindent 10}}
         image: "{{ .Values.global.image.registry }}/{{ .Values.synchronizer.image}}:{{ .Values.global.image.tag }}"

--- a/install/helm/open-match/values.yaml
+++ b/install/helm/open-match/values.yaml
@@ -97,12 +97,14 @@ image:
 # Specifies the location and name of the Open Match application-level config volumes.
   # Used in template: `openmatch.volumemounts.configs` and `openmatch.volumes.configs` under `templates/_helpers.tpl` file.
 configs:
-  om-configmap-default:
+  default:
     volumeName: om-config-volume-default
     mountPath: /app/config/default
-  om-configmap-override:
+    configName: om-configmap-default
+  override:
     volumeName: om-config-volume-override
     mountPath: /app/config/override
+    configName: om-configmap-override
 
 # Override Redis settings
 # https://hub.helm.sh/charts/stable/redis


### PR DESCRIPTION
This commit completely decouple the customize chart from using the default configmap in `open-match` namespace. As a workaround, it defines a `default` and `override` yaml in the same configmap and mount it to two different volumes - which is required by the harness.

`make install-chart` will now install a demo chart with its MMF to the `open-match-demo` namespace and `open-match-core` to `open-match` namespace.
