### PR TITLE
Have synchronizerClient use cacher, to update on config changes

### DIFF
--- a/internal/app/backend/backend.go
+++ b/internal/app/backend/backend.go
@@ -25,7 +25,7 @@ import (
 // BindService creates the backend service and binds it to the serving harness.
 func BindService(p *rpc.ServerParams, cfg config.View) error {
 	service := &backendService{
-		synchronizer: &synchronizerClient{cfg: cfg},
+		synchronizer: newSynchronizerClient(cfg),
 		store:        statestore.New(cfg),
 		mmfClients:   rpc.NewClientCache(cfg),
 	}

--- a/internal/app/backend/synchronizer_client.go
+++ b/internal/app/backend/synchronizer_client.go
@@ -3,7 +3,6 @@ package backend
 import (
 	"context"
 	"io"
-	"sync"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -20,26 +19,45 @@ var (
 )
 
 type synchronizerClient struct {
-	cfg          config.View
-	synchronizer ipb.SynchronizerClient
-	m            sync.Mutex
+	enabled func() bool
+	cacher  *config.Cacher
+}
+
+func newSynchronizerClient(cfg config.View) *synchronizerClient {
+	newInstance := func(cfg config.View) (interface{}, error) {
+		conn, err := rpc.GRPCClientFromConfig(cfg, "api.synchronizer")
+		if err != nil {
+			return nil, err
+		}
+
+		return ipb.NewSynchronizerClient(conn), nil
+	}
+
+	enabled := func() bool {
+		return cfg.GetBool("synchronizer.enabled")
+	}
+
+	return &synchronizerClient{
+		enabled: enabled,
+		cacher:  config.NewCacher(cfg, newInstance),
+	}
 }
 
 // register calls the Register method on Synchronizer service. It only triggers this
 // if the synchronizer is enabled. The first attempt to call the synchronizer service
 // establishes a connection. Consequent requests use the cached connection.
 func (sc *synchronizerClient) register(ctx context.Context) (string, error) {
-	if !sc.cfg.GetBool("synchronizer.enabled") {
+	if !sc.enabled() {
 		// Synchronizer is disabled. Succeed the call without returning any ID.
 		return "", nil
 	}
 
-	if err := sc.initialize(); err != nil {
-		// Failed to connect to the synchronizer service.
+	client, err := sc.cacher.Get()
+	if err != nil {
 		return "", err
 	}
 
-	resp, err := sc.synchronizer.Register(ctx, &ipb.RegisterRequest{})
+	resp, err := client.(ipb.SynchronizerClient).Register(ctx, &ipb.RegisterRequest{})
 	if err != nil {
 		return "", err
 	}
@@ -51,23 +69,23 @@ func (sc *synchronizerClient) register(ctx context.Context) (string, error) {
 // this if the synchronizer is enabled. The first attempt to call the synchronizer service
 // establishes a connection. Consequent requests use the cached connection.
 func (sc *synchronizerClient) evaluate(ctx context.Context, id string, proposals []*pb.Match) ([]*pb.Match, error) {
-	if !sc.cfg.GetBool("synchronizer.enabled") {
+	if !sc.enabled() {
 		// Synchronizer is disabled. Return all the proposals as results. This is only temporary.
 		// After the synchronizer is implememnted, it will be mandatory and this check will be removed.
 		return proposals, nil
 	}
 
-	if err := sc.initialize(); err != nil {
-		// Failed to connect to the synchronizer service.
+	client, err := sc.cacher.Get()
+	if err != nil {
 		return nil, err
 	}
 
-	ctx, err := util.AppendSynchronizerContextID(ctx, id)
+	ctx, err = util.AppendSynchronizerContextID(ctx, id)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "%v", err)
 	}
 
-	stream, err := sc.synchronizer.EvaluateProposals(ctx)
+	stream, err := client.(ipb.SynchronizerClient).EvaluateProposals(ctx)
 	for _, proposal := range proposals {
 		if err = stream.Send(&ipb.EvaluateProposalsRequest{Id: id, Match: proposal}); err != nil {
 			return nil, err
@@ -93,21 +111,4 @@ func (sc *synchronizerClient) evaluate(ctx context.Context, id string, proposals
 
 	telemetry.RecordNUnitMeasurement(ctx, mMatchEvaluations, int64(len(results)))
 	return results, nil
-}
-
-// initialize attempts to connect to the Sychronizer service. If the connection is
-// successful, the client is cached and reused for all future communication.
-func (sc *synchronizerClient) initialize() error {
-	sc.m.Lock()
-	defer sc.m.Unlock()
-	if sc.synchronizer == nil {
-		conn, err := rpc.GRPCClientFromConfig(sc.cfg, "api.synchronizer")
-		if err != nil {
-			return err
-		}
-
-		sc.synchronizer = ipb.NewSynchronizerClient(conn)
-	}
-
-	return nil
 }


### PR DESCRIPTION
This also aligns better with patterns for other clients, and removes some synchronization complexity for this type.