### PR TITLE
Switch Open Match services to use consistent ports.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -721,7 +721,7 @@ test-e2e-cluster: all-protos tls-certs third_party/
 	$(HELM) test --timeout 7m30s -v 0 --logs -n $(OPEN_MATCH_KUBERNETES_NAMESPACE) $(OPEN_MATCH_HELM_NAME)
 
 stress-frontend-%: build/toolchain/python/
-	$(TOOLCHAIN_DIR)/python/bin/locust -f $(REPOSITORY_ROOT)/test/stress/frontend.py --host=http://localhost:$(HTTP_PORT) \
+	$(TOOLCHAIN_DIR)/python/bin/locust -f $(REPOSITORY_ROOT)/test/stress/frontend.py --host=http://localhost:$(FRONTEND_PORT) \
 		--no-web -c $* -r 100 -t10m --csv=test/stress/stress_user$*
 
 fmt:

--- a/examples/demo/components/clients/clients.go
+++ b/examples/demo/components/clients/clients.go
@@ -81,7 +81,7 @@ func runScenario(ctx context.Context, name string, update updater.SetFunc) {
 	update(s)
 
 	// See https://open-match.dev/site/docs/guides/api/
-	conn, err := grpc.Dial("om-frontend.open-match.svc.cluster.local:50504", grpc.WithInsecure())
+	conn, err := grpc.Dial("om-frontend.open-match.svc.cluster.local:50500", grpc.WithInsecure())
 	if err != nil {
 		panic(err)
 	}

--- a/examples/demo/components/director/director.go
+++ b/examples/demo/components/director/director.go
@@ -68,7 +68,7 @@ func run(ds *components.DemoShared) {
 	ds.Update(s)
 
 	// See https://open-match.dev/site/docs/guides/api/
-	conn, err := grpc.Dial("om-backend.open-match.svc.cluster.local:50505", grpc.WithInsecure())
+	conn, err := grpc.Dial("om-backend.open-match.svc.cluster.local:50500", grpc.WithInsecure())
 	if err != nil {
 		panic(err)
 	}
@@ -84,7 +84,7 @@ func run(ds *components.DemoShared) {
 		req := &pb.FetchMatchesRequest{
 			Config: &pb.FunctionConfig{
 				Host: "om-function.open-match-demo.svc.cluster.local",
-				Port: 50502,
+				Port: 50500,
 				Type: pb.FunctionConfig_GRPC,
 			},
 			Profiles: []*pb.MatchProfile{

--- a/examples/demo/demo.go
+++ b/examples/demo/demo.go
@@ -71,7 +71,7 @@ func Run(comps map[string]func(*components.DemoShared)) {
 		})
 	}
 
-	address := fmt.Sprintf(":%d", 51507)
+	address := fmt.Sprintf(":%d", 51500)
 	err := http.ListenAndServe(address, nil)
 	log.Printf("HTTP server closed: %s", err.Error())
 }

--- a/examples/scale/backend/backend.go
+++ b/examples/scale/backend/backend.go
@@ -102,7 +102,7 @@ func run(fe pb.FrontendClient, be pb.BackendClient, p *pb.MatchProfile) {
 	req := &pb.FetchMatchesRequest{
 		Config: &pb.FunctionConfig{
 			Host: "om-function",
-			Port: 50502,
+			Port: 50500,
 			Type: pb.FunctionConfig_GRPC,
 		},
 		Profiles: []*pb.MatchProfile{p},

--- a/examples/scale/evaluator/evaluator.go
+++ b/examples/scale/evaluator/evaluator.go
@@ -40,16 +40,16 @@ func Run() {
 
 	server := grpc.NewServer(utilTesting.NewGRPCServerOptions(logger)...)
 	pb.RegisterEvaluatorServer(server, activeScenario.Evaluator)
-	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", 50508))
+	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", 50500))
 	if err != nil {
 		logger.WithFields(logrus.Fields{
 			"error": err.Error(),
-			"port":  50508,
+			"port":  50500,
 		}).Fatal("net.Listen() error")
 	}
 
 	logger.WithFields(logrus.Fields{
-		"port": 50508,
+		"port": 50500,
 	}).Info("TCP net listener initialized")
 
 	logger.Info("Serving gRPC endpoint")

--- a/examples/scale/mmf/mmf.go
+++ b/examples/scale/mmf/mmf.go
@@ -39,7 +39,7 @@ var (
 func Run() {
 	activeScenario := scenarios.ActiveScenario
 
-	conn, err := grpc.Dial("om-mmlogic.open-match.svc.cluster.local:50503", utilTesting.NewGRPCDialOptions(logger)...)
+	conn, err := grpc.Dial("om-mmlogic.open-match.svc.cluster.local:50500", utilTesting.NewGRPCDialOptions(logger)...)
 	if err != nil {
 		logger.Fatalf("Failed to connect to Open Match, got %v", err)
 	}
@@ -47,16 +47,16 @@ func Run() {
 
 	server := grpc.NewServer(utilTesting.NewGRPCServerOptions(logger)...)
 	pb.RegisterMatchFunctionServer(server, activeScenario.MMF)
-	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", 50502))
+	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", 50500))
 	if err != nil {
 		logger.WithFields(logrus.Fields{
 			"error": err.Error(),
-			"port":  50502,
+			"port":  50500,
 		}).Fatal("net.Listen() error")
 	}
 
 	logger.WithFields(logrus.Fields{
-		"port": 50502,
+		"port": 50500,
 	}).Info("TCP net listener initialized")
 
 	logger.Info("Serving gRPC endpoint")

--- a/examples/scale/scenarios/util.go
+++ b/examples/scale/scenarios/util.go
@@ -25,7 +25,7 @@ import (
 )
 
 var (
-	mmlogicAddress = "om-mmlogic.open-match.svc.cluster.local:50503" // Address of the MMLogic Endpoint.
+	mmlogicAddress = "om-mmlogic.open-match.svc.cluster.local:50500" // Address of the MMLogic Endpoint.
 )
 
 // StatProcessor uses syncMaps to store the stress test metrics and occurrence of errors.

--- a/install/02-open-match-demo.yaml
+++ b/install/02-open-match-demo.yaml
@@ -34,8 +34,8 @@ data:
     api:
       functions:
         hostname: "om-function"
-        grpcport: 50502
-        httpport: 51502
+        grpcport: 50500
+        httpport: 51500
   matchmaker_config_override.yaml: |-
     api:
       mmlogic:
@@ -61,10 +61,10 @@ spec:
   ports:
   - name: grpc
     protocol: TCP
-    port: 50502
+    port: 50500
   - name: http
     protocol: TCP
-    port: 51502
+    port: 51500
 ---
 kind: Service
 apiVersion: v1
@@ -83,7 +83,7 @@ spec:
   ports:
   - name: http
     protocol: TCP
-    port: 51507
+    port: 51500
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -125,9 +125,9 @@ spec:
         image: "gcr.io/open-match-public-images/openmatch-mmf-go-soloduel:0.0.0-dev"
         ports:
         - name: grpc
-          containerPort: 50502
+          containerPort: 50500
         - name: http
-          containerPort: 51502
+          containerPort: 51500
         imagePullPolicy: Always
         resources:
           requests:
@@ -163,12 +163,12 @@ spec:
         imagePullPolicy: Always
         ports:
         - name: http
-          containerPort: 51507
+          containerPort: 51500
         livenessProbe:
           httpGet:
             scheme: HTTP
             path: /healthz
-            port: 51507
+            port: 51500
           initialDelaySeconds: 5
           periodSeconds: 5
           failureThreshold: 3
@@ -176,7 +176,7 @@ spec:
           httpGet:
             scheme: HTTP
             path: /healthz?readiness=true
-            port: 51507
+            port: 51500
           initialDelaySeconds: 10
           periodSeconds: 10
           failureThreshold: 2

--- a/install/02-open-match-demo.yaml
+++ b/install/02-open-match-demo.yaml
@@ -40,7 +40,7 @@ data:
     api:
       mmlogic:
         hostname: "om-mmlogic.open-match.svc.cluster.local"
-        grpcport: "50503"
+        grpcport: "50500"
 ---
 kind: Service
 apiVersion: v1

--- a/install/helm/open-match/subcharts/open-match-customize/templates/customize-configmap.yaml
+++ b/install/helm/open-match/subcharts/open-match-customize/templates/customize-configmap.yaml
@@ -24,18 +24,18 @@ metadata:
     release: {{ .Release.Name }}
 data:
   matchmaker_config_default.yaml: |-
+    ports:
+      grpcPort: "{{ .Values.global.kubernetes.service.grpcPort }}"
+      httpPort: "{{ .Values.global.kubernetes.service.httpPort }}"
+
     api:
       functions:
         hostname: "{{ .Values.function.hostName }}"
-        grpcport: "{{ .Values.function.grpcPort }}"
-        httpport: "{{ .Values.function.httpPort }}"
       
       evaluator:
         hostname: "{{ .Values.evaluator.hostName }}"
-        grpcport: "{{ .Values.evaluator.grpcPort }}"
-        httpport: "{{ .Values.evaluator.httpPort }}"    
   matchmaker_config_override.yaml: |-
     api:
       mmlogic:
         hostname: "{{ .Values.mmlogic.hostName }}.{{ .Release.Namespace }}.svc.cluster.local"
-        grpcport: "{{ .Values.mmlogic.grpcPort }}"
+        grpcport: "{{ .Values.global.kubernetes.service.grpcPort }}"

--- a/install/helm/open-match/subcharts/open-match-customize/templates/evaluator.yaml
+++ b/install/helm/open-match/subcharts/open-match-customize/templates/evaluator.yaml
@@ -38,10 +38,10 @@ spec:
   ports:
   - name: grpc
     protocol: TCP
-    port: {{ .Values.evaluator.grpcPort }}
+    port: {{ .Values.global.kubernetes.service.grpcPort }}
   - name: http
     protocol: TCP
-    port: {{ .Values.evaluator.httpPort }}
+    port: {{ .Values.global.kubernetes.service.httpPort }}
 ---
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
@@ -75,7 +75,7 @@ spec:
     metadata:
       namespace: {{ .Release.Namespace }}
       annotations:
-        {{- include "prometheus.annotations" (dict "port" .Values.evaluator.httpPort "prometheus" .Values.global.telemetry.prometheus) | nindent 8 }}
+        {{- include "prometheus.annotations" . | nindent 8 }}
         {{- include "openmatch.chartmeta" . | nindent 8 }}
       labels:
         app: {{ template "openmatch.name" . }}
@@ -94,9 +94,9 @@ spec:
         image: "{{ .Values.global.image.registry }}/{{ .Values.evaluator.image}}:{{ .Values.global.image.tag }}"
         ports:
         - name: grpc
-          containerPort: {{ .Values.evaluator.grpcPort }}
+          containerPort: {{ .Values.global.kubernetes.service.grpcPort }}
         - name: http
-          containerPort: {{ .Values.evaluator.httpPort }}
+          containerPort: {{ .Values.global.kubernetes.service.httpPort }}
         {{- include "openmatch.container.common" . | nindent 8 }}
 {{- end }}
 

--- a/install/helm/open-match/subcharts/open-match-customize/templates/matchfunctions.yaml
+++ b/install/helm/open-match/subcharts/open-match-customize/templates/matchfunctions.yaml
@@ -38,10 +38,10 @@ spec:
   ports:
   - name: grpc
     protocol: TCP
-    port: {{ .Values.function.grpcPort }}
+    port: {{ .Values.global.kubernetes.service.grpcPort }}
   - name: http
     protocol: TCP
-    port: {{ .Values.function.httpPort }}
+    port: {{ .Values.global.kubernetes.service.httpPort }}
 ---
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
@@ -76,7 +76,7 @@ spec:
     metadata:
       namespace: {{ .Release.Namespace }}
       annotations:
-        {{- include "prometheus.annotations" (dict "port" .Values.function.httpPort "prometheus" .Values.global.telemetry.prometheus) | nindent 8 }}
+        {{- include "prometheus.annotations" . | nindent 8 }}
         {{- include "openmatch.chartmeta" . | nindent 8 }}
       labels:
         app: {{ template "openmatch.name" . }}
@@ -95,9 +95,9 @@ spec:
         image: "{{ .Values.global.image.registry }}/{{ .Values.function.image}}:{{ .Values.global.image.tag }}"
         ports:
         - name: grpc
-          containerPort: {{ .Values.function.grpcPort }}
+          containerPort: {{ .Values.global.kubernetes.service.grpcPort }}
         - name: http
-          containerPort: {{ .Values.function.httpPort }}
+          containerPort: {{ .Values.global.kubernetes.service.httpPort }}
         {{- include "openmatch.container.common" . | nindent 8 }}
 {{- end }}
 

--- a/install/helm/open-match/subcharts/open-match-scale/templates/scale-backend.yaml
+++ b/install/helm/open-match/subcharts/open-match-scale/templates/scale-backend.yaml
@@ -29,7 +29,7 @@ spec:
   ports:
   - name: http
     protocol: TCP
-    port: {{ .Values.scaleBackend.httpPort }}
+    port: {{ .Values.global.kubernetes.service.httpPort }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -69,5 +69,5 @@ spec:
         image: "{{ .Values.global.image.registry }}/{{ .Values.scaleBackend.image}}:{{ .Values.global.image.tag }}"
         ports:
         - name: http
-          containerPort: {{ .Values.scaleBackend.httpPort }}
+          containerPort: {{ .Values.global.kubernetes.service.httpPort }}
         {{- include "openmatch.container.common" . | nindent 8 }}

--- a/install/helm/open-match/subcharts/open-match-scale/templates/scale-configmap.yaml
+++ b/install/helm/open-match/subcharts/open-match-scale/templates/scale-configmap.yaml
@@ -24,15 +24,15 @@ metadata:
     release: {{ .Release.Name }}
 data:
   matchmaker_config_default.yaml: |-
+    ports:
+      grpcPort: "{{ .Values.global.kubernetes.service.grpcPort }}"
+      httpPort: "{{ .Values.global.kubernetes.service.httpPort }}"
+
     api:
       backend:
         hostname: "{{ .Values.backend.hostName }}"
-        grpcport: "{{ .Values.backend.grpcPort }}"
-        httpport: "{{ .Values.backend.httpPort }}"
       frontend:
         hostname: "{{ .Values.frontend.hostName }}"
-        grpcport: "{{ .Values.frontend.grpcPort }}"
-        httpport: "{{ .Values.frontend.httpPort }}"
   matchmaker_config_override.yaml: |-
     testConfig:
       profile: "{{ .Values.testConfig.profile }}"

--- a/install/helm/open-match/subcharts/open-match-scale/templates/scale-frontend.yaml
+++ b/install/helm/open-match/subcharts/open-match-scale/templates/scale-frontend.yaml
@@ -29,7 +29,7 @@ spec:
   ports:
   - name: http
     protocol: TCP
-    port: {{ .Values.scaleFrontend.httpPort }}
+    port: {{ .Values.global.kubernetes.service.httpPort }}
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -69,5 +69,5 @@ spec:
         image: "{{ .Values.global.image.registry }}/{{ .Values.scaleFrontend.image}}:{{ .Values.global.image.tag }}"
         ports:
         - name: http
-          containerPort: {{ .Values.scaleFrontend.httpPort }}
+          containerPort: {{ .Values.global.kubernetes.service.httpPort }}
         {{- include "openmatch.container.common" . | nindent 8 }}

--- a/install/helm/open-match/subcharts/open-match-scale/values.yaml
+++ b/install/helm/open-match/subcharts/open-match-scale/values.yaml
@@ -14,13 +14,11 @@
 
 scaleFrontend:
   hostName: om-scale-frontend
-  httpPort: 51509
   replicas: 1
   image: openmatch-scale-frontend
 
 scaleBackend:
   hostName: om-scale-backend
-  httpPort: 51510
   replicas: 1
   image: openmatch-scale-backend
 

--- a/install/helm/open-match/subcharts/open-match-test/templates/stress-master.yaml
+++ b/install/helm/open-match/subcharts/open-match-test/templates/stress-master.yaml
@@ -96,7 +96,7 @@ spec:
         - "./locust"
         - "-f"
         - "./frontend.py"
-        - "--host=http://{{ .Values.frontend.hostName }}:{{ .Values.frontend.httpPort }}"
+        - "--host=http://{{ .Values.frontend.hostName }}:{{ .Values.global.kubernetes.service.httpPort }}"
         - "--master"
 {{- if .Values.stresstest.noweb }}
         - "--no-web"

--- a/install/helm/open-match/subcharts/open-match-test/templates/stress-slaves.yaml
+++ b/install/helm/open-match/subcharts/open-match-test/templates/stress-slaves.yaml
@@ -49,7 +49,7 @@ spec:
         - "./locust"
         - "-f"
         - "./frontend.py"
-        - "--host=http://{{ .Values.frontend.hostName }}:{{ .Values.frontend.httpPort }}"
+        - "--host=http://{{ .Values.frontend.hostName }}:{{ .Values.global.kubernetes.service.httpPort }}"
         - "--slave"
         - "--master-host={{ .Values.stresstest.masterName }}"
 {{- end }}

--- a/install/helm/open-match/templates/_helpers.tpl
+++ b/install/helm/open-match/templates/_helpers.tpl
@@ -35,8 +35,8 @@ heritage: {{ .Release.Service }}
 {{- define "prometheus.annotations" -}}
 {{- if and (.prometheus.serviceDiscovery) (.prometheus.enabled) -}}
 prometheus.io/scrape: "true"
-prometheus.io/port: {{ .port | quote }}
-prometheus.io/path: {{ .prometheus.endpoint }}
+prometheus.io/port: {{ .Values.global.kubernetes.service.httpPort | quote }}
+prometheus.io/path: {{ .Values.global.telemetry.prometheus.endpoint }}
 {{- end -}}
 {{- end -}}
 
@@ -114,17 +114,17 @@ tolerations:
 {{- define "kubernetes.probe" -}}
 livenessProbe:
   httpGet:
-    scheme: {{ if (.isHTTPS) }}HTTPS{{ else }}HTTP{{ end }}
+    scheme: {{ if (.Values.global.tls.enabled) }}HTTPS{{ else }}HTTP{{ end }}
     path: /healthz
-    port: {{ .port }}
+    port: {{ .Values.global.kubernetes.service.httpPort }}
   initialDelaySeconds: 10
   periodSeconds: 10
   failureThreshold: 3
 readinessProbe:
   httpGet:
-    scheme: {{ if (.isHTTPS) }}HTTPS{{ else }}HTTP{{ end }}
+    scheme: {{ if (.Values.global.tls.enabled) }}HTTPS{{ else }}HTTP{{ end }}
     path: /healthz?readiness=true
-    port: {{ .port }}
+    port: {{ .Values.global.kubernetes.service.httpPort }}
   initialDelaySeconds: 10
   periodSeconds: 10
   failureThreshold: 2

--- a/install/helm/open-match/templates/_helpers.tpl
+++ b/install/helm/open-match/templates/_helpers.tpl
@@ -33,7 +33,7 @@ heritage: {{ .Release.Service }}
 {{- end -}}
 
 {{- define "prometheus.annotations" -}}
-{{- if and (.prometheus.serviceDiscovery) (.prometheus.enabled) -}}
+{{- if and (.Values.global.telemetry.prometheus.serviceDiscovery) (.Values.global.telemetry.prometheus.enabled) -}}
 prometheus.io/scrape: "true"
 prometheus.io/port: {{ .Values.global.kubernetes.service.httpPort | quote }}
 prometheus.io/path: {{ .Values.global.telemetry.prometheus.endpoint }}

--- a/install/helm/open-match/templates/backend.yaml
+++ b/install/helm/open-match/templates/backend.yaml
@@ -36,10 +36,10 @@ spec:
   ports:
   - name: grpc
     protocol: TCP
-    port: {{ .Values.backend.grpcPort }}
+    port: {{ .Values.global.kubernetes.service.grpcPort }}
   - name: http
     protocol: TCP
-    port: {{ .Values.backend.httpPort }}
+    port: {{ .Values.global.kubernetes.service.httpPort }}
 ---
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
@@ -74,7 +74,7 @@ spec:
       namespace: {{ .Release.Namespace }}
       annotations:
         {{- include "openmatch.chartmeta" . | nindent 8 }}
-        {{- include "prometheus.annotations" (dict "port" .Values.backend.httpPort "prometheus" .Values.global.telemetry.prometheus) | nindent 8 }}
+        {{- include "prometheus.annotations" . | nindent 8 }}
       labels:
         app: {{ template "openmatch.name" . }}
         component: backend
@@ -95,9 +95,9 @@ spec:
         image: "{{ .Values.global.image.registry }}/{{ .Values.backend.image}}:{{ .Values.global.image.tag }}"
         ports:
         - name: grpc
-          containerPort: {{ .Values.backend.grpcPort }}
+          containerPort: {{ .Values.global.kubernetes.service.grpcPort }}
         - name: http
-          containerPort: {{ .Values.backend.httpPort }}
+          containerPort: {{ .Values.global.kubernetes.service.httpPort }}
         {{- include "openmatch.container.common" . | nindent 8 }}
-        {{- include "kubernetes.probe" (dict "port" .Values.backend.httpPort "isHTTPS" .Values.global.tls.enabled) | nindent 8 }}
+        {{- include "kubernetes.probe" . | nindent 8 }}
 {{- end }}

--- a/install/helm/open-match/templates/frontend.yaml
+++ b/install/helm/open-match/templates/frontend.yaml
@@ -36,10 +36,10 @@ spec:
   ports:
   - name: grpc
     protocol: TCP
-    port: {{ .Values.frontend.grpcPort }}
+    port: {{ .Values.global.kubernetes.service.grpcPort }}
   - name: http
     protocol: TCP
-    port: {{ .Values.frontend.httpPort }}
+    port: {{ .Values.global.kubernetes.service.httpPort }}
 ---
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
@@ -74,7 +74,7 @@ spec:
       namespace: {{ .Release.Namespace }}
       annotations:
         {{- include "openmatch.chartmeta" . | nindent 8 }}
-        {{- include "prometheus.annotations" (dict "port" .Values.frontend.httpPort "prometheus" .Values.global.telemetry.prometheus) | nindent 8 }}
+        {{- include "prometheus.annotations" . | nindent 8 }}
       labels:
         app: {{ template "openmatch.name" . }}
         component: frontend
@@ -95,9 +95,9 @@ spec:
         image: "{{ .Values.global.image.registry }}/{{ .Values.frontend.image}}:{{ .Values.global.image.tag }}"
         ports:
         - name: grpc
-          containerPort: {{ .Values.frontend.grpcPort }}
+          containerPort: {{ .Values.global.kubernetes.service.grpcPort }}
         - name: http
-          containerPort: {{ .Values.frontend.httpPort }}
+          containerPort: {{ .Values.global.kubernetes.service.httpPort }}
         {{- include "openmatch.container.common" . | nindent 8 }}
-        {{- include "kubernetes.probe" (dict "port" .Values.frontend.httpPort "isHTTPS" .Values.global.tls.enabled) | nindent 8 }}
+        {{- include "kubernetes.probe" . | nindent 8 }}
 {{- end }}

--- a/install/helm/open-match/templates/mmlogic.yaml
+++ b/install/helm/open-match/templates/mmlogic.yaml
@@ -36,10 +36,10 @@ spec:
   ports:
   - name: grpc
     protocol: TCP
-    port: {{ .Values.mmlogic.grpcPort }}
+    port: {{ .Values.global.kubernetes.service.grpcPort }}
   - name: http
     protocol: TCP
-    port: {{ .Values.mmlogic.httpPort }}
+    port: {{ .Values.global.kubernetes.service.httpPort }}
 ---
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
@@ -74,7 +74,7 @@ spec:
       namespace: {{ .Release.Namespace }}
       annotations:
         {{- include "openmatch.chartmeta" . | nindent 8 }}
-        {{- include "prometheus.annotations" (dict "port" .Values.mmlogic.httpPort "prometheus" .Values.global.telemetry.prometheus) | nindent 8 }}
+        {{- include "prometheus.annotations" . | nindent 8 }}
       labels:
         app: {{ template "openmatch.name" . }}
         component: mmlogic
@@ -95,9 +95,9 @@ spec:
         image: "{{ .Values.global.image.registry }}/{{ .Values.mmlogic.image}}:{{ .Values.global.image.tag }}"
         ports:
         - name: grpc
-          containerPort: {{ .Values.mmlogic.grpcPort }}
+          containerPort: {{ .Values.global.kubernetes.service.grpcPort }}
         - name: http
-          containerPort: {{ .Values.mmlogic.httpPort }}
+          containerPort: {{ .Values.global.kubernetes.service.httpPort }}
         {{- include "openmatch.container.common" . | nindent 8 }}
-        {{- include "kubernetes.probe" (dict "port" .Values.mmlogic.httpPort "isHTTPS" .Values.global.tls.enabled) | nindent 8 }}
+        {{- include "kubernetes.probe" . | nindent 8 }}
 {{- end }}

--- a/install/helm/open-match/templates/om-configmap-default.yaml
+++ b/install/helm/open-match/templates/om-configmap-default.yaml
@@ -48,26 +48,21 @@ data:
       # maxElapsedTime caps the retry time (in milliseconds)
       maxElapsedTime: 3000ms
 
+    ports:
+      grpcPort: "{{ .Values.global.kubernetes.service.grpcPort }}"
+      httpPort: "{{ .Values.global.kubernetes.service.httpPort }}"
+
     api:
       backend:
         hostname: "{{ .Values.backend.hostName }}"
-        grpcport: "{{ .Values.backend.grpcPort }}"
-        httpport: "{{ .Values.backend.httpPort }}"
       frontend:
         hostname: "{{ .Values.frontend.hostName }}"
-        grpcport: "{{ .Values.frontend.grpcPort }}"
-        httpport: "{{ .Values.frontend.httpPort }}"
       mmlogic:
         hostname: "{{ .Values.mmlogic.hostName }}"
-        grpcport: "{{ .Values.mmlogic.grpcPort }}"
-        httpport: "{{ .Values.mmlogic.httpPort }}"
       synchronizer:
         hostname: "{{ .Values.synchronizer.hostName }}"
-        grpcport: "{{ .Values.synchronizer.grpcPort }}"
-        httpport: "{{ .Values.synchronizer.httpPort }}"
       swaggerui:
         hostname: "{{ .Values.swaggerui.hostName }}"
-        httpport: "{{ .Values.swaggerui.httpPort }}"
 {{- if .Values.global.tls.enabled }}
       tls:
         trustedCertificatePath: "{{.Values.global.tls.rootca.mountPath}}/public.cert"

--- a/install/helm/open-match/templates/om-configmap-override.yaml
+++ b/install/helm/open-match/templates/om-configmap-override.yaml
@@ -28,8 +28,8 @@ data:
     api:
       evaluator:
         hostname: "{{ .Values.evaluator.hostName }}"
-        grpcport: "{{ .Values.evaluator.grpcPort }}"
-        httpport: "{{ .Values.evaluator.httpPort }}"
+        grpcport: "{{ .Values.global.kubernetes.service.grpcPort }}"
+        httpport: "{{ .Values.global.kubernetes.service.httpPort }}"
     synchronizer:
       registrationIntervalMs: 3000ms
       proposalCollectionIntervalMs: 15000ms

--- a/install/helm/open-match/templates/podsecuritypolicy.yaml
+++ b/install/helm/open-match/templates/podsecuritypolicy.yaml
@@ -77,9 +77,9 @@ spec:
   hostPorts:
   # Open Match Services
   - min: 50500
-    max: 50510
+    max: 50500
   - min: 51500
-    max: 51510
+    max: 51500
   # Cassandra
   - min: 7000
     max: 7001

--- a/install/helm/open-match/templates/swaggerui.yaml
+++ b/install/helm/open-match/templates/swaggerui.yaml
@@ -31,7 +31,7 @@ spec:
   ports:
   - name: http
     protocol: TCP
-    port: {{ .Values.swaggerui.httpPort }}
+    port: {{ .Values.global.kubernetes.service.httpPort }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -72,7 +72,7 @@ spec:
         image: "{{ .Values.global.image.registry }}/{{ .Values.swaggerui.image}}:{{ .Values.global.image.tag }}"
         ports:
         - name: http
-          containerPort: {{ .Values.swaggerui.httpPort }}
+          containerPort: {{ .Values.global.kubernetes.service.httpPort }}
         {{- include "openmatch.container.common" . | nindent 8 }}
-        {{- include "kubernetes.probe" (dict "port" .Values.swaggerui.httpPort) | nindent 8 }}
+        {{- include "kubernetes.probe" . | nindent 8 }}
 {{- end }}

--- a/install/helm/open-match/templates/synchronizer.yaml
+++ b/install/helm/open-match/templates/synchronizer.yaml
@@ -32,10 +32,10 @@ spec:
   ports:
   - name: grpc
     protocol: TCP
-    port: {{ .Values.synchronizer.grpcPort }}
+    port: {{ .Values.global.kubernetes.service.grpcPort }}
   - name: http
     protocol: TCP
-    port: {{ .Values.synchronizer.httpPort }}
+    port: {{ .Values.global.kubernetes.service.httpPort }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -58,7 +58,7 @@ spec:
       namespace: {{ .Release.Namespace }}
       annotations:
         {{- include "openmatch.chartmeta" . | nindent 8 }}
-        {{- include "prometheus.annotations" (dict "port" .Values.synchronizer.httpPort "prometheus" .Values.global.telemetry.prometheus) | nindent 8 }}
+        {{- include "prometheus.annotations" . | nindent 8 }}
       labels:
         app: {{ template "openmatch.name" . }}
         component: synchronizer
@@ -79,9 +79,9 @@ spec:
         image: "{{ .Values.global.image.registry }}/{{ .Values.synchronizer.image}}:{{ .Values.global.image.tag }}"
         ports:
         - name: grpc
-          containerPort: {{ .Values.synchronizer.grpcPort }}
+          containerPort: {{ .Values.global.kubernetes.service.grpcPort }}
         - name: http
-          containerPort: {{ .Values.synchronizer.httpPort }}
+          containerPort: {{ .Values.global.kubernetes.service.httpPort }}
         {{- include "openmatch.container.common" . | nindent 8 }}
-        {{- include "kubernetes.probe" (dict "port" .Values.synchronizer.httpPort "isHTTPS" .Values.global.tls.enabled) | nindent 8 }}
+        {{- include "kubernetes.probe" . | nindent 8 }}
 {{- end }}

--- a/install/helm/open-match/values-production.yaml
+++ b/install/helm/open-match/values-production.yaml
@@ -26,14 +26,6 @@
 #   # Specifies om-mmlogic as the in-cluster domain name for the `mmlogic` service.
 #   hostName: om-mmlogic
 #
-#   # Specifies the port for receiving RESTful HTTP requests in the `mmlogic` service.
-#   # Checkouts https://open-match.dev/site/swaggerui/index.html for the RESTful APIs Open Match provides.
-#   httpPort: 51503
-#
-#   # Specifies the port for receiving gRPC calls in the `mmlogic` service.
-#   # Note that some services may not have grpcPort defined as they don't have gRPC APIs defined.
-#   grpcPort: 50503
-#
 #   # Specifies the port type for the `mmlogic` service, default to ClusterIP - available port types are ClusterIP, NodePort, LoadBalancer, ExternalName.
 #   # Please see https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types for Type values and their behaviors.
 #   portType: ClusterIP

--- a/install/helm/open-match/values-production.yaml
+++ b/install/helm/open-match/values-production.yaml
@@ -45,47 +45,34 @@
 #   image: openmatch-mmlogic
 swaggerui: &swaggerui
   hostName: om-swaggerui
-  httpPort: 51500
   portType: ClusterIP
   replicas: 1
   image: openmatch-swaggerui
 mmlogic: &mmlogic
   hostName: om-mmlogic
-  grpcPort: 50503
-  httpPort: 51503
   portType: ClusterIP
   replicas: 3
   image: openmatch-mmlogic
 frontend: &frontend
   hostName: om-frontend
-  grpcPort: 50504
-  httpPort: 51504
   portType: ClusterIP
   replicas: 3
   image: openmatch-frontend
 backend: &backend
   hostName: om-backend
-  grpcPort: 50505
-  httpPort: 51505
   portType: ClusterIP
   replicas: 3
   image: openmatch-backend
 synchronizer: &synchronizer
   hostName: om-synchronizer
-  grpcPort: 50506
-  httpPort: 51506
   portType: ClusterIP
   replicas: 1
   image: openmatch-synchronizer
 evaluator: &evaluator
   hostName: om-evaluator
-  grpcPort: 50508
-  httpPort: 51508
   replicas: 3
 function: &function
   hostName: om-function
-  grpcPort: 50502
-  httpPort: 51502
   replicas: 3
 
 # Specifies the location and name of the Open Match application-level config volumes.
@@ -231,8 +218,10 @@ global:
         cpu: 2
     # Defines a service account which provides an identity for processes that run in a Pod in Open Match.
     serviceAccount: open-match-unprivileged-service
-    # Use this field if you need to override the port type for all services defined in this chart
     service:
+      grpcPort: 50500
+      httpPort: 51500
+      # Use this field if you need to override the port type for all services defined in this chart
       portType:
 
   gcpProjectId: "replace_with_your_project_id"

--- a/install/helm/open-match/values.yaml
+++ b/install/helm/open-match/values.yaml
@@ -26,14 +26,6 @@
 #   # Specifies om-mmlogic as the in-cluster domain name for the `mmlogic` service.
 #   hostName: om-mmlogic
 #
-#   # Specifies the port for receiving RESTful HTTP requests in the `mmlogic` service.
-#   # Checkouts https://open-match.dev/site/swaggerui/index.html for the RESTful APIs Open Match provides.
-#   httpPort: 51503
-#
-#   # Specifies the port for receiving gRPC calls in the `mmlogic` service.
-#   # Note that some services may not have grpcPort defined as they don't have gRPC APIs defined.
-#   grpcPort: 50503
-#
 #   # Specifies the port type for the `mmlogic` service, default to ClusterIP - available port types are ClusterIP, NodePort, LoadBalancer, ExternalName.
 #   # Please see https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types for Type values and their behaviors.
 #   portType: ClusterIP

--- a/install/helm/open-match/values.yaml
+++ b/install/helm/open-match/values.yaml
@@ -45,47 +45,34 @@
 #   image: openmatch-mmlogic
 swaggerui: &swaggerui
   hostName: om-swaggerui
-  httpPort: 51500
   portType: ClusterIP
   replicas: 1
   image: openmatch-swaggerui
 mmlogic: &mmlogic
   hostName: om-mmlogic
-  grpcPort: 50503
-  httpPort: 51503
   portType: ClusterIP
   replicas: 3
   image: openmatch-mmlogic
 frontend: &frontend
   hostName: om-frontend
-  grpcPort: 50504
-  httpPort: 51504
   portType: ClusterIP
   replicas: 3
   image: openmatch-frontend
 backend: &backend
   hostName: om-backend
-  grpcPort: 50505
-  httpPort: 51505
   portType: ClusterIP
   replicas: 3
   image: openmatch-backend
 synchronizer: &synchronizer
   hostName: om-synchronizer
-  grpcPort: 50506
-  httpPort: 51506
   portType: ClusterIP
   replicas: 1
   image: openmatch-synchronizer
 evaluator: &evaluator
   hostName: om-evaluator
-  grpcPort: 50508
-  httpPort: 51508
   replicas: 3
 function: &function
   hostName: om-function
-  grpcPort: 50502
-  httpPort: 51502
   replicas: 3
 
 # Specifies the location and name of the Open Match application-level config volumes.
@@ -214,8 +201,10 @@ global:
         cpu: 100m
     # Defines a service account which provides an identity for processes that run in a Pod in Open Match.
     serviceAccount: open-match-unprivileged-service
-    # Use this field if you need to override the port type for all services defined in this chart
     service:
+      grpcPort: 50500
+      httpPort: 51500
+      # Use this field if you need to override the port type for all services defined in this chart
       portType:
 
   gcpProjectId: "replace_with_your_project_id"

--- a/internal/app/backend/backend_service.go
+++ b/internal/app/backend/backend_service.go
@@ -88,14 +88,14 @@ func (s *backendService) FetchMatches(req *pb.FetchMatchesRequest, stream pb.Bac
 		if err != nil {
 			// TODO: Log but continue case where mmfs were canceled once fully
 			// streaming.
-			return fmt.Errorf("Error receiving matches from MMF: %w", err)
+			return fmt.Errorf("Error receiving proposals from MMF: %w", err)
 		}
 
 		proposals, err := doFetchMatchesValidateProposals(mmfCtx, resultChan, len(req.GetProfiles()))
 		if err != nil {
 			// TODO: Log but continue case where mmfs were canceled once fully
 			// streaming.
-			return err
+			return fmt.Errorf("Error validating proposals from MMF: %w", err)
 		}
 
 	sendProposals:

--- a/internal/app/backend/backend_service.go
+++ b/internal/app/backend/backend_service.go
@@ -88,7 +88,7 @@ func (s *backendService) FetchMatches(req *pb.FetchMatchesRequest, stream pb.Bac
 		if err != nil {
 			// TODO: Log but continue case where mmfs were canceled once fully
 			// streaming.
-			return fmt.Errorf("Error recieving matches from MMF: %w", err)
+			return fmt.Errorf("Error receiving matches from MMF: %w", err)
 		}
 
 		proposals, err := doFetchMatchesValidateProposals(mmfCtx, resultChan, len(req.GetProfiles()))

--- a/internal/app/backend/backend_service.go
+++ b/internal/app/backend/backend_service.go
@@ -88,7 +88,7 @@ func (s *backendService) FetchMatches(req *pb.FetchMatchesRequest, stream pb.Bac
 		if err != nil {
 			// TODO: Log but continue case where mmfs were canceled once fully
 			// streaming.
-			return err
+			return fmt.Errorf("Error recieving matches from MMF: %w", err)
 		}
 
 		proposals, err := doFetchMatchesValidateProposals(mmfCtx, resultChan, len(req.GetProfiles()))

--- a/internal/app/swaggerui/swaggerui.go
+++ b/internal/app/swaggerui/swaggerui.go
@@ -55,7 +55,7 @@ func serve(cfg config.View) {
 	mux := &http.ServeMux{}
 	closer := telemetry.Setup("swaggerui", mux, cfg)
 	defer closer()
-	port := cfg.GetInt("api.swaggerui.httpport")
+	port := cfg.GetInt("ports.httpPort")
 	baseDir, err := os.Getwd()
 	if err != nil {
 		logger.WithError(err).Fatal("cannot get current working directory")

--- a/internal/rpc/clients.go
+++ b/internal/rpc/clients.go
@@ -84,7 +84,7 @@ func (p *ClientParams) usingTLS() bool {
 // GRPCClientFromConfig creates a gRPC client connection from a configuration.
 func GRPCClientFromConfig(cfg config.View, prefix string) (*grpc.ClientConn, error) {
 	clientParams := &ClientParams{
-		Address:                 toAddress(cfg.GetString(prefix+".hostname"), cfg.GetInt(prefix+".grpcport")),
+		Address:                 toAddress(cfg.GetString(prefix+".hostname"), cfg.GetInt("ports.grpcPort")),
 		EnableRPCLogging:        cfg.GetBool(ConfigNameEnableRPCLogging),
 		EnableRPCPayloadLogging: logging.IsDebugEnabled(cfg),
 		EnableMetrics:           cfg.GetBool(telemetry.ConfigNameEnableMetrics),
@@ -162,7 +162,7 @@ func GRPCClientFromParams(params *ClientParams) (*grpc.ClientConn, error) {
 // HTTPClientFromConfig creates a HTTP client from from a configuration.
 func HTTPClientFromConfig(cfg config.View, prefix string) (*http.Client, string, error) {
 	clientParams := &ClientParams{
-		Address:                 toAddress(cfg.GetString(prefix+".hostname"), cfg.GetInt(prefix+".httpport")),
+		Address:                 toAddress(cfg.GetString(prefix+".hostname"), cfg.GetInt("ports.httpPort")),
 		EnableRPCLogging:        cfg.GetBool(ConfigNameEnableRPCLogging),
 		EnableRPCPayloadLogging: logging.IsDebugEnabled(cfg),
 		EnableMetrics:           cfg.GetBool(telemetry.ConfigNameEnableMetrics),

--- a/internal/rpc/clients_test.go
+++ b/internal/rpc/clients_test.go
@@ -16,19 +16,20 @@ package rpc
 
 import (
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"testing"
+
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
-	"io/ioutil"
-	"net/http"
 	"open-match.dev/open-match/internal/config"
 	"open-match.dev/open-match/internal/telemetry"
 	shellTesting "open-match.dev/open-match/internal/testing"
 	utilTesting "open-match.dev/open-match/internal/util/testing"
 	"open-match.dev/open-match/pkg/pb"
 	certgenTesting "open-match.dev/open-match/tools/certgen/testing"
-	"os"
-	"testing"
 )
 
 func TestSecureGRPCFromConfig(t *testing.T) {
@@ -166,8 +167,8 @@ func configureConfigAndKeysForTesting(assert *assert.Assertions, tlsEnabled bool
 	// Generate a config view with paths to the manifests
 	cfg := viper.New()
 	cfg.Set("test.hostname", "localhost")
-	cfg.Set("test.grpcport", grpcLh.Number())
-	cfg.Set("test.httpport", httpLh.Number())
+	cfg.Set("ports.grpcPort", grpcLh.Number())
+	cfg.Set("ports.httpPort", httpLh.Number())
 
 	// Create temporary TLS key files for testing
 	pubFile, err := ioutil.TempFile("", "pub*")

--- a/internal/rpc/server.go
+++ b/internal/rpc/server.go
@@ -88,12 +88,12 @@ type ServerParams struct {
 
 // NewServerParamsFromConfig returns server Params initialized from the configuration file.
 func NewServerParamsFromConfig(cfg config.View, prefix string) (*ServerParams, error) {
-	grpcLh, err := newFromPortNumber(cfg.GetInt(prefix + ".grpcport"))
+	grpcLh, err := newFromPortNumber(cfg.GetInt("ports.grpcPort"))
 	if err != nil {
 		serverLogger.Fatal(err)
 		return nil, err
 	}
-	httpLh, err := newFromPortNumber(cfg.GetInt(prefix + ".httpport"))
+	httpLh, err := newFromPortNumber(cfg.GetInt("ports.httpPort"))
 	if err != nil {
 		closeErr := grpcLh.Close()
 		if closeErr != nil {

--- a/internal/testing/customize/evaluator/evaluator.go
+++ b/internal/testing/customize/evaluator/evaluator.go
@@ -43,8 +43,8 @@ func BindService(p *rpc.ServerParams, cfg config.View, eval Evaluator) error {
 func getCfg() (config.View, error) {
 	cfg := viper.New()
 	cfg.Set("api.evaluator.hostname", "om-evaluator")
-	cfg.Set("api.evaluator.grpcport", 50508)
-	cfg.Set("api.evaluator.httpport", 51508)
+	cfg.Set("api.evaluator.grpcport", 50500)
+	cfg.Set("api.evaluator.httpport", 51500)
 
 	return cfg, nil
 }

--- a/internal/testing/e2e/in_memory.go
+++ b/internal/testing/e2e/in_memory.go
@@ -161,7 +161,7 @@ func createMatchFunctionForTest(t *testing.T, c *rpcTesting.TestContext) *rpcTes
 		// The below configuration is used by GRPC harness to create an mmlogic client to query tickets.
 		cfg.Set("api.mmlogic.hostname", c.GetHostname())
 		cfg.Set("ports.grpcPort", c.GetGRPCPort())
-		cfg.Set("ports.httpport", c.GetHTTPPort())
+		cfg.Set("ports.httpPort", c.GetHTTPPort())
 
 		assert.Nil(t, internalMmf.BindService(p, cfg, &internalMmf.FunctionSettings{
 			Func: mmf.MakeMatches,

--- a/internal/testing/e2e/in_memory.go
+++ b/internal/testing/e2e/in_memory.go
@@ -134,8 +134,8 @@ func createMinimatchForTest(t *testing.T, evalTc *rpcTesting.TestContext) *rpcTe
 	// the backend sets up a connection to the synchronizer at runtime and hence can access these
 	// config values to establish the connection.
 	cfg.Set("api.synchronizer.hostname", tc.GetHostname())
-	cfg.Set("api.synchronizer.grpcport", tc.GetGRPCPort())
-	cfg.Set("api.synchronizer.httpport", tc.GetHTTPPort())
+	cfg.Set("ports.grpcport", tc.GetGRPCPort())
+	cfg.Set("ports.httpport", tc.GetHTTPPort())
 	cfg.Set("synchronizer.registrationIntervalMs", "200ms")
 	cfg.Set("synchronizer.proposalCollectionIntervalMs", "200ms")
 	cfg.Set("api.evaluator.hostname", evalTc.GetHostname())

--- a/internal/testing/e2e/in_memory.go
+++ b/internal/testing/e2e/in_memory.go
@@ -134,8 +134,8 @@ func createMinimatchForTest(t *testing.T, evalTc *rpcTesting.TestContext) *rpcTe
 	// the backend sets up a connection to the synchronizer at runtime and hence can access these
 	// config values to establish the connection.
 	cfg.Set("api.synchronizer.hostname", tc.GetHostname())
-	cfg.Set("ports.grpcport", tc.GetGRPCPort())
-	cfg.Set("ports.httpport", tc.GetHTTPPort())
+	cfg.Set("ports.grpcPort", tc.GetGRPCPort())
+	cfg.Set("ports.httpPort", tc.GetHTTPPort())
 	cfg.Set("synchronizer.registrationIntervalMs", "200ms")
 	cfg.Set("synchronizer.proposalCollectionIntervalMs", "200ms")
 	cfg.Set("api.evaluator.hostname", evalTc.GetHostname())
@@ -160,8 +160,8 @@ func createMatchFunctionForTest(t *testing.T, c *rpcTesting.TestContext) *rpcTes
 
 		// The below configuration is used by GRPC harness to create an mmlogic client to query tickets.
 		cfg.Set("api.mmlogic.hostname", c.GetHostname())
-		cfg.Set("api.mmlogic.grpcport", c.GetGRPCPort())
-		cfg.Set("api.mmlogic.httpport", c.GetHTTPPort())
+		cfg.Set("ports.grpcPort", c.GetGRPCPort())
+		cfg.Set("ports.httpport", c.GetHTTPPort())
 
 		assert.Nil(t, internalMmf.BindService(p, cfg, &internalMmf.FunctionSettings{
 			Func: mmf.MakeMatches,

--- a/internal/testing/mmf/matchfunction.go
+++ b/internal/testing/mmf/matchfunction.go
@@ -54,11 +54,11 @@ func getCfg() (config.View, error) {
 	cfg := viper.New()
 
 	cfg.Set("api.functions.hostname", "om-function")
-	cfg.Set("api.functions.grpcport", 50502)
-	cfg.Set("api.functions.httpport", 51502)
+	cfg.Set("api.functions.grpcport", 50500)
+	cfg.Set("api.functions.httpport", 51500)
 
 	cfg.Set("api.mmlogic.hostname", "om-mmlogic")
-	cfg.Set("api.mmlogic.grpcport", 50503)
+	cfg.Set("api.mmlogic.grpcport", 50500)
 
 	return cfg, nil
 }

--- a/tools/certgen/certgen.go
+++ b/tools/certgen/certgen.go
@@ -30,16 +30,16 @@ var (
 	// serviceAddresses is a list of all the HTTP hostname:port combinations for generating a TLS certificate.
 	// It appears that gRPC does not care about validating the port number so we only add the HTTP addresses here.
 	serviceAddressList = []string{
-		"om-backend:51505",
-		"om-demo:51507",
-		"om-demoevaluator:51508",
-		"om-demofunction:51502",
-		"om-e2eevaluator:51518",
-		"om-e2ematchfunction:51512",
-		"om-frontend:51504",
-		"om-mmlogic:51503",
+		"om-backend:51500",
+		"om-demo:51500",
+		"om-demoevaluator:51500",
+		"om-demofunction:51500",
+		"om-e2eevaluator:51500",
+		"om-e2ematchfunction:51500",
+		"om-frontend:51500",
+		"om-mmlogic:51500",
 		"om-swaggerui:51500",
-		"om-synchronizer:51506",
+		"om-synchronizer:51500",
 	}
 	caFlag                    = flag.Bool("ca", false, "Create a root certificate. Use if you want a chain of trust with other certificates.")
 	rootPublicCertificateFlag = flag.String("rootpubliccertificate", "", "(optional) Path to root certificate file. If set the output certificate is rooted from this certificate.")

--- a/tutorials/custom_evaluator/customization.yaml
+++ b/tutorials/custom_evaluator/customization.yaml
@@ -29,7 +29,7 @@ data:
     api:
       evaluator:
         hostname: "custom-eval-tutorial-evaluator.custom-eval-tutorial.svc.cluster.local"
-        grpcport: "50508"
+        grpcport: "50500"
     synchronizer:
       enabled: true
       registrationIntervalMs: 3000ms

--- a/tutorials/custom_evaluator/director/main.go
+++ b/tutorials/custom_evaluator/director/main.go
@@ -32,10 +32,10 @@ import (
 
 const (
 	// The endpoint for the Open Match Backend service.
-	omBackendEndpoint = "om-backend.open-match.svc.cluster.local:50505"
+	omBackendEndpoint = "om-backend.open-match.svc.cluster.local:50500"
 	// The Host and Port for the Match Function service endpoint.
 	functionHostName       = "custom-eval-tutorial-matchfunction.custom-eval-tutorial.svc.cluster.local"
-	functionPort     int32 = 50502
+	functionPort     int32 = 50500
 )
 
 func main() {

--- a/tutorials/custom_evaluator/evaluator/evaluator.yaml
+++ b/tutorials/custom_evaluator/evaluator/evaluator.yaml
@@ -27,7 +27,7 @@ spec:
     imagePullPolicy: Always
     ports:
     - name: grpc
-      containerPort: 50508
+      containerPort: 50500
 ---
 kind: Service
 apiVersion: v1
@@ -46,5 +46,5 @@ spec:
   ports:
   - name: grpc
     protocol: TCP
-    port: 50508
+    port: 50500
 ---

--- a/tutorials/custom_evaluator/evaluator/main.go
+++ b/tutorials/custom_evaluator/evaluator/main.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	// Replace this with the port on which your Evaluator service is exposed.
-	evaluatorPort = 50508
+	evaluatorPort = 50500
 )
 
 func main() {

--- a/tutorials/custom_evaluator/frontend/main.go
+++ b/tutorials/custom_evaluator/frontend/main.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	// The endpoint for the Open Match Frontend service.
-	omFrontendEndpoint = "om-frontend.open-match.svc.cluster.local:50504"
+	omFrontendEndpoint = "om-frontend.open-match.svc.cluster.local:50500"
 	// Number of tickets created per iteration
 	ticketsPerIter = 20
 )

--- a/tutorials/custom_evaluator/matchfunction/main.go
+++ b/tutorials/custom_evaluator/matchfunction/main.go
@@ -28,8 +28,8 @@ import (
 // with which the Match Function communicates to query the Tickets.
 
 const (
-	mmlogicAddress = "om-mmlogic.open-match.svc.cluster.local:50503" // Address of the MMLogic service endpoint.
-	serverPort     = 50502                                           // The port for hosting the Match Function.
+	mmlogicAddress = "om-mmlogic.open-match.svc.cluster.local:50500" // Address of the MMLogic service endpoint.
+	serverPort     = 50500                                           // The port for hosting the Match Function.
 )
 
 func main() {

--- a/tutorials/custom_evaluator/matchfunction/matchfunction.yaml
+++ b/tutorials/custom_evaluator/matchfunction/matchfunction.yaml
@@ -27,7 +27,7 @@ spec:
     imagePullPolicy: Always
     ports:
     - name: grpc
-      containerPort: 50502
+      containerPort: 50500
 ---
 kind: Service
 apiVersion: v1
@@ -46,4 +46,4 @@ spec:
   ports:
   - name: grpc
     protocol: TCP
-    port: 50502
+    port: 50500

--- a/tutorials/custom_evaluator/matchmaker.yaml
+++ b/tutorials/custom_evaluator/matchmaker.yaml
@@ -55,7 +55,7 @@ spec:
     imagePullPolicy: Always
     ports:
     - name: grpc
-      containerPort: 50502
+      containerPort: 50500
 ---
 kind: Service
 apiVersion: v1
@@ -74,7 +74,7 @@ spec:
   ports:
   - name: grpc
     protocol: TCP
-    port: 50502
+    port: 50500
 ---
 apiVersion: v1
 kind: Pod
@@ -91,7 +91,7 @@ spec:
     imagePullPolicy: Always
     ports:
     - name: grpc
-      containerPort: 50508
+      containerPort: 50500
 ---
 kind: Service
 apiVersion: v1
@@ -110,5 +110,5 @@ spec:
   ports:
   - name: grpc
     protocol: TCP
-    port: 50508
+    port: 50500
 ---

--- a/tutorials/custom_evaluator/solution/customization.yaml
+++ b/tutorials/custom_evaluator/solution/customization.yaml
@@ -29,7 +29,7 @@ data:
     api:
       evaluator:
         hostname: "custom-eval-tutorial-evaluator.custom-eval-tutorial.svc.cluster.local"
-        grpcport: "50508"
+        grpcport: "50500"
     synchronizer:
       enabled: true
       registrationIntervalMs: 3000ms

--- a/tutorials/custom_evaluator/solution/director/main.go
+++ b/tutorials/custom_evaluator/solution/director/main.go
@@ -32,10 +32,10 @@ import (
 
 const (
 	// The endpoint for the Open Match Backend service.
-	omBackendEndpoint = "om-backend.open-match.svc.cluster.local:50505"
+	omBackendEndpoint = "om-backend.open-match.svc.cluster.local:50500"
 	// The Host and Port for the Match Function service endpoint.
 	functionHostName       = "custom-eval-tutorial-matchfunction.custom-eval-tutorial.svc.cluster.local"
-	functionPort     int32 = 50502
+	functionPort     int32 = 50500
 )
 
 func main() {

--- a/tutorials/custom_evaluator/solution/evaluator/evaluator.yaml
+++ b/tutorials/custom_evaluator/solution/evaluator/evaluator.yaml
@@ -27,7 +27,7 @@ spec:
     imagePullPolicy: Always
     ports:
     - name: grpc
-      containerPort: 50508
+      containerPort: 50500
 ---
 kind: Service
 apiVersion: v1
@@ -46,5 +46,5 @@ spec:
   ports:
   - name: grpc
     protocol: TCP
-    port: 50508
+    port: 50500
 ---

--- a/tutorials/custom_evaluator/solution/evaluator/main.go
+++ b/tutorials/custom_evaluator/solution/evaluator/main.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	// Replace this with the port on which your Evaluator service is exposed.
-	evaluatorPort = 50508
+	evaluatorPort = 50500
 )
 
 func main() {

--- a/tutorials/custom_evaluator/solution/frontend/main.go
+++ b/tutorials/custom_evaluator/solution/frontend/main.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	// The endpoint for the Open Match Frontend service.
-	omFrontendEndpoint = "om-frontend.open-match.svc.cluster.local:50504"
+	omFrontendEndpoint = "om-frontend.open-match.svc.cluster.local:50500"
 	// Number of tickets created per iteration
 	ticketsPerIter = 20
 )

--- a/tutorials/custom_evaluator/solution/matchfunction/main.go
+++ b/tutorials/custom_evaluator/solution/matchfunction/main.go
@@ -28,8 +28,8 @@ import (
 // with which the Match Function communicates to query the Tickets.
 
 const (
-	mmlogicAddress = "om-mmlogic.open-match.svc.cluster.local:50503" // Address of the MMLogic service endpoint.
-	serverPort     = 50502                                           // The port for hosting the Match Function.
+	mmlogicAddress = "om-mmlogic.open-match.svc.cluster.local:50500" // Address of the MMLogic service endpoint.
+	serverPort     = 50500                                           // The port for hosting the Match Function.
 )
 
 func main() {

--- a/tutorials/custom_evaluator/solution/matchfunction/matchfunction.yaml
+++ b/tutorials/custom_evaluator/solution/matchfunction/matchfunction.yaml
@@ -27,7 +27,7 @@ spec:
     imagePullPolicy: Always
     ports:
     - name: grpc
-      containerPort: 50502
+      containerPort: 50500
 ---
 kind: Service
 apiVersion: v1
@@ -46,4 +46,4 @@ spec:
   ports:
   - name: grpc
     protocol: TCP
-    port: 50502
+    port: 50500

--- a/tutorials/custom_evaluator/solution/matchmaker.yaml
+++ b/tutorials/custom_evaluator/solution/matchmaker.yaml
@@ -55,7 +55,7 @@ spec:
     imagePullPolicy: Always
     ports:
     - name: grpc
-      containerPort: 50502
+      containerPort: 50500
 ---
 kind: Service
 apiVersion: v1
@@ -74,7 +74,7 @@ spec:
   ports:
   - name: grpc
     protocol: TCP
-    port: 50502
+    port: 50500
 ---
 apiVersion: v1
 kind: Pod
@@ -91,7 +91,7 @@ spec:
     imagePullPolicy: Always
     ports:
     - name: grpc
-      containerPort: 50508
+      containerPort: 50500
 ---
 kind: Service
 apiVersion: v1
@@ -110,5 +110,5 @@ spec:
   ports:
   - name: grpc
     protocol: TCP
-    port: 50508
+    port: 50500
 ---

--- a/tutorials/default_evaluator/director/main.go
+++ b/tutorials/default_evaluator/director/main.go
@@ -32,10 +32,10 @@ import (
 
 const (
 	// The endpoint for the Open Match Backend service.
-	omBackendEndpoint = "om-backend.open-match.svc.cluster.local:50505"
+	omBackendEndpoint = "om-backend.open-match.svc.cluster.local:50500"
 	// The Host and Port for the Match Function service endpoint.
 	functionHostName       = "default-eval-tutorial-matchfunction.default-eval-tutorial.svc.cluster.local"
-	functionPort     int32 = 50502
+	functionPort     int32 = 50500
 )
 
 func main() {

--- a/tutorials/default_evaluator/frontend/main.go
+++ b/tutorials/default_evaluator/frontend/main.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	// The endpoint for the Open Match Frontend service.
-	omFrontendEndpoint = "om-frontend.open-match.svc.cluster.local:50504"
+	omFrontendEndpoint = "om-frontend.open-match.svc.cluster.local:50500"
 	// Number of tickets created per iteration
 	ticketsPerIter = 20
 )

--- a/tutorials/default_evaluator/matchfunction/main.go
+++ b/tutorials/default_evaluator/matchfunction/main.go
@@ -28,8 +28,8 @@ import (
 // with which the Match Function communicates to query the Tickets.
 
 const (
-	mmlogicAddress = "om-mmlogic.open-match.svc.cluster.local:50503" // Address of the MMLogic service endpoint.
-	serverPort     = 50502                                           // The port for hosting the Match Function.
+	mmlogicAddress = "om-mmlogic.open-match.svc.cluster.local:50500" // Address of the MMLogic service endpoint.
+	serverPort     = 50500                                           // The port for hosting the Match Function.
 )
 
 func main() {

--- a/tutorials/default_evaluator/matchfunction/matchfunction.yaml
+++ b/tutorials/default_evaluator/matchfunction/matchfunction.yaml
@@ -27,7 +27,7 @@ spec:
     imagePullPolicy: Always
     ports:
     - name: grpc
-      containerPort: 50502
+      containerPort: 50500
 ---
 kind: Service
 apiVersion: v1
@@ -46,4 +46,4 @@ spec:
   ports:
   - name: grpc
     protocol: TCP
-    port: 50502
+    port: 50500

--- a/tutorials/default_evaluator/matchmaker.yaml
+++ b/tutorials/default_evaluator/matchmaker.yaml
@@ -55,7 +55,7 @@ spec:
     imagePullPolicy: Always
     ports:
     - name: grpc
-      containerPort: 50502
+      containerPort: 50500
 ---
 kind: Service
 apiVersion: v1
@@ -74,5 +74,5 @@ spec:
   ports:
   - name: grpc
     protocol: TCP
-    port: 50502
+    port: 50500
 ---

--- a/tutorials/default_evaluator/solution/director/main.go
+++ b/tutorials/default_evaluator/solution/director/main.go
@@ -32,10 +32,10 @@ import (
 
 const (
 	// The endpoint for the Open Match Backend service.
-	omBackendEndpoint = "om-backend.open-match.svc.cluster.local:50505"
+	omBackendEndpoint = "om-backend.open-match.svc.cluster.local:50500"
 	// The Host and Port for the Match Function service endpoint.
 	functionHostName       = "default-eval-tutorial-matchfunction.default-eval-tutorial.svc.cluster.local"
-	functionPort     int32 = 50502
+	functionPort     int32 = 50500
 )
 
 func main() {

--- a/tutorials/default_evaluator/solution/frontend/main.go
+++ b/tutorials/default_evaluator/solution/frontend/main.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	// The endpoint for the Open Match Frontend service.
-	omFrontendEndpoint = "om-frontend.open-match.svc.cluster.local:50504"
+	omFrontendEndpoint = "om-frontend.open-match.svc.cluster.local:50500"
 	// Number of tickets created per iteration
 	ticketsPerIter = 20
 )

--- a/tutorials/default_evaluator/solution/matchfunction/main.go
+++ b/tutorials/default_evaluator/solution/matchfunction/main.go
@@ -28,8 +28,8 @@ import (
 // with which the Match Function communicates to query the Tickets.
 
 const (
-	mmlogicAddress = "om-mmlogic.open-match.svc.cluster.local:50503" // Address of the MMLogic service endpoint.
-	serverPort     = 50502                                           // The port for hosting the Match Function.
+	mmlogicAddress = "om-mmlogic.open-match.svc.cluster.local:50500" // Address of the MMLogic service endpoint.
+	serverPort     = 50500                                           // The port for hosting the Match Function.
 )
 
 func main() {

--- a/tutorials/default_evaluator/solution/matchfunction/matchfunction.yaml
+++ b/tutorials/default_evaluator/solution/matchfunction/matchfunction.yaml
@@ -27,7 +27,7 @@ spec:
     imagePullPolicy: Always
     ports:
     - name: grpc
-      containerPort: 50502
+      containerPort: 50500
 ---
 kind: Service
 apiVersion: v1
@@ -46,4 +46,4 @@ spec:
   ports:
   - name: grpc
     protocol: TCP
-    port: 50502
+    port: 50500

--- a/tutorials/default_evaluator/solution/matchmaker.yaml
+++ b/tutorials/default_evaluator/solution/matchmaker.yaml
@@ -55,7 +55,7 @@ spec:
     imagePullPolicy: Always
     ports:
     - name: grpc
-      containerPort: 50502
+      containerPort: 50500
 ---
 kind: Service
 apiVersion: v1
@@ -74,5 +74,5 @@ spec:
   ports:
   - name: grpc
     protocol: TCP
-    port: 50502
+    port: 50500
 ---

--- a/tutorials/matchmaker101/director/main.go
+++ b/tutorials/matchmaker101/director/main.go
@@ -32,10 +32,10 @@ import (
 
 const (
 	// The endpoint for the Open Match Backend service.
-	omBackendEndpoint = "om-backend.open-match.svc.cluster.local:50505"
+	omBackendEndpoint = "om-backend.open-match.svc.cluster.local:50500"
 	// The Host and Port for the Match Function service endpoint.
 	functionHostName       = "mm101-tutorial-matchfunction.mm101-tutorial.svc.cluster.local"
-	functionPort     int32 = 50502
+	functionPort     int32 = 50500
 )
 
 func main() {

--- a/tutorials/matchmaker101/frontend/main.go
+++ b/tutorials/matchmaker101/frontend/main.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	// The endpoint for the Open Match Frontend service.
-	omFrontendEndpoint = "om-frontend.open-match.svc.cluster.local:50504"
+	omFrontendEndpoint = "om-frontend.open-match.svc.cluster.local:50500"
 	// Number of tickets created per iteration
 	ticketsPerIter = 20
 )

--- a/tutorials/matchmaker101/matchfunction/main.go
+++ b/tutorials/matchmaker101/matchfunction/main.go
@@ -28,8 +28,8 @@ import (
 // with which the Match Function communicates to query the Tickets.
 
 const (
-	mmlogicAddress = "om-mmlogic.open-match.svc.cluster.local:50503" // Address of the MMLogic service endpoint.
-	serverPort     = 50502                                           // The port for hosting the Match Function.
+	mmlogicAddress = "om-mmlogic.open-match.svc.cluster.local:50500" // Address of the MMLogic service endpoint.
+	serverPort     = 50500                                           // The port for hosting the Match Function.
 )
 
 func main() {

--- a/tutorials/matchmaker101/matchfunction/matchfunction.yaml
+++ b/tutorials/matchmaker101/matchfunction/matchfunction.yaml
@@ -27,7 +27,7 @@ spec:
     imagePullPolicy: Always
     ports:
     - name: grpc
-      containerPort: 50502
+      containerPort: 50500
 ---
 kind: Service
 apiVersion: v1
@@ -46,4 +46,4 @@ spec:
   ports:
   - name: grpc
     protocol: TCP
-    port: 50502
+    port: 50500

--- a/tutorials/matchmaker101/matchmaker.yaml
+++ b/tutorials/matchmaker101/matchmaker.yaml
@@ -55,7 +55,7 @@ spec:
     imagePullPolicy: Always
     ports:
     - name: grpc
-      containerPort: 50502
+      containerPort: 50500
 ---
 kind: Service
 apiVersion: v1
@@ -74,5 +74,5 @@ spec:
   ports:
   - name: grpc
     protocol: TCP
-    port: 50502
+    port: 50500
 ---

--- a/tutorials/matchmaker101/solution/director/main.go
+++ b/tutorials/matchmaker101/solution/director/main.go
@@ -32,10 +32,10 @@ import (
 
 const (
 	// The endpoint for the Open Match Backend service.
-	omBackendEndpoint = "om-backend.open-match.svc.cluster.local:50505"
+	omBackendEndpoint = "om-backend.open-match.svc.cluster.local:50500"
 	// The Host and Port for the Match Function service endpoint.
 	functionHostName       = "mm101-tutorial-matchfunction.mm101-tutorial.svc.cluster.local"
-	functionPort     int32 = 50502
+	functionPort     int32 = 50500
 )
 
 func main() {

--- a/tutorials/matchmaker101/solution/frontend/main.go
+++ b/tutorials/matchmaker101/solution/frontend/main.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	// The endpoint for the Open Match Frontend service.
-	omFrontendEndpoint = "om-frontend.open-match.svc.cluster.local:50504"
+	omFrontendEndpoint = "om-frontend.open-match.svc.cluster.local:50500"
 	// Number of tickets created per iteration
 	ticketsPerIter = 20
 )

--- a/tutorials/matchmaker101/solution/matchfunction/main.go
+++ b/tutorials/matchmaker101/solution/matchfunction/main.go
@@ -28,8 +28,8 @@ import (
 // with which the Match Function communicates to query the Tickets.
 
 const (
-	mmlogicAddress = "om-mmlogic.open-match.svc.cluster.local:50503" // Address of the MMLogic service endpoint.
-	serverPort     = 50502                                           // The port for hosting the Match Function.
+	mmlogicAddress = "om-mmlogic.open-match.svc.cluster.local:50500" // Address of the MMLogic service endpoint.
+	serverPort     = 50500                                           // The port for hosting the Match Function.
 )
 
 func main() {

--- a/tutorials/matchmaker101/solution/matchfunction/matchfunction.yaml
+++ b/tutorials/matchmaker101/solution/matchfunction/matchfunction.yaml
@@ -27,7 +27,7 @@ spec:
     imagePullPolicy: Always
     ports:
     - name: grpc
-      containerPort: 50502
+      containerPort: 50500
 ---
 kind: Service
 apiVersion: v1
@@ -46,4 +46,4 @@ spec:
   ports:
   - name: grpc
     protocol: TCP
-    port: 50502
+    port: 50500

--- a/tutorials/matchmaker101/solution/matchmaker.yaml
+++ b/tutorials/matchmaker101/solution/matchmaker.yaml
@@ -55,7 +55,7 @@ spec:
     imagePullPolicy: Always
     ports:
     - name: grpc
-      containerPort: 50502
+      containerPort: 50500
 ---
 kind: Service
 apiVersion: v1
@@ -74,5 +74,5 @@ spec:
   ports:
   - name: grpc
     protocol: TCP
-    port: 50502
+    port: 50500
 ---

--- a/tutorials/matchmaker102/director/main.go
+++ b/tutorials/matchmaker102/director/main.go
@@ -32,10 +32,10 @@ import (
 
 const (
 	// The endpoint for the Open Match Backend service.
-	omBackendEndpoint = "om-backend.open-match.svc.cluster.local:50505"
+	omBackendEndpoint = "om-backend.open-match.svc.cluster.local:50500"
 	// The Host and Port for the Match Function service endpoint.
 	functionHostName       = "mm102-tutorial-matchfunction.mm102-tutorial.svc.cluster.local"
-	functionPort     int32 = 50502
+	functionPort     int32 = 50500
 )
 
 func main() {

--- a/tutorials/matchmaker102/frontend/main.go
+++ b/tutorials/matchmaker102/frontend/main.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	// The endpoint for the Open Match Frontend service.
-	omFrontendEndpoint = "om-frontend.open-match.svc.cluster.local:50504"
+	omFrontendEndpoint = "om-frontend.open-match.svc.cluster.local:50500"
 	// Number of tickets created per iteration
 	ticketsPerIter = 20
 )

--- a/tutorials/matchmaker102/matchfunction/main.go
+++ b/tutorials/matchmaker102/matchfunction/main.go
@@ -28,8 +28,8 @@ import (
 // with which the Match Function communicates to query the Tickets.
 
 const (
-	mmlogicAddress = "om-mmlogic.open-match.svc.cluster.local:50503" // Address of the MMLogic service endpoint.
-	serverPort     = 50502                                           // The port for hosting the Match Function.
+	mmlogicAddress = "om-mmlogic.open-match.svc.cluster.local:50500" // Address of the MMLogic service endpoint.
+	serverPort     = 50500                                           // The port for hosting the Match Function.
 )
 
 func main() {

--- a/tutorials/matchmaker102/matchfunction/matchfunction.yaml
+++ b/tutorials/matchmaker102/matchfunction/matchfunction.yaml
@@ -27,7 +27,7 @@ spec:
     imagePullPolicy: Always
     ports:
     - name: grpc
-      containerPort: 50502
+      containerPort: 50500
 ---
 kind: Service
 apiVersion: v1
@@ -46,4 +46,4 @@ spec:
   ports:
   - name: grpc
     protocol: TCP
-    port: 50502
+    port: 50500

--- a/tutorials/matchmaker102/matchmaker.yaml
+++ b/tutorials/matchmaker102/matchmaker.yaml
@@ -55,7 +55,7 @@ spec:
     imagePullPolicy: Always
     ports:
     - name: grpc
-      containerPort: 50502
+      containerPort: 50500
 ---
 kind: Service
 apiVersion: v1
@@ -74,5 +74,5 @@ spec:
   ports:
   - name: grpc
     protocol: TCP
-    port: 50502
+    port: 50500
 ---

--- a/tutorials/matchmaker102/solution/director/main.go
+++ b/tutorials/matchmaker102/solution/director/main.go
@@ -32,10 +32,10 @@ import (
 
 const (
 	// The endpoint for the Open Match Backend service.
-	omBackendEndpoint = "om-backend.open-match.svc.cluster.local:50505"
+	omBackendEndpoint = "om-backend.open-match.svc.cluster.local:50500"
 	// The Host and Port for the Match Function service endpoint.
 	functionHostName       = "mm102-tutorial-matchfunction.mm102-tutorial.svc.cluster.local"
-	functionPort     int32 = 50502
+	functionPort     int32 = 50500
 )
 
 func main() {

--- a/tutorials/matchmaker102/solution/frontend/main.go
+++ b/tutorials/matchmaker102/solution/frontend/main.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	// The endpoint for the Open Match Frontend service.
-	omFrontendEndpoint = "om-frontend.open-match.svc.cluster.local:50504"
+	omFrontendEndpoint = "om-frontend.open-match.svc.cluster.local:50500"
 	// Number of tickets created per iteration
 	ticketsPerIter = 20
 )

--- a/tutorials/matchmaker102/solution/matchfunction/main.go
+++ b/tutorials/matchmaker102/solution/matchfunction/main.go
@@ -28,8 +28,8 @@ import (
 // with which the Match Function communicates to query the Tickets.
 
 const (
-	mmlogicAddress = "om-mmlogic.open-match.svc.cluster.local:50503" // Address of the MMLogic service endpoint.
-	serverPort     = 50502                                           // The port for hosting the Match Function.
+	mmlogicAddress = "om-mmlogic.open-match.svc.cluster.local:50500" // Address of the MMLogic service endpoint.
+	serverPort     = 50500                                           // The port for hosting the Match Function.
 )
 
 func main() {

--- a/tutorials/matchmaker102/solution/matchfunction/matchfunction.yaml
+++ b/tutorials/matchmaker102/solution/matchfunction/matchfunction.yaml
@@ -27,7 +27,7 @@ spec:
     imagePullPolicy: Always
     ports:
     - name: grpc
-      containerPort: 50502
+      containerPort: 50500
 ---
 kind: Service
 apiVersion: v1
@@ -46,4 +46,4 @@ spec:
   ports:
   - name: grpc
     protocol: TCP
-    port: 50502
+    port: 50500

--- a/tutorials/matchmaker102/solution/matchmaker.yaml
+++ b/tutorials/matchmaker102/solution/matchmaker.yaml
@@ -55,7 +55,7 @@ spec:
     imagePullPolicy: Always
     ports:
     - name: grpc
-      containerPort: 50502
+      containerPort: 50500
 ---
 kind: Service
 apiVersion: v1
@@ -74,5 +74,5 @@ spec:
   ports:
   - name: grpc
     protocol: TCP
-    port: 50502
+    port: 50500
 ---


### PR DESCRIPTION
READY FOR REVIEW BUT NEED TO RUN A FULL CLUSTER BEFORE MERGE TO VERIFY PROXY COMMANDS ALL WORK.

Resolves: https://github.com/googleforgames/open-match/issues/991

This simplifies service start up as it means services don't need to be defined in the config in order to know what ports they should open.  I would like to look into simplifying/removing the configuration around hostnames at some point in the future.  It also generally makes things easier from a standpoint of not having to choose ports to allocate.

While I need to test all of the proxy commands anyways, simplifies them.  (except locust, which we might be able to remove?)