### PR TITLE
Reduced in-cluster test flakiness and stablize gRPC client connections

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -325,7 +325,7 @@ install-chart-prerequisite: build/toolchain/bin/kubectl$(EXE_EXTENSION) update-c
 	$(KUBECTL) apply -f install/gke-metadata-server-workaround.yaml
 
 # Used for Open Match development. Install om-configmap-override.yaml by default.
-HELM_UPGRADE_FLAGS = --cleanup-on-fail -i --atomic --no-hooks --debug --timeout=600s --namespace=$(OPEN_MATCH_KUBERNETES_NAMESPACE) --set global.gcpProjectId=$(GCP_PROJECT_ID) --set open-match-override.enabled=true
+HELM_UPGRADE_FLAGS = --cleanup-on-fail -i --no-hooks --debug --timeout=600s --namespace=$(OPEN_MATCH_KUBERNETES_NAMESPACE) --set global.gcpProjectId=$(GCP_PROJECT_ID) --set open-match-override.enabled=true
 # Used for generate static yamls. Install om-configmap-override.yaml as needed.
 HELM_TEMPLATE_FLAGS = --no-hooks --namespace $(OPEN_MATCH_KUBERNETES_NAMESPACE) --set usingHelmTemplate=true
 HELM_IMAGE_FLAGS = --set global.image.registry=$(REGISTRY) --set global.image.tag=$(TAG)
@@ -715,7 +715,7 @@ test: $(ALL_PROTOS) tls-certs third_party/
 	$(GO) test -cover -test.count $(GOLANG_TEST_COUNT) -run IgnoreRace$$ ./...
 
 test-e2e-cluster: all-protos tls-certs third_party/
-	$(HELM) test --logs --timeout 5m0s -n $(OPEN_MATCH_KUBERNETES_NAMESPACE) $(OPEN_MATCH_HELM_NAME)
+	$(HELM) test --logs -n $(OPEN_MATCH_KUBERNETES_NAMESPACE) $(OPEN_MATCH_HELM_NAME)
 
 stress-frontend-%: build/toolchain/python/
 	$(TOOLCHAIN_DIR)/python/bin/locust -f $(REPOSITORY_ROOT)/test/stress/frontend.py --host=http://localhost:$(FRONTEND_PORT) \

--- a/examples/functions/golang/rosterbased/mmf/server.go
+++ b/examples/functions/golang/rosterbased/mmf/server.go
@@ -39,6 +39,7 @@ var (
 	})
 )
 
+// nolint: gochecknoinits
 func init() {
 	// Using gRPC's DNS resolver to create clients.
 	// This is a workaround for load balancing gRPC applications under k8s environments.
@@ -102,6 +103,12 @@ func newGRPCServerOptions() []grpc.ServerOption {
 	return []grpc.ServerOption{
 		grpc.StreamInterceptor(grpc_middleware.ChainStreamServer(si...)),
 		grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(ui...)),
+		grpc.KeepaliveEnforcementPolicy(
+			keepalive.EnforcementPolicy{
+				MinTime:             10 * time.Second,
+				PermitWithoutStream: true,
+			},
+		),
 	}
 }
 

--- a/internal/rpc/server.go
+++ b/internal/rpc/server.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
+	"time"
 
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_logrus "github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus"
@@ -33,6 +34,7 @@ import (
 	"go.opencensus.io/plugin/ochttp"
 	"go.opencensus.io/plugin/ochttp/propagation/b3"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
 	"open-match.dev/open-match/internal/config"
 	"open-match.dev/open-match/internal/logging"
 	"open-match.dev/open-match/internal/signal"
@@ -336,5 +338,11 @@ func newGRPCServerOptions(params *ServerParams) []grpc.ServerOption {
 
 	return append(opts,
 		grpc.StreamInterceptor(grpc_middleware.ChainStreamServer(si...)),
-		grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(ui...)))
+		grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(ui...)),
+		grpc.KeepaliveEnforcementPolicy(
+			keepalive.EnforcementPolicy{
+				MinTime:             10 * time.Second,
+				PermitWithoutStream: true,
+			},
+		))
 }

--- a/internal/testing/e2e/cluster.go
+++ b/internal/testing/e2e/cluster.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/resolver"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -33,8 +34,15 @@ import (
 	"open-match.dev/open-match/internal/logging"
 	"open-match.dev/open-match/internal/rpc"
 	"open-match.dev/open-match/internal/util"
+
 	pb "open-match.dev/open-match/pkg/pb"
 )
+
+func init() {
+	// Reset the gRPC resolver to passthrough for end-to-end out-of-cluster testings.
+	// DNS resolver is unsupported for end-to-end local testings.
+	resolver.SetDefaultScheme("dns")
+}
 
 type clusterOM struct {
 	kubeClient kubernetes.Interface

--- a/internal/testing/e2e/common.go
+++ b/internal/testing/e2e/common.go
@@ -21,8 +21,6 @@ import (
 	"os"
 	"testing"
 
-	"google.golang.org/grpc/resolver"
-
 	pb "open-match.dev/open-match/pkg/pb"
 )
 
@@ -62,9 +60,6 @@ func New(t *testing.T) (OM, func()) {
 
 // RunMain provides the setup and teardown for Open Match e2e tests.
 func RunMain(m *testing.M) {
-	// Reset the gRPC resolver to passthrough for end-to-end out-of-cluster testings.
-	// DNS resolver is unsupported for end-to-end local testings.
-	resolver.SetDefaultScheme("passthrough")
 	var exitCode int
 	z, err := createZygote(m)
 	if err != nil {

--- a/internal/testing/e2e/in_memory.go
+++ b/internal/testing/e2e/in_memory.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/resolver"
 	simple "open-match.dev/open-match/examples/evaluator/golang/simple/evaluate"
 	pool "open-match.dev/open-match/examples/functions/golang/pool/mmf"
 	"open-match.dev/open-match/internal/app/minimatch"
@@ -33,6 +34,13 @@ import (
 	mmfHarness "open-match.dev/open-match/pkg/harness/function/golang"
 	pb "open-match.dev/open-match/pkg/pb"
 )
+
+// nolint:gochecknoinits
+func init() {
+	// Reset the gRPC resolver to passthrough for end-to-end out-of-cluster testings.
+	// DNS resolver is unsupported for end-to-end local testings.
+	resolver.SetDefaultScheme("passthrough")
+}
 
 type inmemoryOM struct {
 	mainTc *rpcTesting.TestContext

--- a/pkg/harness/function/golang/matchfunction_service.go
+++ b/pkg/harness/function/golang/matchfunction_service.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
 	"open-match.dev/open-match/internal/config"
 	"open-match.dev/open-match/internal/rpc"
 	"open-match.dev/open-match/pkg/pb"
@@ -123,7 +124,7 @@ func (s *matchFunctionService) getMatchManifest(ctx context.Context, req *pb.Run
 	filterPools := req.GetProfile().GetPools()
 
 	for _, pool := range filterPools {
-		qtClient, err := s.mmlogicClient.QueryTickets(ctx, &pb.QueryTicketsRequest{Pool: pool})
+		qtClient, err := s.mmlogicClient.QueryTickets(ctx, &pb.QueryTicketsRequest{Pool: pool}, grpc.WaitForReady(true))
 		if err != nil {
 			logger.WithError(err).Error("Failed to get queryTicketClient from mmlogic.")
 			return nil, err

--- a/test/e2e/game_flow_test.go
+++ b/test/e2e/game_flow_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 	statestoreTesting "open-match.dev/open-match/internal/statestore/testing"
 	"open-match.dev/open-match/internal/testing/e2e"
 	"open-match.dev/open-match/pkg/pb"
@@ -122,7 +123,7 @@ func TestGameMatchWorkFlow(t *testing.T) {
 	// 1. Create a few tickets with delicate designs and hand crafted search fields
 	for i := 0; i < len(tickets); i++ {
 		var ctResp *pb.CreateTicketResponse
-		ctResp, err = fe.CreateTicket(ctx, &pb.CreateTicketRequest{Ticket: tickets[i]})
+		ctResp, err = fe.CreateTicket(ctx, &pb.CreateTicketRequest{Ticket: tickets[i]}, grpc.WaitForReady(true))
 		require.Nil(t, err)
 		require.NotNil(t, ctResp)
 		// Assign Open Match ids back to the input tickets
@@ -176,7 +177,7 @@ func TestGameMatchWorkFlow(t *testing.T) {
 		for _, ticket := range tickets {
 			tids = append(tids, ticket.GetId())
 		}
-		gotAtResp, err = be.AssignTickets(ctx, &pb.AssignTicketsRequest{TicketIds: tids, Assignment: &pb.Assignment{Connection: "agones-1"}})
+		gotAtResp, err = be.AssignTickets(ctx, &pb.AssignTicketsRequest{TicketIds: tids, Assignment: &pb.Assignment{Connection: "agones-1"}}, grpc.WaitForReady(true))
 		require.Nil(t, err)
 		require.NotNil(t, gotAtResp)
 	}
@@ -188,7 +189,7 @@ func TestGameMatchWorkFlow(t *testing.T) {
 
 	// 7. Call frontend.DeleteTicket to delete the tickets returned in step 6.
 	var gotDtResp *pb.DeleteTicketResponse
-	gotDtResp, err = fe.DeleteTicket(ctx, &pb.DeleteTicketRequest{TicketId: ticket1.GetId()})
+	gotDtResp, err = fe.DeleteTicket(ctx, &pb.DeleteTicketRequest{TicketId: ticket1.GetId()}, grpc.WaitForReady(true))
 	require.Nil(t, err)
 	require.NotNil(t, gotDtResp)
 
@@ -199,7 +200,7 @@ func TestGameMatchWorkFlow(t *testing.T) {
 }
 
 func validateFetchMatchesResponse(ctx context.Context, t *testing.T, wantTickets [][]*pb.Ticket, be pb.BackendClient, fmReq *pb.FetchMatchesRequest) {
-	stream, err := be.FetchMatches(ctx, fmReq)
+	stream, err := be.FetchMatches(ctx, fmReq, grpc.WaitForReady(true))
 	require.Nil(t, err)
 	matches := make([]*pb.Match, 0)
 	for {


### PR DESCRIPTION
This commit does the following things:

1. Explicitly enabled the `dns` resolver in the in-cluster end-to-end test to make sure the load balancer works as expected.
2. Reduced test flakiness by setting `keepalive.EnforcementPolicy` with `PermitWithoutStream` to `true` to match the option set on the client side. Otherwise, if we turn on the grpc logger `GRPC_GO_LOG_VERBOSITY_LEVEL=99 GRPC_GO_LOG_SEVERITY_LEVEL=info`, we will see the bidirectional stream server sending `GOAWAY, received too many pings` or `ENHANCE_YOUR_CALM` signal to the clients that has KeepAlive enabled under the hood.
3. Added a `grpc.WaitForReady(true)` call option to each of our end-to-end test calls. We decoupled our MMF from the internal library in v0.8 - which removed the healthcheck handler and k8s readiness probes from our customize helm chart. This may introduce some flakiness where the MMFs and evaluators reported themselves as ready when they are not fully initialized. This call option changed the call behavior in the in-cluster end-to-end from failfast to waitforready to mitigate this issue.