### PR TITLE
Reuse query client in scale tests

### DIFF
--- a/examples/scale/scenarios/util.go
+++ b/examples/scale/scenarios/util.go
@@ -109,7 +109,7 @@ func queryPoolsWrapper(mmf func(req *pb.MatchProfile, pools map[string][]*pb.Tic
 
 	return func(req *pb.RunRequest, stream pb.MatchFunction_RunServer) error {
 		startQ.Do(func() {
-			q := getQueryServiceGRPCClient()
+			q = getQueryServiceGRPCClient()
 		})
 
 		poolTickets, err := matchfunction.QueryPools(stream.Context(), q, req.GetProfile().GetPools())

--- a/examples/scale/scenarios/util.go
+++ b/examples/scale/scenarios/util.go
@@ -104,9 +104,14 @@ func getQueryServiceGRPCClient() pb.QueryServiceClient {
 }
 
 func queryPoolsWrapper(mmf func(req *pb.MatchProfile, pools map[string][]*pb.Ticket) ([]*pb.Match, error)) matchFunction {
-	q := getQueryServiceGRPCClient()
+	var q pb.QueryServiceClient
+	var startQ sync.Once
 
 	return func(req *pb.RunRequest, stream pb.MatchFunction_RunServer) error {
+		startQ.Do(func() {
+			q := getQueryServiceGRPCClient()
+		})
+
 		poolTickets, err := matchfunction.QueryPools(stream.Context(), q, req.GetProfile().GetPools())
 		if err != nil {
 			return err

--- a/examples/scale/scenarios/util.go
+++ b/examples/scale/scenarios/util.go
@@ -103,13 +103,8 @@ func getQueryServiceGRPCClient() pb.QueryServiceClient {
 	return pb.NewQueryServiceClient(conn)
 }
 
-var q pb.QueryServiceClient
-var startQ sync.Once
-
 func queryPoolsWrapper(mmf func(req *pb.MatchProfile, pools map[string][]*pb.Ticket) ([]*pb.Match, error)) matchFunction {
-	startQ.Do(func() {
-		q = getQueryServiceGRPCClient()
-	})
+	q := getQueryServiceGRPCClient()
 
 	return func(req *pb.RunRequest, stream pb.MatchFunction_RunServer) error {
 		poolTickets, err := matchfunction.QueryPools(stream.Context(), q, req.GetProfile().GetPools())

--- a/internal/rpc/server.go
+++ b/internal/rpc/server.go
@@ -303,7 +303,13 @@ func instrumentHTTPHandler(handler http.Handler, params *ServerParams) http.Hand
 }
 
 func newGRPCServerOptions(params *ServerParams) []grpc.ServerOption {
-	opts := []grpc.ServerOption{}
+	opts := []grpc.ServerOption{
+		grpc.KeepaliveParams(keepalive.ServerParameters{
+			MaxConnectionIdle: time.Second * 20,
+			Time:              time.Second,
+			Timeout:           time.Second * 5,
+		}),
+	}
 	si := []grpc.StreamServerInterceptor{
 		grpc_recovery.StreamServerInterceptor(),
 		grpc_validator.StreamServerInterceptor(),

--- a/internal/rpc/server.go
+++ b/internal/rpc/server.go
@@ -303,13 +303,7 @@ func instrumentHTTPHandler(handler http.Handler, params *ServerParams) http.Hand
 }
 
 func newGRPCServerOptions(params *ServerParams) []grpc.ServerOption {
-	opts := []grpc.ServerOption{
-		grpc.KeepaliveParams(keepalive.ServerParameters{
-			MaxConnectionIdle: time.Second * 20,
-			Time:              time.Second,
-			Timeout:           time.Second * 5,
-		}),
-	}
+	opts := []grpc.ServerOption{}
 	si := []grpc.StreamServerInterceptor{
 		grpc_recovery.StreamServerInterceptor(),
 		grpc_validator.StreamServerInterceptor(),


### PR DESCRIPTION
It was previously not reusing it, so the clients would leak over time.