### PR TITLE
Have applications read in config from custom input

### DIFF
--- a/cmd/backend/backend.go
+++ b/cmd/backend/backend.go
@@ -18,8 +18,9 @@ package main
 import (
 	"open-match.dev/open-match/internal/app"
 	"open-match.dev/open-match/internal/app/backend"
+	"open-match.dev/open-match/internal/config"
 )
 
 func main() {
-	app.RunApplication("backend", backend.BindService)
+	app.RunApplication("backend", config.Read, backend.BindService)
 }

--- a/cmd/frontend/frontend.go
+++ b/cmd/frontend/frontend.go
@@ -18,8 +18,9 @@ package main
 import (
 	"open-match.dev/open-match/internal/app"
 	"open-match.dev/open-match/internal/app/frontend"
+	"open-match.dev/open-match/internal/config"
 )
 
 func main() {
-	app.RunApplication("frontend", frontend.BindService)
+	app.RunApplication("frontend", config.Read, frontend.BindService)
 }

--- a/cmd/minimatch/main.go
+++ b/cmd/minimatch/main.go
@@ -18,8 +18,9 @@ package main
 import (
 	"open-match.dev/open-match/internal/app"
 	"open-match.dev/open-match/internal/app/minimatch"
+	"open-match.dev/open-match/internal/config"
 )
 
 func main() {
-	app.RunApplication("minimatch", minimatch.BindService)
+	app.RunApplication("minimatch", config.Read, minimatch.BindService)
 }

--- a/cmd/mmlogic/mmlogic.go
+++ b/cmd/mmlogic/mmlogic.go
@@ -18,8 +18,9 @@ package main
 import (
 	"open-match.dev/open-match/internal/app"
 	"open-match.dev/open-match/internal/app/mmlogic"
+	"open-match.dev/open-match/internal/config"
 )
 
 func main() {
-	app.RunApplication("mmlogic", mmlogic.BindService)
+	app.RunApplication("mmlogic", config.Read, mmlogic.BindService)
 }

--- a/cmd/synchronizer/synchronizer.go
+++ b/cmd/synchronizer/synchronizer.go
@@ -18,8 +18,9 @@ package main
 import (
 	"open-match.dev/open-match/internal/app"
 	"open-match.dev/open-match/internal/app/synchronizer"
+	"open-match.dev/open-match/internal/config"
 )
 
 func main() {
-	app.RunApplication("synchronizer", synchronizer.BindService)
+	app.RunApplication("synchronizer", config.Read, synchronizer.BindService)
 }

--- a/internal/app/appmain.go
+++ b/internal/app/appmain.go
@@ -30,8 +30,8 @@ var (
 )
 
 // RunApplication creates a server.
-func RunApplication(serverName string, bindService func(*rpc.ServerParams, config.View) error) {
-	cfg, err := config.Read()
+func RunApplication(serverName string, getCfg func() (config.View, error), bindService func(*rpc.ServerParams, config.View) error) {
+	cfg, err := getCfg()
 	if err != nil {
 		logger.WithFields(logrus.Fields{
 			"error": err.Error(),

--- a/pkg/harness/evaluator/golang/harness.go
+++ b/pkg/harness/evaluator/golang/harness.go
@@ -25,7 +25,7 @@ import (
 
 // RunEvaluator is a hook for the main() method in the main executable.
 func RunEvaluator(eval Evaluator) {
-	app.RunApplication("evaluator", func(p *rpc.ServerParams, cfg config.View) error {
+	app.RunApplication("evaluator", config.Read, func(p *rpc.ServerParams, cfg config.View) error {
 		return BindService(p, cfg, eval)
 	})
 }

--- a/pkg/harness/function/golang/harness.go
+++ b/pkg/harness/function/golang/harness.go
@@ -30,7 +30,7 @@ type FunctionSettings struct {
 
 // RunMatchFunction is a hook for the main() method in the main executable.
 func RunMatchFunction(settings *FunctionSettings) {
-	app.RunApplication("functions", func(p *rpc.ServerParams, cfg config.View) error {
+	app.RunApplication("functions", config.Read, func(p *rpc.ServerParams, cfg config.View) error {
 		return BindService(p, cfg, settings)
 	})
 }


### PR DESCRIPTION
Per discussion, we will have an evaluator and mmf live under the `internal/testing` or `test/e2e` folder for testing purpose. Therefore, it make sense for these components to reuse the internal library instead of reinventing the wheels.

However, the internal config library requires its consumers read in two different config files from different location which complicated the evaluator and mmf setup.

This commit changed the `app.RunApplication` interface to read configurations from a custom getConfig function, such that the new evaluator and mmf could fake their configs and decouple themselves from the internal config library.