### PR TITLE
Generate protos using Dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -689,6 +689,12 @@ pkg/pb/%.pb.gw.go: api/%.proto third_party/ build/toolchain/bin/protoc$(EXE_EXTE
    		--grpc-gateway_out=logtostderr=true,allow_delete_body=true:$(REPOSITORY_ROOT)/build/prototmp
 	mv $(REPOSITORY_ROOT)/build/prototmp/open-match.dev/open-match/$@ $@
 
+gen-proto:
+	$(REPOSITORY_ROOT)/test/proto/generate-protos.sh
+
+cmp-proto:
+	$(REPOSITORY_ROOT)/test/proto/compare-protos.sh
+
 api/%.swagger.json: api/%.proto third_party/ build/toolchain/bin/protoc$(EXE_EXTENSION) build/toolchain/bin/protoc-gen-swagger$(EXE_EXTENSION)
 	$(PROTOC) $< \
 		-I $(REPOSITORY_ROOT) -I $(PROTOC_INCLUDES) \

--- a/test/proto/Dockerfile
+++ b/test/proto/Dockerfile
@@ -1,0 +1,69 @@
+# Copyright 2019 Google LLC
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+######################################################################
+# This target installs required protoc binaries; then generates files.
+FROM golang:1.13.4-alpine3.10 as generated
+ENV GO111MODULE=on
+ENV CGO_ENABLED 0
+ENV PROTOC_VERSION=3.8.0
+
+# https://pkgs.alpinelinux.org/packages?name=protobuf&branch=v3.10
+RUN apk add --no-cache protobuf=3.6.1-r1 git=2.22.0-r0 unzip=6.0-r4
+
+# Install protoc
+WORKDIR /
+RUN wget -O protoc.zip https://github.com/google/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip
+RUN unzip protoc.zip -d protoc
+RUN cp -R /protoc/include /usr/local/include
+
+# Install binaries
+WORKDIR /usr/local/bin
+RUN go build -i -pkgdir . github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway
+RUN go build -i -pkgdir . github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger
+RUN go build -i -pkgdir . github.com/golang/protobuf/protoc-gen-go
+RUN go build -i -pkgdir . github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc
+
+WORKDIR /proto
+COPY api/ api/
+COPY internal/api/*.proto internal/api/
+COPY third_party/ third_party/
+RUN mkdir -p open-match.dev/open-match/csharp/OpenMatch
+# Generate files using the protos
+# - swagger json files will sit within api/ directory
+# - .pb. and .gw.pb files will sit within open-match.dev/open-match/pkg/pb and open-match.dev/open-match/internal/ipb directory
+# - .cs files will sit within open-match.dev/open-match/csharp/OpenMatch directory
+RUN protoc api/*.proto -I . -I /usr/local/include -I third_party/ \
+  --plugin=protoc-gen-grpc=grpc_csharp_plugin \
+  --grpc-gateway_out=logtostderr=true,allow_delete_body=true:. \
+  --swagger_out=logtostderr=true,allow_delete_body=true:. \
+  --go_out=plugins=grpc:. \
+  --csharp_out=open-match.dev/open-match/csharp/OpenMatch
+#  --doc_out=. \
+#  --doc_opt=markdown,api.md
+RUN protoc internal/api/*.proto -I . -I /usr/local/include -I third_party/ \
+  --go_out=plugins=grpc:.
+
+########################################################################
+# This target compares the generated files with the ones in current HEAD
+FROM generated as compare
+WORKDIR /compare/head/
+COPY api/ api/
+COPY pkg/pb/ open-match.dev/open-match/pkg/pb
+COPY internal/ipb open-match.dev/open-match/internal/ipb
+COPY third_party/ third_party/
+COPY --from=generated /proto /compare/tmp
+
+WORKDIR /compare/tmp
+CMD diff -q -r /compare/head/open-match.dev/open-match/internal/ /compare/tmp/open-match.dev/open-match/internal/

--- a/test/proto/compare-protos.sh
+++ b/test/proto/compare-protos.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Copyright 2019 Google LLC
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+docker build -t gen-proto -f ./test/proto/Dockerfile --target compare .
+if [ $? -ne 0 ]; then
+    docker run --rm gen-proto
+    printf "\nGenerated proto files are not updated. Please run 'make gen-proto'\n"
+    exit 1
+fi
+
+docker run --rm gen-proto
+if [ $? -ne 0 ]; then
+    printf "\nGenerated proto files are not updated. Please run 'make gen-proto'\n"
+    exit 1
+fi
+
+printf "\nGenerated proto files are up-to-date ╭(◔ ◡ ◔)/!\n"

--- a/test/proto/generate-protos.sh
+++ b/test/proto/generate-protos.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Copyright 2019 Google LLC
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+docker build -t gen-proto -f ./test/proto/Dockerfile --target generated .
+docker create -ti --name dummy-gen-proto gen-proto bash
+docker cp dummy-gen-proto:/proto/api .
+docker cp dummy-gen-proto:/proto/open-match.dev/open-match/internal/ipb ./internal/
+docker cp dummy-gen-proto:/proto/open-match.dev/open-match/pkg/pb ./pkg/
+docker rm -f dummy-gen-proto


### PR DESCRIPTION
This is an attempt to harden our current verbose Makefile by generating the proto files using an Docker image.

Also partially resolves #491 if we added the `make cmp-proto` call to our CI pipeline.