### PR TITLE
Fix Redis Err: Max Clients Reached error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -610,7 +610,7 @@ get-kind-kubeconfig: build/toolchain/bin/kind$(EXE_EXTENSION)
 delete-kind-cluster: build/toolchain/bin/kind$(EXE_EXTENSION) build/toolchain/bin/kubectl$(EXE_EXTENSION)
 	-$(KIND) delete cluster
 
-create-gke-cluster: GKE_VERSION = 1.14.7-gke.17 # gcloud beta container get-server-config --zone us-west1-a
+create-gke-cluster: GKE_VERSION = 1.14.8-gke.17 # gcloud beta container get-server-config --zone us-west1-a
 create-gke-cluster: GKE_CLUSTER_SHAPE_FLAGS = --machine-type n1-standard-4 --enable-autoscaling --min-nodes 1 --num-nodes 2 --max-nodes 10 --disk-size 50
 create-gke-cluster: GKE_FUTURE_COMPAT_FLAGS = --no-enable-basic-auth --no-issue-client-certificate --enable-ip-alias --metadata disable-legacy-endpoints=true --enable-autoupgrade
 create-gke-cluster: build/toolchain/bin/kubectl$(EXE_EXTENSION) gcloud

--- a/install/helm/open-match/subcharts/open-match-customize/templates/evaluator.yaml
+++ b/install/helm/open-match/subcharts/open-match-customize/templates/evaluator.yaml
@@ -99,3 +99,4 @@ spec:
           containerPort: {{ .Values.evaluator.httpPort }}
         {{- include "openmatch.container.common" . | nindent 8 }}
 {{- end }}
+

--- a/install/helm/open-match/subcharts/open-match-customize/templates/matchfunctions.yaml
+++ b/install/helm/open-match/subcharts/open-match-customize/templates/matchfunctions.yaml
@@ -100,3 +100,4 @@ spec:
           containerPort: {{ .Values.function.httpPort }}
         {{- include "openmatch.container.common" . | nindent 8 }}
 {{- end }}
+

--- a/install/helm/open-match/subcharts/open-match-scale/values.yaml
+++ b/install/helm/open-match/subcharts/open-match-scale/values.yaml
@@ -29,7 +29,7 @@ configs:
     configName: scale-configmap
 
 testConfig:
-  profile: greedy
+  profile: scaleprofiles
   concurrentCreates: 500
   regions:
     - region.europe-west1

--- a/install/helm/open-match/templates/_helpers.tpl
+++ b/install/helm/open-match/templates/_helpers.tpl
@@ -119,6 +119,6 @@ readinessProbe:
 
 {{- define "openmatch.HorizontalPodAutoscaler.spec.common" -}}
 minReplicas: 1
-maxReplicas: 30
-targetCPUUtilizationPercentage: 50
+maxReplicas: 50
+targetCPUUtilizationPercentage: 80
 {{- end -}}

--- a/install/helm/open-match/templates/om-configmap-default.yaml
+++ b/install/helm/open-match/templates/om-configmap-default.yaml
@@ -88,7 +88,7 @@ data:
       passwordPath: {{ .Values.redis.secretMountPath }}/redis-password
 {{- end }}
       pool:
-        maxIdle: 5000
+        maxIdle: 200
         maxActive: 0
         idleTimeout: 60s
         healthCheckTimeout: 100ms

--- a/install/helm/open-match/templates/om-configmap-override.yaml
+++ b/install/helm/open-match/templates/om-configmap-override.yaml
@@ -33,5 +33,5 @@ data:
     synchronizer:
       enabled: true
       registrationIntervalMs: 3000ms
-      proposalCollectionIntervalMs: 2000ms
+      proposalCollectionIntervalMs: 15000ms
 {{- end }}

--- a/install/helm/open-match/values.yaml
+++ b/install/helm/open-match/values.yaml
@@ -106,11 +106,13 @@ configs:
 redis:
   fullnameOverride: om-redis
   redisPort: 6379
-  usePassword: true
-  usePasswordFile: true
+  usePassword: false
+  usePasswordFile: false
   secretMountPath: /opt/bitnami/redis/secrets
   ignoreLists:
     ttl: 60000ms
+  configmap:
+    maxclients 100000
   master:
     disableCommands: [] # don't disable 'FLUSH-' commands
   metrics:
@@ -132,8 +134,8 @@ redis:
       - -c
       - |-
         install_packages procps
-        sysctl -w net.core.somaxconn=10000
-        echo never > /host-sys/kernel/mm/transparent_hugepage/enabled
+        sysctl -w net.core.somaxconn=100000
+        echo never > /host-sys/kernel/mm/transparent_hugepage/enabled # Disable THP support
 
 ###############################################################################################################################
 #                               Open Match configurations for the subcharts
@@ -221,7 +223,7 @@ global:
       enabled: true
     jaeger:
       enabled: false
-      samplerFraction: 1 # Configures a sampler that samples a given fraction of traces.
+      samplerFraction: 0.01 # Configures a sampler that samples a given fraction of traces.
       agentEndpoint: "open-match-jaeger-agent:6831"
       collectorEndpoint: "http://open-match-jaeger-collector:14268/api/traces"
     prometheus:


### PR DESCRIPTION
This commit fixed an issue where Open Match may throw out `Err: max clients reached` errors from Redis side under load testing scenarios. At this point, Open Match should be able to scale with 1600 profiles and 5000 tickets in the statestore.

The reason that we got those errors from Redis is by default Redis set its `maxClient` connections limit to 10k. However, Open Match has `maxIdle` number set to 5000 per pod, which exceed Redis's limit and failed the API calls. This commit manually overrides the maxClient number to 100k, reduce the maxIdle number to 200, and configure the file descriptors' limit to 10k by setting `sysctl -w net.core.somaxconn=100000` using the initContainer if enabled.