### PR TITLE
Remove inaccurate default documentation on range filter

### DIFF
--- a/api/backend.swagger.json
+++ b/api/backend.swagger.json
@@ -144,12 +144,12 @@
         "max": {
           "type": "number",
           "format": "double",
-          "description": "Maximum value. Defaults to positive infinity (any value above minv)."
+          "description": "Maximum value."
         },
         "min": {
           "type": "number",
           "format": "double",
-          "description": "Minimum value. Defaults to 0."
+          "description": "Minimum value."
         }
       },
       "title": "Filters numerical values to only those within a range.\n  double_arg: \"foo\"\n  max: 10\n  min: 5\nmatches:\n  {\"foo\": 5}\n  {\"foo\": 7.5}\n  {\"foo\": 10}\ndoes not match:\n  {\"foo\": 4}\n  {\"foo\": 10.01}\n  {\"foo\": \"7.5\"}\n  {}"

--- a/api/matchfunction.swagger.json
+++ b/api/matchfunction.swagger.json
@@ -91,12 +91,12 @@
         "max": {
           "type": "number",
           "format": "double",
-          "description": "Maximum value. Defaults to positive infinity (any value above minv)."
+          "description": "Maximum value."
         },
         "min": {
           "type": "number",
           "format": "double",
-          "description": "Minimum value. Defaults to 0."
+          "description": "Minimum value."
         }
       },
       "title": "Filters numerical values to only those within a range.\n  double_arg: \"foo\"\n  max: 10\n  min: 5\nmatches:\n  {\"foo\": 5}\n  {\"foo\": 7.5}\n  {\"foo\": 10}\ndoes not match:\n  {\"foo\": 4}\n  {\"foo\": 10.01}\n  {\"foo\": \"7.5\"}\n  {}"

--- a/api/messages.proto
+++ b/api/messages.proto
@@ -94,10 +94,10 @@ message DoubleRangeFilter {
   // Name of the ticket's search_fields.double_args this Filter operates on.
   string double_arg = 1;
 
-  // Maximum value. Defaults to positive infinity (any value above minv).
+  // Maximum value.
   double max = 2;
 
-  // Minimum value. Defaults to 0.
+  // Minimum value.
   double min = 3;
 }
 

--- a/api/query.swagger.json
+++ b/api/query.swagger.json
@@ -91,12 +91,12 @@
         "max": {
           "type": "number",
           "format": "double",
-          "description": "Maximum value. Defaults to positive infinity (any value above minv)."
+          "description": "Maximum value."
         },
         "min": {
           "type": "number",
           "format": "double",
-          "description": "Minimum value. Defaults to 0."
+          "description": "Minimum value."
         }
       },
       "title": "Filters numerical values to only those within a range.\n  double_arg: \"foo\"\n  max: 10\n  min: 5\nmatches:\n  {\"foo\": 5}\n  {\"foo\": 7.5}\n  {\"foo\": 10}\ndoes not match:\n  {\"foo\": 4}\n  {\"foo\": 10.01}\n  {\"foo\": \"7.5\"}\n  {}"

--- a/pkg/pb/messages.pb.go
+++ b/pkg/pb/messages.pb.go
@@ -236,9 +236,9 @@ func (m *Assignment) GetExtensions() map[string]*any.Any {
 type DoubleRangeFilter struct {
 	// Name of the ticket's search_fields.double_args this Filter operates on.
 	DoubleArg string `protobuf:"bytes,1,opt,name=double_arg,json=doubleArg,proto3" json:"double_arg,omitempty"`
-	// Maximum value. Defaults to positive infinity (any value above minv).
+	// Maximum value.
 	Max float64 `protobuf:"fixed64,2,opt,name=max,proto3" json:"max,omitempty"`
-	// Minimum value. Defaults to 0.
+	// Minimum value.
 	Min                  float64  `protobuf:"fixed64,3,opt,name=min,proto3" json:"min,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`


### PR DESCRIPTION
Instead, this is actually just relying on the proto's default values of 0 for each.  As such it shouldn't be documented.