### PR TITLE
Increase Redis ping time tolerance and provision more resources for CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -380,6 +380,7 @@ install-ci-chart: install-chart-prerequisite build/toolchain/bin/helm$(EXE_EXTEN
 		--set open-match-customize.evaluator.enabled=true \
 		--set open-match-customize.function.image=openmatch-mmf-go-pool \
 		--set mmlogic.replicas=1,frontend.replicas=1,backend.replicas=1,open-match-customize.evaluator.replicas=1,open-match-customize.function.replicas=1 \
+		--set redis.master.resources.requests.cpu=0.6,redis.master.resources.requests.memory=300Mi \
 		--set ci=true
 
 delete-chart: build/toolchain/bin/helm$(EXE_EXTENSION) build/toolchain/bin/kubectl$(EXE_EXTENSION)

--- a/install/helm/open-match/values.yaml
+++ b/install/helm/open-match/values.yaml
@@ -157,7 +157,7 @@ open-match-core:
       maxIdle: 200
       maxActive: 0
       idleTimeout: 0
-      healthCheckTimeout: 100ms
+      healthCheckTimeout: 300ms
 
 # Controls if users need to install scale testing setup for Open Match.
 open-match-scale:

--- a/internal/statestore/redis.go
+++ b/internal/statestore/redis.go
@@ -94,9 +94,9 @@ func newRedis(cfg config.View) Service {
 		},
 	}
 	healthCheckPool := &redis.Pool{
-		MaxIdle:     1,
-		MaxActive:   2,
-		IdleTimeout: cfg.GetDuration("redis.pool.healthCheckTimeout"),
+		MaxIdle:     3,
+		MaxActive:   0,
+		IdleTimeout: 10 * cfg.GetDuration("redis.pool.healthCheckTimeout"),
 		Wait:        true,
 		DialContext: func(ctx context.Context) (redis.Conn, error) {
 			if ctx.Err() != nil {


### PR DESCRIPTION
Resolves #1032.

This commit set the MaxActive number on Redis healthcheck pool to 0 such that the pool does not need to wait for an idle connection while there is no connections available for healthcheck pings. Also increased the MaxIdle and IdleTimeout number to make the pods have a higher chance to pass the readiness health check.

This is an attempt to stabilize the open-match core pods during the CI end-to-end stage to avoid test flakiness.