### PR TITLE
Show how to generate install/yaml files in dev guide

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -66,6 +66,8 @@ make build-images -j$(nproc)
 make push-images -j$(nproc)
 # Push images to Docker Hub
 make REGISTRY=mydockerusername push-images -j$(nproc)
+# Generate Kubernetes installation YAML files (Note that the trailing '/' is needed here)
+make install/yaml/
 ```
 
 _**-j$(nproc)** is a flag to tell make to parallelize the commands based on


### PR DESCRIPTION
One of the first things I wanted to review when cloning the open-match repo was the `install/yaml/01-open-match-core.yaml` file referenced in the documentation which I quickly discovered is generated via helm.

My first attempts to generate it with `make install/yaml/01-open-match-core.yaml` failed and after digging further I realised that helm needed to be configured with a repo to fetch dependencies from via `make update-chart-deps` and then discovered there is an `install/yaml/` target (with the trailing slash to avoid conflicting with the direcory name) that in turn depends on `update-chart-deps` and generates all the .yaml files I was interested in.

I've just added a mention of this to `docs/development.md` in case someone else might benefit from the sign posting.