### PR TITLE
Fixed terraform google provider version to 2.9

### DIFF
--- a/install/terraform/open-match-build/versions.tf
+++ b/install/terraform/open-match-build/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_version = ">= 0.12"
 
   required_providers {
-    google = "= 2.8"
-    google-beta = "= 2.8"
+    google = "= 2.9"
+    google-beta = "= 2.9"
   }
 }

--- a/install/terraform/open-match-build/versions.tf
+++ b/install/terraform/open-match-build/versions.tf
@@ -1,0 +1,9 @@
+
+terraform {
+  required_version = ">= 0.12"
+
+  required_providers {
+    google = "= 2.8"
+    google-beta = "= 2.8"
+  }
+}

--- a/install/terraform/open-match/secure-gke.tf
+++ b/install/terraform/open-match/secure-gke.tf
@@ -52,6 +52,7 @@ variable "gcp_location" {
   description = "Location where resources in GCP will be located."
   default     = "us-west1-a"
 }
+
 variable "gcp_machine_type" {
   description = "Machine type of VM."
   default     = "n1-standard-4"
@@ -59,13 +60,13 @@ variable "gcp_machine_type" {
 
 # Enable Kubernetes and Cloud Resource Manager API
 resource "google_project_services" "gcp_apis" {
-  project  = "${var.gcp_project_id}"
+  project  = var.gcp_project_id
   services = ["container.googleapis.com", "cloudresourcemanager.googleapis.com"]
 }
 
 # Create a role with the minimum amount of permissions for logging, auditing, etc from the node VM.
 resource "google_project_iam_custom_role" "open_match_node_vm_role" {
-  project     = "${var.gcp_project_id}"
+  project     = var.gcp_project_id
   role_id     = "open_match_node_vm"
   title       = "Open Match Service Agent"
   description = "Role for Open Match Cluster to interact with Google APIs"
@@ -84,14 +85,14 @@ resource "google_project_iam_custom_role" "open_match_node_vm_role" {
 # Create a low-privileged service account that will be the identity of the Node VMs that run Open Match.
 # This service account is mainly used to export service health and logging data to Stackdriver.
 resource "google_service_account" "node_vm" {
-  project      = "${var.gcp_project_id}"
+  project      = var.gcp_project_id
   account_id   = "open-match-node-vm"
   display_name = "Open Match Node VM Service Account"
 }
 
 # Create the IAM role binding {Node VM service account to the minimal role.}
 resource "google_project_iam_binding" "node_vm_binding" {
-  project = "${google_project_iam_custom_role.open_match_node_vm_role.project}"
+  project = google_project_iam_custom_role.open_match_node_vm_role.project
   role    = "projects/${google_project_iam_custom_role.open_match_node_vm_role.project}/roles/${google_project_iam_custom_role.open_match_node_vm_role.role_id}"
   members = [
     "user:${google_service_account.node_vm.name}",
@@ -100,10 +101,10 @@ resource "google_project_iam_binding" "node_vm_binding" {
 
 # Create a GKE Cluster for serving Open Match.
 resource "google_container_cluster" "primary" {
-  provider = "google-beta"
+  provider = google-beta
 
   name     = "om-cluster"
-  location = "${var.gcp_location}"
+  location = var.gcp_location
 
   addons_config {
     horizontal_pod_autoscaling {
@@ -193,7 +194,7 @@ resource "google_container_cluster" "primary" {
     enabled = false
   }
 
-  project                  = "${var.gcp_project_id}"
+  project                  = var.gcp_project_id
   remove_default_node_pool = true
 
   /*
@@ -208,11 +209,11 @@ resource "google_container_cluster" "primary" {
 
 # Create a Node Pool inside the GKE cluster to serve the Open Match services.
 resource "google_container_node_pool" "om-services" {
-  provider = "google-beta"
+  provider = google-beta
 
   name     = "open-match-services"
-  cluster  = "${google_container_cluster.primary.name}"
-  location = "${google_container_cluster.primary.location}"
+  cluster  = google_container_cluster.primary.name
+  location = google_container_cluster.primary.location
 
   autoscaling {
     min_node_count = 1
@@ -228,19 +229,22 @@ resource "google_container_node_pool" "om-services" {
   node_config {
     disk_size_gb = 50
     disk_type    = "pd-standard"
+
     /*
     guest_accelerator {
       
     }
     */
     image_type = "cos_containerd"
+
     /*
     labels {
       
     }
     */
     local_ssd_count = 0
-    machine_type    = "${var.gcp_machine_type}"
+    machine_type    = var.gcp_machine_type
+
     /*
     metadata {
       disable-legacy-endpoints = "true"
@@ -255,8 +259,9 @@ resource "google_container_node_pool" "om-services" {
       "https://www.googleapis.com/auth/monitoring",
     ]
     preemptible     = false
-    service_account = "${google_service_account.node_vm.email}"
+    service_account = google_service_account.node_vm.email
     tags            = []
+
     /*
     taint {
       
@@ -267,28 +272,29 @@ resource "google_container_node_pool" "om-services" {
     }
   }
   node_count = 5
-  project    = "${google_container_cluster.primary.project}"
+  project    = google_container_cluster.primary.project
   version    = "1.13"
 
   depends_on = [google_project_services.gcp_apis]
 }
 
 output "cluster_name" {
-  value = "${google_container_cluster.primary.name}"
+  value = google_container_cluster.primary.name
 }
 
 output "primary_zone" {
-  value = "${google_container_cluster.primary.zone}"
+  value = google_container_cluster.primary.zone
 }
 
 output "additional_zones" {
-  value = "${google_container_cluster.primary.additional_zones}"
+  value = google_container_cluster.primary.additional_zones
 }
 
 output "endpoint" {
-  value = "${google_container_cluster.primary.endpoint}"
+  value = google_container_cluster.primary.endpoint
 }
 
 output "node_version" {
-  value = "${google_container_cluster.primary.node_version}"
+  value = google_container_cluster.primary.node_version
 }
+

--- a/install/terraform/open-match/versions.tf
+++ b/install/terraform/open-match/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_version = ">= 0.12"
 
   required_providers {
-    google = "= 2.8"
-    google-beta = "= 2.8"
+    google = "= 2.9"
+    google-beta = "= 2.9"
   }
 }

--- a/install/terraform/open-match/versions.tf
+++ b/install/terraform/open-match/versions.tf
@@ -1,0 +1,9 @@
+
+terraform {
+  required_version = ">= 0.12"
+
+  required_providers {
+    google = "= 2.8"
+    google-beta = "= 2.8"
+  }
+}


### PR DESCRIPTION
Google recently updated its terraform provider version to 3.0 and it involves a bunch of incompatible changes which blocks the CI - since the CI is using the latest version by default. This commit added a `versions.tf` file and defined the google provider version to 2.8 to unblock the CI.

The rest of the changes are reformat/syntax updates.