### PR TITLE
Reduced Redis PING check frequency on Redis pool

### DIFF
--- a/internal/statestore/redis.go
+++ b/internal/statestore/redis.go
@@ -83,8 +83,8 @@ func newRedis(cfg config.View) Service {
 		IdleTimeout: cfg.GetDuration("redis.pool.idleTimeout"),
 		Wait:        true,
 		TestOnBorrow: func(c redis.Conn, t time.Time) error {
-			// Check if this connection have been returned for more than 10 seconds, if so, do a PING check.
-			if time.Since(t) > 10*time.Second {
+			// Check if this connection have been returned for more than 15 seconds, if so, do a PING check.
+			if time.Since(t) < 15*time.Second {
 				return nil
 			}
 

--- a/internal/statestore/redis.go
+++ b/internal/statestore/redis.go
@@ -82,10 +82,8 @@ func newRedis(cfg config.View) Service {
 		MaxActive:   cfg.GetInt("redis.pool.maxActive"),
 		IdleTimeout: cfg.GetDuration("redis.pool.idleTimeout"),
 		Wait:        true,
-		TestOnBorrow: func(c redis.Conn, t time.Time) error {
-			// Checking the health of an idle connection before the connection is used again by
-			// the application if it has been returned to the pool for more than 15 seconds.
-			if time.Since(t) < 15*time.Second {
+		TestOnBorrow: func(c redis.Conn, lastUsed time.Time) error {
+			if time.Since(lastUsed) < 15*time.Second {
 				return nil
 			}
 

--- a/internal/statestore/redis.go
+++ b/internal/statestore/redis.go
@@ -84,7 +84,7 @@ func newRedis(cfg config.View) Service {
 		Wait:        true,
 		TestOnBorrow: func(c redis.Conn, t time.Time) error {
 			// Check if this connection have been returned for more than 10 seconds, if so, do a PING check.
-			if time.Now().Sub(t) > 10*time.Second {
+			if time.Since(t) > 10*time.Second {
 				return nil
 			}
 

--- a/internal/statestore/redis.go
+++ b/internal/statestore/redis.go
@@ -83,7 +83,8 @@ func newRedis(cfg config.View) Service {
 		IdleTimeout: cfg.GetDuration("redis.pool.idleTimeout"),
 		Wait:        true,
 		TestOnBorrow: func(c redis.Conn, t time.Time) error {
-			// Check if this connection have been returned for more than 15 seconds, if so, do a PING check.
+			// Checking the health of an idle connection before the connection is used again by
+			// the application if it has been returned to the pool for more than 15 seconds.
 			if time.Since(t) < 15*time.Second {
 				return nil
 			}

--- a/internal/statestore/redis.go
+++ b/internal/statestore/redis.go
@@ -82,7 +82,12 @@ func newRedis(cfg config.View) Service {
 		MaxActive:   cfg.GetInt("redis.pool.maxActive"),
 		IdleTimeout: cfg.GetDuration("redis.pool.idleTimeout"),
 		Wait:        true,
-		TestOnBorrow: func(c redis.Conn, _ time.Time) error {
+		TestOnBorrow: func(c redis.Conn, t time.Time) error {
+			// Check if this connection have been returned for more than 10 seconds, if so, do a PING check.
+			if time.Now().Sub(t) > 10*time.Second {
+				return nil
+			}
+
 			_, err := c.Do("PING")
 			return err
 		},


### PR DESCRIPTION
As https://snapshot.raintank.io/dashboard/snapshot/IDKoZqYacXMYcECikPgK9GYJPTn10kEu pointed out, 20% of the Redis commands are spent on doing Ping checks when being returned to the pool. This commit checks if this connection have been returned for more than 10 seconds, and only do a PING check if so.

Performance improvement after this change comparing to our current benchmark result at 3k CreateTicketQPS.
https://snapshot.raintank.io/dashboard/snapshot/Wr3lY7TlRN6NIQbF1eOdd1EBNiijKA5f