### PR TITLE
Update Grafana dashboard for more detailed metrics

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -48,8 +48,8 @@
 
 steps:
 - id: 'Docker Image: open-match-build'
-  name: gcr.io/kaniko-project/executor
-  args: ['--destination=gcr.io/$PROJECT_ID/open-match-build', '--cache=true', '--cache-ttl=48h', '--dockerfile=Dockerfile.ci']
+  name: gcr.io/cloud-builders/docker
+  args: ['build', '-t', 'gcr.io/$PROJECT_ID/open-match-build', '-f', 'Dockerfile.ci', '.']
   waitFor: ['-']
 
 - id: 'Build: Clean'

--- a/install/helm/open-match/subcharts/open-match-telemetry/dashboards/grpc.json
+++ b/install/helm/open-match/subcharts/open-match-telemetry/dashboards/grpc.json
@@ -15,8 +15,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 3,
-  "iteration": 1580245993833,
+  "id": 2,
+  "iteration": 1580944984710,
   "links": [],
   "panels": [
     {
@@ -415,7 +415,7 @@
       },
       "id": 57,
       "panels": [],
-      "title": "openmatch.Mmlogic/QueryTickets",
+      "title": "openmatch.QueryService/QueryTickets",
       "type": "row"
     },
     {
@@ -812,7 +812,7 @@
       },
       "id": 29,
       "panels": [],
-      "title": "openmatch.Backend/AssignTickets",
+      "title": "openmatch.BackendService/AssignTickets",
       "type": "row"
     },
     {
@@ -1210,7 +1210,7 @@
       "id": 31,
       "panels": [],
       "repeat": null,
-      "title": "openmatch.Frontend/CreateTicket",
+      "title": "openmatch.FrontendService/CreateTicket",
       "type": "row"
     },
     {
@@ -2399,7 +2399,7 @@
       },
       "id": 42,
       "panels": [],
-      "title": "openmatch.Frontend/FetchMatches",
+      "title": "openmatch.BackendService/FetchMatches",
       "type": "row"
     },
     {
@@ -3191,7 +3191,7 @@
       },
       "id": 23,
       "panels": [],
-      "title": "openmatch.Frontend/DeleteTicket",
+      "title": "openmatch.FrontendService/DeleteTicket",
       "type": "row"
     },
     {

--- a/install/helm/open-match/subcharts/open-match-telemetry/dashboards/redis.json
+++ b/install/helm/open-match/subcharts/open-match-telemetry/dashboards/redis.json
@@ -16,8 +16,8 @@
   "editable": true,
   "gnetId": 763,
   "graphTooltip": 0,
-  "id": 2,
-  "iteration": 1579655194536,
+  "id": 3,
+  "iteration": 1580944567924,
   "links": [],
   "panels": [
     {
@@ -312,6 +312,8 @@
         "min": false,
         "rightSide": true,
         "show": true,
+        "sort": null,
+        "sortDesc": null,
         "total": false,
         "values": true
       },
@@ -410,6 +412,8 @@
         "min": false,
         "rightSide": true,
         "show": true,
+        "sort": "current",
+        "sortDesc": true,
         "total": false,
         "values": true
       },
@@ -517,6 +521,8 @@
         "min": false,
         "rightSide": true,
         "show": true,
+        "sort": "current",
+        "sortDesc": true,
         "total": false,
         "values": true
       },
@@ -628,6 +634,8 @@
         "min": false,
         "rightSide": true,
         "show": true,
+        "sort": "current",
+        "sortDesc": true,
         "total": false,
         "values": true
       },
@@ -655,6 +663,13 @@
           "refId": "A",
           "step": 240,
           "target": ""
+        },
+        {
+          "expr": "sum by (kubernetes_pod_name) (rate(redis_commands_total{cmd!~\"info|slowlog|client|latency|replconf|config\"}[5m]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "total - {{kubernetes_pod_name}}",
+          "refId": "B"
         }
       ],
       "thresholds": [],
@@ -726,6 +741,8 @@
         "min": false,
         "rightSide": true,
         "show": true,
+        "sort": "current",
+        "sortDesc": true,
         "total": false,
         "values": true
       },
@@ -829,6 +846,8 @@
         "min": false,
         "rightSide": true,
         "show": true,
+        "sort": null,
+        "sortDesc": null,
         "total": false,
         "values": true
       },
@@ -911,8 +930,8 @@
       {
         "allValue": null,
         "current": {
-          "text": "10.28.0.27:9121",
-          "value": "10.28.0.27:9121"
+          "text": "10.28.0.12:9121",
+          "value": "10.28.0.12:9121"
         },
         "datasource": "Prometheus",
         "definition": "label_values(redis_up, instance)",

--- a/install/helm/open-match/subcharts/open-match-telemetry/dashboards/redis.json
+++ b/install/helm/open-match/subcharts/open-match-telemetry/dashboards/redis.json
@@ -17,7 +17,7 @@
   "gnetId": 763,
   "graphTooltip": 0,
   "id": 3,
-  "iteration": 1580944567924,
+  "iteration": 1580945453636,
   "links": [],
   "panels": [
     {
@@ -296,7 +296,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "fill": 1,
+      "fill": 0,
       "gridPos": {
         "h": 7,
         "w": 8,
@@ -312,8 +312,8 @@
         "min": false,
         "rightSide": true,
         "show": true,
-        "sort": null,
-        "sortDesc": null,
+        "sort": "current",
+        "sortDesc": true,
         "total": false,
         "values": true
       },
@@ -327,24 +327,54 @@
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
-      "seriesOverrides": [],
+      "seriesOverrides": [
+        {
+          "alias": "limit",
+          "color": "#C4162A",
+          "hideTooltip": true,
+          "legend": false,
+          "nullPointMode": "connected"
+        },
+        {
+          "alias": "request",
+          "color": "#73BF69",
+          "hideTooltip": true,
+          "legend": false,
+          "nullPointMode": "connected"
+        }
+      ],
       "spaceLength": 10,
       "stack": false,
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(container_cpu_usage_seconds_total{pod_name=~\"om-redis.*\", name!~\".*prometheus.*\", image!=\"\", container_name!=\"POD\"}[5m])) by (pod_name, container_name) /\nsum(container_spec_cpu_quota{name!~\".*prometheus.*\", image!=\"\", container_name!=\"POD\"}/container_spec_cpu_period{name!~\".*prometheus.*\", image!=\"\", container_name!=\"POD\"}) by (pod_name, container_name) * 100",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{pod_name=~\"om-redis.*\", name!~\".*prometheus.*\", image!=\"\", container_name!=\"POD\"}[5m])) by (pod_name)",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{pod_name}}",
+          "legendFormat": "{{pod_name}} usage",
           "refId": "A"
+        },
+        {
+          "expr": "sum(kube_pod_container_resource_limits_cpu_cores{pod=~\"om-redis.*\"}) by (pod)",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "limit",
+          "refId": "B"
+        },
+        {
+          "expr": "sum(kube_pod_container_resource_requests_cpu_cores{pod=~\"om-redis.*\"}) by (pod)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "request",
+          "refId": "C"
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "CPU Usage Percentage of Limit",
+      "title": "CPU Usage",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -362,7 +392,7 @@
       "yaxes": [
         {
           "format": "short",
-          "label": "%",
+          "label": "core",
           "logBase": 1,
           "max": null,
           "min": null,
@@ -412,8 +442,6 @@
         "min": false,
         "rightSide": true,
         "show": true,
-        "sort": "current",
-        "sortDesc": true,
         "total": false,
         "values": true
       },
@@ -521,8 +549,6 @@
         "min": false,
         "rightSide": true,
         "show": true,
-        "sort": "current",
-        "sortDesc": true,
         "total": false,
         "values": true
       },
@@ -634,8 +660,6 @@
         "min": false,
         "rightSide": true,
         "show": true,
-        "sort": "current",
-        "sortDesc": true,
         "total": false,
         "values": true
       },
@@ -663,13 +687,6 @@
           "refId": "A",
           "step": 240,
           "target": ""
-        },
-        {
-          "expr": "sum by (kubernetes_pod_name) (rate(redis_commands_total{cmd!~\"info|slowlog|client|latency|replconf|config\"}[5m]))",
-          "format": "time_series",
-          "intervalFactor": 1,
-          "legendFormat": "total - {{kubernetes_pod_name}}",
-          "refId": "B"
         }
       ],
       "thresholds": [],
@@ -741,8 +758,6 @@
         "min": false,
         "rightSide": true,
         "show": true,
-        "sort": "current",
-        "sortDesc": true,
         "total": false,
         "values": true
       },
@@ -846,8 +861,6 @@
         "min": false,
         "rightSide": true,
         "show": true,
-        "sort": null,
-        "sortDesc": null,
         "total": false,
         "values": true
       },

--- a/install/helm/open-match/subcharts/open-match-telemetry/dashboards/redis.json
+++ b/install/helm/open-match/subcharts/open-match-telemetry/dashboards/redis.json
@@ -16,8 +16,8 @@
   "editable": true,
   "gnetId": 763,
   "graphTooltip": 0,
-  "id": 3,
-  "iteration": 1580945453636,
+  "id": 6,
+  "iteration": 1580946687856,
   "links": [],
   "panels": [
     {
@@ -660,6 +660,8 @@
         "min": false,
         "rightSide": true,
         "show": true,
+        "sort": "current",
+        "sortDesc": true,
         "total": false,
         "values": true
       },
@@ -687,6 +689,13 @@
           "refId": "A",
           "step": 240,
           "target": ""
+        },
+        {
+          "expr": "sum by (kubernetes_pod_name) (rate(redis_commands_total[5m]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "total - {{kubernetes_pod_name}}",
+          "refId": "B"
         }
       ],
       "thresholds": [],


### PR DESCRIPTION
This commit:

1. Added an aggregated metric for the Redis dashboard to see the total number of processed commands per instance. Also reworked the CPU usage chart for Redis - This could help us to identify whether Redis is hitting its bottleneck under load - e.g. https://snapshot.raintank.io/dashboard/snapshot/IDKoZqYacXMYcECikPgK9GYJPTn10kEu is showing Redis master is using 1 core - fully loaded and the number of commands processed per second is not increasing anymore starting from 14:05 though I scaled the CreateTicketQPS from 3000 to 4000 afterward.
2. Renamed the gRPC panel rows to most up-to-date API surface names.