### PR TITLE
Improve README instructions and code templates for the tutorials (#997)

### DIFF
--- a/tutorials/custom_evaluator/director/README.md
+++ b/tutorials/custom_evaluator/director/README.md
@@ -1,6 +1,4 @@
 This folder provides a sample Director for Open Match Matchmaker 101 Tutorial.
-<TODO - Update the README with details of the Director and the steps that need
-to be run before executing the commamds below>
 
 Run the below steps in this folder to set up the Director.
 
@@ -20,6 +18,13 @@ docker push $REGISTRY/custom-eval-tutorial-director
 ```
 
 Step4: Update the install yaml for your setup.
-```
-sed "s|REGISTRY_PLACEHOLDER|$REGISTRY|g" director.yaml | kubectl apply -f -
-```
+
+- For GKE users, run:
+    ```bash
+    sed "s|REGISTRY_PLACEHOLDER|$REGISTRY|g" director.yaml | kubectl apply -f -
+    ```
+- For Minikube users, [use local image](https://kubernetes.io/docs/setup/learning-environment/minikube/#use-local-images-by-re-using-the-docker-daemon) by running the following command:
+    ```bash
+    eval $(minikube docker-env)
+    sed "s|REGISTRY_PLACEHOLDER|$REGISTRY|g" director.yaml | sed "s|Always|Never|g" | kubectl apply -f -
+    ```

--- a/tutorials/custom_evaluator/evaluator/README.md
+++ b/tutorials/custom_evaluator/evaluator/README.md
@@ -1,6 +1,4 @@
 This folder provides a sample Evaluator for Open Match Matchmaker 101 Tutorial.
-<TODO - Update the README with details of the Evaluator and the steps that need
-to be run before executing the commamds below>
 
 Run the below steps in this folder to set up the Evaluator.
 
@@ -20,6 +18,13 @@ docker push $REGISTRY/custom-eval-tutorial-evaluator
 ```
 
 Step4: Update the install yaml for your setup.
-```
-sed "s|REGISTRY_PLACEHOLDER|$REGISTRY|g" evaluator.yaml | kubectl apply -f -
-```
+
+- For GKE users, run:
+    ```bash
+    sed "s|REGISTRY_PLACEHOLDER|$REGISTRY|g" evaluator.yaml | kubectl apply -f -
+    ```
+- For Minikube users, [use local image](https://kubernetes.io/docs/setup/learning-environment/minikube/#use-local-images-by-re-using-the-docker-daemon) by running the following command:
+    ```bash
+    eval $(minikube docker-env)
+    sed "s|REGISTRY_PLACEHOLDER|$REGISTRY|g" evaluator.yaml | sed "s|Always|Never|g" | kubectl apply -f -
+    ```

--- a/tutorials/custom_evaluator/frontend/README.md
+++ b/tutorials/custom_evaluator/frontend/README.md
@@ -1,6 +1,4 @@
 This folder provides a sample Frontend for Open Match Matchmaker 101 Tutorial.
-<TODO - Update the README with details of the Frontend and the steps that need
-to be run before executing the commamds below>
 
 Run the below steps in this folder to set up the Frontend.
 
@@ -20,6 +18,13 @@ docker push $REGISTRY/custom-eval-tutorial-frontend
 ```
 
 Step4: Update the install yaml for your setup.
-```
-sed "s|REGISTRY_PLACEHOLDER|$REGISTRY|g" frontend.yaml | kubectl apply -f -
-```
+
+- For GKE users, run:
+    ```bash
+    sed "s|REGISTRY_PLACEHOLDER|$REGISTRY|g" frontend.yaml | kubectl apply -f -
+    ```
+- For Minikube users, [use local image](https://kubernetes.io/docs/setup/learning-environment/minikube/#use-local-images-by-re-using-the-docker-daemon) by running the following command:
+    ```bash
+    eval $(minikube docker-env)
+    sed "s|REGISTRY_PLACEHOLDER|$REGISTRY|g" frontend.yaml | sed "s|Always|Never|g" | kubectl apply -f -
+    ```

--- a/tutorials/custom_evaluator/matchfunction/README.md
+++ b/tutorials/custom_evaluator/matchfunction/README.md
@@ -1,6 +1,4 @@
 This folder provides a sample Match Function for Open Match Matchmaker 101 Tutorial.
-<TODO - Update the README with details of the Match Function and the steps that need
-to be run before executing the commamds below>
 
 Run the below steps in this folder to set up the Match Function.
 
@@ -20,6 +18,13 @@ docker push $REGISTRY/custom-eval-tutorial-matchfunction
 ```
 
 Step4: Update the install yaml for your setup.
-```
-sed "s|REGISTRY_PLACEHOLDER|$REGISTRY|g" matchfunction.yaml | kubectl apply -f -
-```
+
+- For GKE users, run:
+    ```bash
+    sed "s|REGISTRY_PLACEHOLDER|$REGISTRY|g" matchfunction.yaml | kubectl apply -f -
+    ```
+- For Minikube users, [use local image](https://kubernetes.io/docs/setup/learning-environment/minikube/#use-local-images-by-re-using-the-docker-daemon) by running the following command:
+    ```bash
+    eval $(minikube docker-env)
+    sed "s|REGISTRY_PLACEHOLDER|$REGISTRY|g" matchfunction.yaml | sed "s|Always|Never|g" | kubectl apply -f -
+    ```

--- a/tutorials/default_evaluator/director/README.md
+++ b/tutorials/default_evaluator/director/README.md
@@ -1,6 +1,4 @@
 This folder provides a sample Director for Open Match Matchmaker 101 Tutorial.
-<TODO - Update the README with details of the Director and the steps that need
-to be run before executing the commamds below>
 
 Run the below steps in this folder to set up the Director.
 
@@ -20,6 +18,13 @@ docker push $REGISTRY/default-eval-tutorial-director
 ```
 
 Step4: Update the install yaml for your setup.
-```
-sed "s|REGISTRY_PLACEHOLDER|$REGISTRY|g" director.yaml | kubectl apply -f -
-```
+
+- For GKE users, run:
+    ```bash
+    sed "s|REGISTRY_PLACEHOLDER|$REGISTRY|g" director.yaml | kubectl apply -f -
+    ```
+- For Minikube users, [use local image](https://kubernetes.io/docs/setup/learning-environment/minikube/#use-local-images-by-re-using-the-docker-daemon) by running the following command:
+    ```bash
+    eval $(minikube docker-env)
+    sed "s|REGISTRY_PLACEHOLDER|$REGISTRY|g" director.yaml | sed "s|Always|Never|g" | kubectl apply -f -
+    ```

--- a/tutorials/default_evaluator/frontend/README.md
+++ b/tutorials/default_evaluator/frontend/README.md
@@ -1,6 +1,4 @@
 This folder provides a sample Frontend for Open Match Matchmaker 101 Tutorial.
-<TODO - Update the README with details of the Frontend and the steps that need
-to be run before executing the commamds below>
 
 Run the below steps in this folder to set up the Frontend.
 
@@ -20,6 +18,13 @@ docker push $REGISTRY/default-eval-tutorial-frontend
 ```
 
 Step4: Update the install yaml for your setup.
-```
-sed "s|REGISTRY_PLACEHOLDER|$REGISTRY|g" frontend.yaml | kubectl apply -f -
-```
+
+- For GKE users, run:
+    ```bash
+    sed "s|REGISTRY_PLACEHOLDER|$REGISTRY|g" frontend.yaml | kubectl apply -f -
+    ```
+- For Minikube users, [use local image](https://kubernetes.io/docs/setup/learning-environment/minikube/#use-local-images-by-re-using-the-docker-daemon) by running the following command:
+    ```bash
+    eval $(minikube docker-env)
+    sed "s|REGISTRY_PLACEHOLDER|$REGISTRY|g" frontend.yaml | sed "s|Always|Never|g" | kubectl apply -f -
+    ```

--- a/tutorials/default_evaluator/matchfunction/README.md
+++ b/tutorials/default_evaluator/matchfunction/README.md
@@ -1,6 +1,4 @@
 This folder provides a sample Match Function for Open Match Matchmaker 101 Tutorial.
-<TODO - Update the README with details of the Match Function and the steps that need
-to be run before executing the commamds below>
 
 Run the below steps in this folder to set up the Match Function.
 
@@ -20,6 +18,13 @@ docker push $REGISTRY/default-eval-tutorial-matchfunction
 ```
 
 Step4: Update the install yaml for your setup.
-```
-sed "s|REGISTRY_PLACEHOLDER|$REGISTRY|g" matchfunction.yaml | kubectl apply -f -
-```
+
+- For GKE users, run:
+    ```bash
+    sed "s|REGISTRY_PLACEHOLDER|$REGISTRY|g" matchfunction.yaml | kubectl apply -f -
+    ```
+- For Minikube users, [use local image](https://kubernetes.io/docs/setup/learning-environment/minikube/#use-local-images-by-re-using-the-docker-daemon) by running the following command:
+    ```bash
+    eval $(minikube docker-env)
+    sed "s|REGISTRY_PLACEHOLDER|$REGISTRY|g" matchfunction.yaml | sed "s|Always|Never|g" | kubectl apply -f -
+    ```

--- a/tutorials/matchmaker101/director/README.md
+++ b/tutorials/matchmaker101/director/README.md
@@ -1,6 +1,4 @@
 This folder provides a sample Director for Open Match Matchmaker 101 Tutorial.
-<TODO - Update the README with details of the Director and the steps that need
-to be run before executing the commamds below>
 
 Run the below steps in this folder to set up the Director.
 
@@ -20,6 +18,13 @@ docker push $REGISTRY/mm101-tutorial-director
 ```
 
 Step4: Update the install yaml for your setup.
-```
-sed "s|REGISTRY_PLACEHOLDER|$REGISTRY|g" director.yaml | kubectl apply -f -
-```
+
+- For GKE users, run:
+    ```
+    sed "s|REGISTRY_PLACEHOLDER|$REGISTRY|g" director.yaml | kubectl apply -f -
+    ```
+- For Minikube users, [use local image](https://kubernetes.io/docs/setup/learning-environment/minikube/#use-local-images-by-re-using-the-docker-daemon) by running the following command:
+    ```bash
+    eval $(minikube docker-env)
+    sed "s|REGISTRY_PLACEHOLDER|$REGISTRY|g" director.yaml | sed "s|Always|Never|g" | kubectl apply -f -
+    ```

--- a/tutorials/matchmaker101/frontend/README.md
+++ b/tutorials/matchmaker101/frontend/README.md
@@ -1,6 +1,4 @@
 This folder provides a sample Frontend for Open Match Matchmaker 101 Tutorial.
-<TODO - Update the README with details of the Frontend and the steps that need
-to be run before executing the commamds below>
 
 Run the below steps in this folder to set up the Frontend.
 
@@ -20,6 +18,13 @@ docker push $REGISTRY/mm101-tutorial-frontend
 ```
 
 Step4: Update the install yaml for your setup.
-```
-sed "s|REGISTRY_PLACEHOLDER|$REGISTRY|g" frontend.yaml | kubectl apply -f -
-```
+
+- For GKE users, run:
+    ```
+    sed "s|REGISTRY_PLACEHOLDER|$REGISTRY|g" frontend.yaml | kubectl apply -f -
+    ```
+- For Minikube users, [use local image](https://kubernetes.io/docs/setup/learning-environment/minikube/#use-local-images-by-re-using-the-docker-daemon) by running the following command:
+    ```bash
+    eval $(minikube docker-env)
+    sed "s|REGISTRY_PLACEHOLDER|$REGISTRY|g" frontend.yaml | sed "s|Always|Never|g" | kubectl apply -f -
+    ```

--- a/tutorials/matchmaker101/frontend/ticket.go
+++ b/tutorials/matchmaker101/frontend/ticket.go
@@ -15,6 +15,9 @@
 package main
 
 import (
+	// Uncomment if following the tutorial
+	// "math/rand"
+
 	"open-match.dev/open-match/pkg/pb"
 )
 

--- a/tutorials/matchmaker101/matchfunction/README.md
+++ b/tutorials/matchmaker101/matchfunction/README.md
@@ -1,6 +1,4 @@
 This folder provides a sample Match Function for Open Match Matchmaker 101 Tutorial.
-<TODO - Update the README with details of the Match Function and the steps that need
-to be run before executing the commamds below>
 
 Run the below steps in this folder to set up the Match Function.
 
@@ -20,6 +18,13 @@ docker push $REGISTRY/mm101-tutorial-matchfunction
 ```
 
 Step4: Update the install yaml for your setup.
-```
-sed "s|REGISTRY_PLACEHOLDER|$REGISTRY|g" matchfunction.yaml | kubectl apply -f -
-```
+
+- For GKE users, run:
+    ```bash
+    sed "s|REGISTRY_PLACEHOLDER|$REGISTRY|g" matchfunction.yaml | kubectl apply -f -
+    ```
+- For Minikube users, [use local image](https://kubernetes.io/docs/setup/learning-environment/minikube/#use-local-images-by-re-using-the-docker-daemon) by running the following command:
+    ```bash
+    eval $(minikube docker-env)
+    sed "s|REGISTRY_PLACEHOLDER|$REGISTRY|g" matchfunction.yaml | sed "s|Always|Never|g" | kubectl apply -f -
+    ```

--- a/tutorials/matchmaker101/matchfunction/mmf/matchfunction.go
+++ b/tutorials/matchmaker101/matchfunction/mmf/matchfunction.go
@@ -17,12 +17,19 @@ package mmf
 import (
 	"log"
 
+	// Uncomment if following the tutorial
+	// "fmt"
+	// "time"
+
 	"open-match.dev/open-match/pkg/matchfunction"
 	"open-match.dev/open-match/pkg/pb"
 )
 
 const (
 	matchName = "basic-matchfunction"
+
+	// Uncomment if following the tutorial
+	// ticketsPerPoolPerMatch = 4
 )
 
 // Run is this match function's implementation of the gRPC call defined in api/matchfunction.proto.

--- a/tutorials/matchmaker101/matchmaker.yaml
+++ b/tutorials/matchmaker101/matchmaker.yaml
@@ -39,3 +39,40 @@ spec:
     image: REGISTRY_PLACEHOLDER/mm101-tutorial-frontend:latest
     imagePullPolicy: Always
   hostname: mm101-tutorial-frontend
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: mm101-tutorial-matchfunction
+  namespace: mm101-tutorial
+  labels:
+    app: mm101-tutorial
+    component: matchfunction
+spec:
+  containers:
+  - name: mm101-tutorial-matchfunction
+    image: REGISTRY_PLACEHOLDER/mm101-tutorial-matchfunction:latest
+    imagePullPolicy: Always
+    ports:
+    - name: grpc
+      containerPort: 50502
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: mm101-tutorial-matchfunction
+  namespace: mm101-tutorial
+  labels:
+    app: mm101-tutorial
+    component: matchfunction
+spec:
+  selector:
+    app: mm101-tutorial
+    component: matchfunction
+  clusterIP: None
+  type: ClusterIP
+  ports:
+  - name: grpc
+    protocol: TCP
+    port: 50502
+---

--- a/tutorials/matchmaker102/director/README.md
+++ b/tutorials/matchmaker102/director/README.md
@@ -1,6 +1,4 @@
 This folder provides a sample Director for Open Match Matchmaker 101 Tutorial.
-<TODO - Update the README with details of the Director and the steps that need
-to be run before executing the commamds below>
 
 Run the below steps in this folder to set up the Director.
 
@@ -20,6 +18,13 @@ docker push $REGISTRY/mm102-tutorial-director
 ```
 
 Step4: Update the install yaml for your setup.
-```
-sed "s|REGISTRY_PLACEHOLDER|$REGISTRY|g" director.yaml | kubectl apply -f -
-```
+
+- For GKE users, run:
+    ```
+    sed "s|REGISTRY_PLACEHOLDER|$REGISTRY|g" director.yaml | kubectl apply -f -
+    ```
+- For Minikube users, [use local image](https://kubernetes.io/docs/setup/learning-environment/minikube/#use-local-images-by-re-using-the-docker-daemon) by running the following command:
+    ```bash
+    eval $(minikube docker-env)
+    sed "s|REGISTRY_PLACEHOLDER|$REGISTRY|g" director.yaml | sed "s|Always|Never|g" | kubectl apply -f -
+    ```

--- a/tutorials/matchmaker102/frontend/README.md
+++ b/tutorials/matchmaker102/frontend/README.md
@@ -1,6 +1,4 @@
 This folder provides a sample Frontend for Open Match Matchmaker 101 Tutorial.
-<TODO - Update the README with details of the Frontend and the steps that need
-to be run before executing the commamds below>
 
 Run the below steps in this folder to set up the Frontend.
 
@@ -20,6 +18,13 @@ docker push $REGISTRY/mm102-tutorial-frontend
 ```
 
 Step4: Update the install yaml for your setup.
-```
-sed "s|REGISTRY_PLACEHOLDER|$REGISTRY|g" frontend.yaml | kubectl apply -f -
-```
+
+- For GKE users, run:
+    ```
+    sed "s|REGISTRY_PLACEHOLDER|$REGISTRY|g" frontend.yaml | kubectl apply -f -
+    ```
+- For Minikube users, [use local image](https://kubernetes.io/docs/setup/learning-environment/minikube/#use-local-images-by-re-using-the-docker-daemon) by running the following command:
+    ```bash
+    eval $(minikube docker-env)
+    sed "s|REGISTRY_PLACEHOLDER|$REGISTRY|g" frontend.yaml | sed "s|Always|Never|g" | kubectl apply -f -
+    ```

--- a/tutorials/matchmaker102/matchfunction/README.md
+++ b/tutorials/matchmaker102/matchfunction/README.md
@@ -1,6 +1,4 @@
 This folder provides a sample Match Function for Open Match Matchmaker 101 Tutorial.
-<TODO - Update the README with details of the Match Function and the steps that need
-to be run before executing the commamds below>
 
 Run the below steps in this folder to set up the Match Function.
 
@@ -20,6 +18,13 @@ docker push $REGISTRY/mm102-tutorial-matchfunction
 ```
 
 Step4: Update the install yaml for your setup.
-```
-sed "s|REGISTRY_PLACEHOLDER|$REGISTRY|g" matchfunction.yaml | kubectl apply -f -
-```
+
+- For GKE users, run:
+    ```
+    sed "s|REGISTRY_PLACEHOLDER|$REGISTRY|g" matchfunction.yaml | kubectl apply -f -
+    ```
+- For Minikube users, [use local image](https://kubernetes.io/docs/setup/learning-environment/minikube/#use-local-images-by-re-using-the-docker-daemon) by running the following command:
+    ```bash
+    eval $(minikube docker-env)
+    sed "s|REGISTRY_PLACEHOLDER|$REGISTRY|g" matchfunction.yaml | sed "s|Always|Never|g" | kubectl apply -f -
+    ```


### PR DESCRIPTION
Cherry-pick the tutorial changes to 0.8 branch. Per discussion, there is no need for a hot-fix release since this commit only affects the tutorial directory.