### PR TITLE
Implement a prototype for Open Match benchmarking framework

### DIFF
--- a/cmd/scale-evaluator/main.go
+++ b/cmd/scale-evaluator/main.go
@@ -1,0 +1,22 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	scaleEvaluator "open-match.dev/open-match/examples/scale/evaluator"
+)
+
+func main() {
+	scaleEvaluator.Run()
+}

--- a/cmd/scale-mmf/main.go
+++ b/cmd/scale-mmf/main.go
@@ -1,0 +1,23 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	scaleMmf "open-match.dev/open-match/examples/scale/mmf"
+)
+
+func main() {
+	scaleMmf.Run()
+}

--- a/examples/scale/evaluator/evaluator.go
+++ b/examples/scale/evaluator/evaluator.go
@@ -39,7 +39,7 @@ func Run() {
 	activeScenario := scenarios.ActiveScenario
 
 	server := grpc.NewServer(utilTesting.NewGRPCServerOptions(logger)...)
-	pb.RegisterEvaluatorServer(server, pb.EvaluatorServer(activeScenario.Evaluator))
+	pb.RegisterEvaluatorServer(server, activeScenario.Evaluator)
 	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", 50508))
 	if err != nil {
 		logger.WithFields(logrus.Fields{

--- a/examples/scale/evaluator/evaluator.go
+++ b/examples/scale/evaluator/evaluator.go
@@ -1,0 +1,61 @@
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package evaluator
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+
+	"open-match.dev/open-match/pkg/pb"
+
+	utilTesting "open-match.dev/open-match/internal/util/testing"
+
+	"open-match.dev/open-match/examples/scale/scenarios"
+)
+
+// Run triggers execution of an evaluator.
+func Run() {
+	activeScenario := scenarios.ActiveScenario
+
+	conn, err := grpc.Dial(activeScenario.MmlogicAddr, utilTesting.NewGRPCDialOptions(activeScenario.Logger)...)
+	if err != nil {
+		activeScenario.Logger.Fatalf("Failed to connect to Open Match, got %v", err)
+	}
+	defer conn.Close()
+
+	server := grpc.NewServer(utilTesting.NewGRPCServerOptions(activeScenario.Logger)...)
+	pb.RegisterEvaluatorServer(server, activeScenario)
+	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", activeScenario.MmfServerPort))
+	if err != nil {
+		activeScenario.Logger.WithFields(logrus.Fields{
+			"error": err.Error(),
+			"port":  activeScenario.MmfServerPort,
+		}).Fatal("net.Listen() error")
+	}
+
+	activeScenario.Logger.WithFields(logrus.Fields{
+		"port": activeScenario.MmfServerPort,
+	}).Info("TCP net listener initialized")
+
+	activeScenario.Logger.Info("Serving gRPC endpoint")
+	err = server.Serve(ln)
+	if err != nil {
+		activeScenario.Logger.WithFields(logrus.Fields{
+			"error": err.Error(),
+		}).Fatal("gRPC serve() error")
+	}
+}

--- a/examples/scale/mmf/mmf.go
+++ b/examples/scale/mmf/mmf.go
@@ -46,7 +46,7 @@ func Run() {
 	defer conn.Close()
 
 	server := grpc.NewServer(utilTesting.NewGRPCServerOptions(logger)...)
-	pb.RegisterMatchFunctionServer(server, pb.MatchFunctionServer(activeScenario.MMF))
+	pb.RegisterMatchFunctionServer(server, activeScenario.MMF)
 	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", 50502))
 	if err != nil {
 		logger.WithFields(logrus.Fields{

--- a/examples/scale/mmf/mmf.go
+++ b/examples/scale/mmf/mmf.go
@@ -1,0 +1,62 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mmf
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+
+	"open-match.dev/open-match/pkg/pb"
+
+	utilTesting "open-match.dev/open-match/internal/util/testing"
+
+	"open-match.dev/open-match/examples/scale/scenarios"
+)
+
+// Run triggers execution of a MMF.
+func Run() {
+	activeScenario := scenarios.ActiveScenario
+
+	conn, err := grpc.Dial(activeScenario.MmlogicAddr, utilTesting.NewGRPCDialOptions(activeScenario.Logger)...)
+	if err != nil {
+		activeScenario.Logger.Fatalf("Failed to connect to Open Match, got %v", err)
+	}
+	defer conn.Close()
+
+	server := grpc.NewServer(utilTesting.NewGRPCServerOptions(activeScenario.Logger)...)
+	pb.RegisterMatchFunctionServer(server, activeScenario)
+	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", activeScenario.MmfServerPort))
+	if err != nil {
+		activeScenario.Logger.WithFields(logrus.Fields{
+			"error": err.Error(),
+			"port":  activeScenario.MmfServerPort,
+		}).Fatal("net.Listen() error")
+	}
+
+	activeScenario.Logger.WithFields(logrus.Fields{
+		"port": activeScenario.MmfServerPort,
+	}).Info("TCP net listener initialized")
+
+	activeScenario.Logger.Info("Serving gRPC endpoint")
+	err = server.Serve(ln)
+	if err != nil {
+		activeScenario.Logger.WithFields(logrus.Fields{
+			"error": err.Error(),
+		}).Fatal("gRPC serve() error")
+	}
+}

--- a/examples/scale/scenarios/basic_scenario.go
+++ b/examples/scale/scenarios/basic_scenario.go
@@ -1,23 +1,16 @@
 package scenarios
 
-import (
-	"fmt"
-	"open-match.dev/open-match/pkg/pb"
-)
+import "open-match.dev/open-match/pkg/pb"
 
-// BasicScenario is a struct with Scenario embedded that implements mmf.Run and evaluator.Evaluate methods.
-type BasicScenario struct {
-	Scenario
+var basicScenario = &Scenario{
+	MMF:       basicMatchFunction,
+	Evaluator: basicEvaluate,
 }
 
-// Run implements the basic matchfunction.Run logic for Open Match benchmarking under BasicScenario
-func (s BasicScenario) Run(*pb.RunRequest, pb.MatchFunction_RunServer) error {
-	fmt.Println("hello")
+func basicMatchFunction(*pb.RunRequest, pb.MatchFunction_RunServer) error {
 	return nil
 }
 
-// Evaluate implements the basic evaluator.Evaluate logic for Open Match benchmarking under BasicScenario
-func (s BasicScenario) Evaluate(pb.Evaluator_EvaluateServer) error {
-	fmt.Println("hi")
+func basicEvaluate(pb.Evaluator_EvaluateServer) error {
 	return nil
 }

--- a/examples/scale/scenarios/basic_scenario.go
+++ b/examples/scale/scenarios/basic_scenario.go
@@ -1,0 +1,23 @@
+package scenarios
+
+import (
+	"fmt"
+	"open-match.dev/open-match/pkg/pb"
+)
+
+// BasicScenario is a struct with Scenario embedded that implements mmf.Run and evaluator.Evaluate methods.
+type BasicScenario struct {
+	Scenario
+}
+
+// Run implements the basic matchfunction.Run logic for Open Match benchmarking under BasicScenario
+func (s BasicScenario) Run(*pb.RunRequest, pb.MatchFunction_RunServer) error {
+	fmt.Println("hello")
+	return nil
+}
+
+// Evaluate implements the basic evaluator.Evaluate logic for Open Match benchmarking under BasicScenario
+func (s BasicScenario) Evaluate(pb.Evaluator_EvaluateServer) error {
+	fmt.Println("hi")
+	return nil
+}

--- a/examples/scale/scenarios/scenarios.go
+++ b/examples/scale/scenarios/scenarios.go
@@ -14,12 +14,7 @@
 
 package scenarios
 
-import (
-
-	// "sync"
-
-	"github.com/sirupsen/logrus"
-)
+import "open-match.dev/open-match/pkg/pb"
 
 // TODO:
 // - add images for scale-mmf and scale-evaluator, have this use it.
@@ -29,52 +24,39 @@ import (
 
 // after that start on getting metrics to show up from the scale-backend and scale-frontend.
 
-var ActiveScenario = BasicScenario{Scenario{
-	MmfServerPort:              50502,
-	MatchOverlapRatio:          0,
-	TicketSearchFieldsUnitSize: 0,
-	TicketSearchFieldsNumber:   1,
-	MmlogicAddr:                "om-mmlogic.open-match.svc.cluster.local:50503",
-	EvaluatorServerPort:        50508,
-	TicketExtensionSize:        0,
-	PendingTicketNumber:        10000,
-	MatchExtensionSize:         0,
-	ShouldCreateTicketForever:  false,
-	TicketQPS:                  100,
-	ProfileNumber:              20,
-	FilterNumber:               20,
-	ShouldAssignTicket:         true,
-	ShouldDeleteTicket:         true,
-	Logger: logrus.WithFields(logrus.Fields{
-		"app":       "openmatch",
-		"component": "scale",
-	}),
-}}
+var ActiveScenario = basicScenario
+
+type matchFunction func(*pb.RunRequest, pb.MatchFunction_RunServer) error
+type evaluatorFunction func(pb.Evaluator_EvaluateServer) error
 
 // Scenario defines the controllable fields for Open Match benchmark scenarios
 type Scenario struct {
 	// MatchFunction Configs
-	MmfServerPort              int32
-	MatchOverlapRatio          float32
-	TicketSearchFieldsUnitSize int
-	TicketSearchFieldsNumber   int
-	MmlogicAddr                string
-
-	// Evaluator Configs
-	EvaluatorServerPort int32
+	// MatchOverlapRatio          float32
+	// TicketSearchFieldsUnitSize int
+	// TicketSearchFieldsNumber   int
 
 	// GameFrontend Configs
-	TicketExtensionSize       int
-	PendingTicketNumber       int
-	MatchExtensionSize        int
-	ShouldCreateTicketForever bool
-	TicketQPS                 int
+	// TicketExtensionSize       int
+	// PendingTicketNumber       int
+	// MatchExtensionSize        int
+	// ShouldCreateTicketForever bool
+	// TicketCreatedQPS          int
 
 	// GameBackend Configs
-	ProfileNumber      int
-	FilterNumber       int
-	ShouldAssignTicket bool
-	ShouldDeleteTicket bool
+	// ProfileNumber      int
+	// FilterNumber       int
+	// ShouldAssignTicket bool
+	// ShouldDeleteTicket bool
 
-	Logger *logrus.Entry
+	MMF       matchFunction
+	Evaluator evaluatorFunction
+}
+
+func (mmf matchFunction) Run(req *pb.RunRequest, srv pb.MatchFunction_RunServer) error {
+	return mmf(req, srv)
+}
+
+func (eval evaluatorFunction) Evaluate(srv pb.Evaluator_EvaluateServer) error {
+	return eval(srv)
 }

--- a/examples/scale/scenarios/scenarios.go
+++ b/examples/scale/scenarios/scenarios.go
@@ -1,0 +1,80 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scenarios
+
+import (
+
+	// "sync"
+
+	"github.com/sirupsen/logrus"
+)
+
+// TODO:
+// - add images for scale-mmf and scale-evaluator, have this use it.
+// - add an evaluator.
+// - add ticket generation function and profiles to the scenario, can just pull from existing
+//     packages for now
+
+// after that start on getting metrics to show up from the scale-backend and scale-frontend.
+
+var ActiveScenario = BasicScenario{Scenario{
+	MmfServerPort:              50502,
+	MatchOverlapRatio:          0,
+	TicketSearchFieldsUnitSize: 0,
+	TicketSearchFieldsNumber:   1,
+	MmlogicAddr:                "om-mmlogic.open-match.svc.cluster.local:50503",
+	EvaluatorServerPort:        50508,
+	TicketExtensionSize:        0,
+	PendingTicketNumber:        10000,
+	MatchExtensionSize:         0,
+	ShouldCreateTicketForever:  false,
+	TicketQPS:                  100,
+	ProfileNumber:              20,
+	FilterNumber:               20,
+	ShouldAssignTicket:         true,
+	ShouldDeleteTicket:         true,
+	Logger: logrus.WithFields(logrus.Fields{
+		"app":       "openmatch",
+		"component": "scale",
+	}),
+}}
+
+// Scenario defines the controllable fields for Open Match benchmark scenarios
+type Scenario struct {
+	// MatchFunction Configs
+	MmfServerPort              int32
+	MatchOverlapRatio          float32
+	TicketSearchFieldsUnitSize int
+	TicketSearchFieldsNumber   int
+	MmlogicAddr                string
+
+	// Evaluator Configs
+	EvaluatorServerPort int32
+
+	// GameFrontend Configs
+	TicketExtensionSize       int
+	PendingTicketNumber       int
+	MatchExtensionSize        int
+	ShouldCreateTicketForever bool
+	TicketQPS                 int
+
+	// GameBackend Configs
+	ProfileNumber      int
+	FilterNumber       int
+	ShouldAssignTicket bool
+	ShouldDeleteTicket bool
+
+	Logger *logrus.Entry
+}

--- a/examples/scale/scenarios/scenarios.go
+++ b/examples/scale/scenarios/scenarios.go
@@ -16,14 +16,7 @@ package scenarios
 
 import "open-match.dev/open-match/pkg/pb"
 
-// TODO:
-// - add images for scale-mmf and scale-evaluator, have this use it.
-// - add an evaluator.
-// - add ticket generation function and profiles to the scenario, can just pull from existing
-//     packages for now
-
-// after that start on getting metrics to show up from the scale-backend and scale-frontend.
-
+// ActiveScenario sets the scenario with preset parameters that we want to use for current Open Match benchmark run.
 var ActiveScenario = basicScenario
 
 type matchFunction func(*pb.RunRequest, pb.MatchFunction_RunServer) error
@@ -31,6 +24,8 @@ type evaluatorFunction func(pb.Evaluator_EvaluateServer) error
 
 // Scenario defines the controllable fields for Open Match benchmark scenarios
 type Scenario struct {
+	// TODO: supports the following controllable parameters
+
 	// MatchFunction Configs
 	// MatchOverlapRatio          float32
 	// TicketSearchFieldsUnitSize int

--- a/examples/scale/scenarios/scenarios.go
+++ b/examples/scale/scenarios/scenarios.go
@@ -19,9 +19,6 @@ import "open-match.dev/open-match/pkg/pb"
 // ActiveScenario sets the scenario with preset parameters that we want to use for current Open Match benchmark run.
 var ActiveScenario = basicScenario
 
-type matchFunction func(*pb.RunRequest, pb.MatchFunction_RunServer) error
-type evaluatorFunction func(pb.Evaluator_EvaluateServer) error
-
 // Scenario defines the controllable fields for Open Match benchmark scenarios
 type Scenario struct {
 	// TODO: supports the following controllable parameters
@@ -47,6 +44,9 @@ type Scenario struct {
 	MMF       matchFunction
 	Evaluator evaluatorFunction
 }
+
+type matchFunction func(*pb.RunRequest, pb.MatchFunction_RunServer) error
+type evaluatorFunction func(pb.Evaluator_EvaluateServer) error
 
 func (mmf matchFunction) Run(req *pb.RunRequest, srv pb.MatchFunction_RunServer) error {
 	return mmf(req, srv)

--- a/internal/util/testing/grpc_options.go
+++ b/internal/util/testing/grpc_options.go
@@ -1,0 +1,93 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testing
+
+import (
+	"time"
+
+	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
+	grpc_logrus "github.com/grpc-ecosystem/go-grpc-middleware/logging/logrus"
+	grpc_recovery "github.com/grpc-ecosystem/go-grpc-middleware/recovery"
+	grpc_tracing "github.com/grpc-ecosystem/go-grpc-middleware/tracing/opentracing"
+	grpc_validator "github.com/grpc-ecosystem/go-grpc-middleware/validator"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/balancer/roundrobin"
+	"google.golang.org/grpc/keepalive"
+	"google.golang.org/grpc/resolver"
+)
+
+// nolint: gochecknoinits
+func init() {
+	// Using gRPC's DNS resolver to create clients.
+	// This is a workaround for load balancing gRPC applications under k8s environments.
+	// See https://kubernetes.io/blog/2018/11/07/grpc-load-balancing-on-kubernetes-without-tears/ for more details.
+	// https://godoc.org/google.golang.org/grpc/resolver#SetDefaultScheme
+	resolver.SetDefaultScheme("dns")
+}
+
+// NewGRPCDialOptions returns the grpc DialOptions for testing internal grpc clients with loadbalancing, tracing, and logging setups
+func NewGRPCDialOptions(grpcLogger *logrus.Entry) []grpc.DialOption {
+	grpcLogger.Level = logrus.DebugLevel
+
+	si := []grpc.StreamClientInterceptor{
+		grpc_logrus.StreamClientInterceptor(grpcLogger),
+		grpc_tracing.StreamClientInterceptor(),
+	}
+	ui := []grpc.UnaryClientInterceptor{
+		grpc_logrus.UnaryClientInterceptor(grpcLogger),
+		grpc_tracing.UnaryClientInterceptor(),
+	}
+	opts := []grpc.DialOption{
+		grpc.WithInsecure(),
+		grpc.WithStreamInterceptor(grpc_middleware.ChainStreamClient(si...)),
+		grpc.WithUnaryInterceptor(grpc_middleware.ChainUnaryClient(ui...)),
+		grpc.WithBalancerName(roundrobin.Name),
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time:                20 * time.Second,
+			Timeout:             10 * time.Second,
+			PermitWithoutStream: true,
+		}),
+	}
+
+	return opts
+}
+
+// NewGRPCServerOptions returns the grpc testing DialOptions for internal grpc servers with loadbalancing, tracing, and logging setups
+func NewGRPCServerOptions(grpcLogger *logrus.Entry) []grpc.ServerOption {
+	si := []grpc.StreamServerInterceptor{
+		grpc_recovery.StreamServerInterceptor(),
+		grpc_validator.StreamServerInterceptor(),
+		grpc_tracing.StreamServerInterceptor(),
+		grpc_logrus.StreamServerInterceptor(grpcLogger),
+	}
+	ui := []grpc.UnaryServerInterceptor{
+		grpc_recovery.UnaryServerInterceptor(),
+		grpc_validator.UnaryServerInterceptor(),
+		grpc_tracing.UnaryServerInterceptor(),
+		grpc_logrus.UnaryServerInterceptor(grpcLogger),
+	}
+
+	return []grpc.ServerOption{
+		grpc.StreamInterceptor(grpc_middleware.ChainStreamServer(si...)),
+		grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(ui...)),
+		grpc.KeepaliveEnforcementPolicy(
+			keepalive.EnforcementPolicy{
+				MinTime:             10 * time.Second,
+				PermitWithoutStream: true,
+			},
+		),
+	}
+}


### PR DESCRIPTION
This PR implemented a prototype for Open Match benchmarking framework. The new framework allows users to modify the test behavior via changing the `ActiveScenario` variable under the `open-match/examples/scale/scenarios/scenarios.go` file. Users may choose to implement their own MMF and Evaluator logic for the benchmark by creating a new scenario.

TODOs:
1. Migrate the existing scale package to use this prototypes.
2. Implement actual logics to control the commented parameters.