### PR TITLE
Run scale test assignment and deletes in parallel

### DIFF
--- a/examples/scale/backend/backend.go
+++ b/examples/scale/backend/backend.go
@@ -81,7 +81,17 @@ func run(cfg config.View) {
 	w := logger.Writer()
 	defer w.Close()
 
-	for {
+	matchesForAssignment := make(chan *pb.Match, 1000)
+	ticketsForDeletion := make(chan string, 1000)
+
+	for i := 0; i < 30; i++ {
+		go runAssignments(be, matchesForAssignment, ticketsForDeletion)
+		go runDeletions(fe, ticketsForDeletion)
+	}
+
+	// Don't go faster than this, as it likely means that FetchMatches is throwing
+	// errors, and will continue doing so if queried very quickly.
+	for range time.Tick(time.Millisecond * 250) {
 		// Keep pulling matches from Open Match backend
 		profiles := activeScenario.Profiles()
 		statProcessor.SetStat("TotalProfiles", len(profiles))
@@ -91,7 +101,7 @@ func run(cfg config.View) {
 			wg.Add(1)
 			go func(wg *sync.WaitGroup, p *pb.MatchProfile) {
 				defer wg.Done()
-				runIteration(fe, be, p)
+				runFetchMatches(be, p, matchesForAssignment)
 			}(&wg, p)
 		}
 
@@ -103,7 +113,7 @@ func run(cfg config.View) {
 	}
 }
 
-func runIteration(fe pb.FrontendClient, be pb.BackendClient, p *pb.MatchProfile) {
+func runFetchMatches(be pb.BackendClient, p *pb.MatchProfile, matchesForAssignment chan<- *pb.Match) {
 	ctx, span := trace.StartSpan(context.Background(), "scale.backend/FetchMatches")
 	defer span.End()
 
@@ -124,10 +134,6 @@ func runIteration(fe pb.FrontendClient, be pb.BackendClient, p *pb.MatchProfile)
 		return
 	}
 
-	processMatches(ctx, fe, be, stream)
-}
-
-func processMatches(ctx context.Context, fe pb.FrontendClient, be pb.BackendClient, stream pb.Backend_FetchMatchesClient) {
 	for {
 		// Pull the Match
 		resp, err := stream.Recv()
@@ -142,22 +148,31 @@ func processMatches(ctx context.Context, fe pb.FrontendClient, be pb.BackendClie
 			return
 		}
 
+		telemetry.RecordNUnitMeasurement(ctx, mSumTicketsReturned, int64(len(resp.GetMatch().Tickets)))
 		telemetry.RecordUnitMeasurement(ctx, mMatchesReturned)
 		statProcessor.IncrementStat("MatchCount", 1)
 
+		matchesForAssignment <- resp.GetMatch()
+	}
+}
+
+func runAssignments(be pb.BackendClient, matchesForAssignment <-chan *pb.Match, ticketsForDeletion chan<- string) {
+	ctx := context.Background()
+
+	for m := range matchesForAssignment {
 		ids := []string{}
-		for _, t := range resp.GetMatch().Tickets {
-			telemetry.RecordUnitMeasurement(ctx, mSumTicketsReturned)
+		for _, t := range m.Tickets {
 			ids = append(ids, t.GetId())
 		}
-		// Assign Tickets
+
 		if activeScenario.BackendAssignsTickets {
-			if _, err := be.AssignTickets(context.Background(), &pb.AssignTicketsRequest{
+			_, err := be.AssignTickets(context.Background(), &pb.AssignTicketsRequest{
 				TicketIds: ids,
 				Assignment: &pb.Assignment{
 					Connection: fmt.Sprintf("%d.%d.%d.%d:2222", rand.Intn(256), rand.Intn(256), rand.Intn(256), rand.Intn(256)),
 				},
-			}); err != nil {
+			})
+			if err != nil {
 				telemetry.RecordUnitMeasurement(ctx, mMatchAssignsFailed)
 				statProcessor.RecordError("failed to assign tickets", err)
 				continue
@@ -167,21 +182,29 @@ func processMatches(ctx context.Context, fe pb.FrontendClient, be pb.BackendClie
 			statProcessor.IncrementStat("Assigned", len(ids))
 		}
 
-		// Delete Tickets
+		for _, id := range ids {
+			ticketsForDeletion <- id
+		}
+	}
+}
+
+func runDeletions(fe pb.FrontendClient, ticketsForDeletion <-chan string) {
+	ctx := context.Background()
+
+	for id := range ticketsForDeletion {
 		if activeScenario.BackendDeletesTickets {
-			for _, id := range ids {
-				req := &pb.DeleteTicketRequest{
-					TicketId: id,
-				}
+			req := &pb.DeleteTicketRequest{
+				TicketId: id,
+			}
 
-				if _, err := fe.DeleteTicket(context.Background(), req); err != nil {
-					telemetry.RecordUnitMeasurement(ctx, mTicketDeletesFailed)
-					statProcessor.RecordError("failed to delete tickets", err)
-					continue
-				}
+			_, err := fe.DeleteTicket(context.Background(), req)
 
+			if err == nil {
 				telemetry.RecordUnitMeasurement(ctx, mTicketsDeleted)
 				statProcessor.IncrementStat("Deleted", 1)
+			} else {
+				telemetry.RecordUnitMeasurement(ctx, mTicketDeletesFailed)
+				statProcessor.RecordError("failed to delete tickets", err)
 			}
 		}
 	}

--- a/examples/scale/backend/backend.go
+++ b/examples/scale/backend/backend.go
@@ -81,10 +81,10 @@ func run(cfg config.View) {
 	w := logger.Writer()
 	defer w.Close()
 
-	matchesForAssignment := make(chan *pb.Match, 1000)
-	ticketsForDeletion := make(chan string, 1000)
+	matchesForAssignment := make(chan *pb.Match, 30000)
+	ticketsForDeletion := make(chan string, 30000)
 
-	for i := 0; i < 30; i++ {
+	for i := 0; i < 50; i++ {
 		go runAssignments(be, matchesForAssignment, ticketsForDeletion)
 		go runDeletions(fe, ticketsForDeletion)
 	}


### PR DESCRIPTION
Start 30 go routines for each at the beginning of the test, and pass them from fetch matches with a buffer.

Gets the redis state store first match to handle >500 tickets per second: 
https://snapshot.raintank.io/dashboard/snapshot/yO88xrIUe1bFR29iNZt4YuM0xuBb8PX9