### PR TITLE
Add filter package, and rework query testing

### DIFF
--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -1,0 +1,64 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package filter defines which tickets pass which filters.  Other implementations which help
+// filter tickets (eg, a range index lookup) must conform to the same set of tickets being within
+// the filter as here.
+package filter
+
+import (
+	"open-match.dev/open-match/pkg/pb"
+)
+
+var emptySearchFields = &pb.SearchFields{}
+
+// InPool returns whether the ticket meets all the criteria of the pool.
+func InPool(ticket *pb.Ticket, pool *pb.Pool) bool {
+	s := ticket.GetSearchFields()
+	if s == nil {
+		s = emptySearchFields
+	}
+	for _, f := range pool.GetDoubleRangeFilters() {
+		v, ok := s.DoubleArgs[f.DoubleArg]
+		if !ok {
+			return false
+		}
+		// Not simplified so that NaN cases are handled correctly.
+		if !(v >= f.Min && v <= f.Max) {
+			return false
+		}
+	}
+
+	for _, f := range pool.GetStringEqualsFilters() {
+		v, ok := s.StringArgs[f.StringArg]
+		if !ok {
+			return false
+		}
+		if f.Value != v {
+			return false
+		}
+	}
+
+outer:
+	for _, f := range pool.GetTagPresentFilters() {
+		for _, v := range s.Tags {
+			if v == f.Tag {
+				continue outer
+			}
+		}
+		return false
+	}
+
+	return true
+}

--- a/internal/filter/filter_test.go
+++ b/internal/filter/filter_test.go
@@ -1,0 +1,39 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package filter
+
+import (
+	"testing"
+
+	"open-match.dev/open-match/internal/filter/testcases"
+)
+
+func TestInPool(t *testing.T) {
+	for _, tt := range testcases.IncludedTestCases() {
+		t.Run(tt.Name, func(t *testing.T) {
+			if !InPool(tt.Ticket, tt.Pool) {
+				t.Error("ticket should be included in the pool")
+			}
+		})
+	}
+
+	for _, tt := range testcases.ExcludedTestCases() {
+		t.Run(tt.Name, func(t *testing.T) {
+			if InPool(tt.Ticket, tt.Pool) {
+				t.Error("ticket should be excluded from the pool")
+			}
+		})
+	}
+}

--- a/internal/filter/filter_test.go
+++ b/internal/filter/filter_test.go
@@ -21,17 +21,19 @@ import (
 )
 
 func TestInPool(t *testing.T) {
-	for _, tt := range testcases.IncludedTestCases() {
-		t.Run(tt.Name, func(t *testing.T) {
-			if !InPool(tt.Ticket, tt.Pool) {
+	for _, tc := range testcases.IncludedTestCases() {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			if !InPool(tc.Ticket, tc.Pool) {
 				t.Error("ticket should be included in the pool")
 			}
 		})
 	}
 
-	for _, tt := range testcases.ExcludedTestCases() {
-		t.Run(tt.Name, func(t *testing.T) {
-			if InPool(tt.Ticket, tt.Pool) {
+	for _, tc := range testcases.ExcludedTestCases() {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			if InPool(tc.Ticket, tc.Pool) {
 				t.Error("ticket should be excluded from the pool")
 			}
 		})

--- a/internal/filter/testcases/testcases.go
+++ b/internal/filter/testcases/testcases.go
@@ -55,7 +55,7 @@ func IncludedTestCases() []TestCase {
 			},
 			&pb.Pool{
 				StringEqualsFilters: []*pb.StringEqualsFilter{
-					&pb.StringEqualsFilter{
+					{
 						StringArg: "field",
 						Value:     "value",
 					},
@@ -74,7 +74,7 @@ func IncludedTestCases() []TestCase {
 			},
 			&pb.Pool{
 				TagPresentFilters: []*pb.TagPresentFilter{
-					&pb.TagPresentFilter{
+					{
 						Tag: "mytag",
 					},
 				},
@@ -92,13 +92,13 @@ func IncludedTestCases() []TestCase {
 			},
 			&pb.Pool{
 				TagPresentFilters: []*pb.TagPresentFilter{
-					&pb.TagPresentFilter{
+					{
 						Tag: "A",
 					},
-					&pb.TagPresentFilter{
+					{
 						Tag: "C",
 					},
-					&pb.TagPresentFilter{
+					{
 						Tag: "B",
 					},
 				},
@@ -118,7 +118,7 @@ func ExcludedTestCases() []TestCase {
 			&pb.Ticket{},
 			&pb.Pool{
 				DoubleRangeFilters: []*pb.DoubleRangeFilter{
-					&pb.DoubleRangeFilter{
+					{
 						DoubleArg: "field",
 						Min:       math.Inf(-1),
 						Max:       math.Inf(1),
@@ -131,7 +131,7 @@ func ExcludedTestCases() []TestCase {
 			&pb.Ticket{},
 			&pb.Pool{
 				StringEqualsFilters: []*pb.StringEqualsFilter{
-					&pb.StringEqualsFilter{
+					{
 						StringArg: "field",
 						Value:     "value",
 					},
@@ -143,7 +143,7 @@ func ExcludedTestCases() []TestCase {
 			&pb.Ticket{},
 			&pb.Pool{
 				TagPresentFilters: []*pb.TagPresentFilter{
-					&pb.TagPresentFilter{
+					{
 						Tag: "value",
 					},
 				},
@@ -161,7 +161,7 @@ func ExcludedTestCases() []TestCase {
 			},
 			&pb.Pool{
 				DoubleRangeFilters: []*pb.DoubleRangeFilter{
-					&pb.DoubleRangeFilter{
+					{
 						DoubleArg: "field",
 						Min:       math.Inf(-1),
 						Max:       math.Inf(1),
@@ -190,7 +190,7 @@ func ExcludedTestCases() []TestCase {
 			},
 			&pb.Pool{
 				StringEqualsFilters: []*pb.StringEqualsFilter{
-					&pb.StringEqualsFilter{
+					{
 						StringArg: "field",
 						Value:     "VALUE",
 					},
@@ -209,7 +209,7 @@ func ExcludedTestCases() []TestCase {
 			},
 			&pb.Pool{
 				StringEqualsFilters: []*pb.StringEqualsFilter{
-					&pb.StringEqualsFilter{
+					{
 						StringArg: "field",
 						Value:     "value",
 					},
@@ -228,7 +228,7 @@ func ExcludedTestCases() []TestCase {
 			},
 			&pb.Pool{
 				TagPresentFilters: []*pb.TagPresentFilter{
-					&pb.TagPresentFilter{
+					{
 						Tag: "mytag",
 					},
 				},
@@ -246,13 +246,13 @@ func ExcludedTestCases() []TestCase {
 			},
 			&pb.Pool{
 				TagPresentFilters: []*pb.TagPresentFilter{
-					&pb.TagPresentFilter{
+					{
 						Tag: "A",
 					},
-					&pb.TagPresentFilter{
+					{
 						Tag: "D",
 					},
-					&pb.TagPresentFilter{
+					{
 						Tag: "C",
 					},
 				},
@@ -277,7 +277,7 @@ func simpleDoubleRange(name string, value, min, max float64) TestCase {
 		},
 		&pb.Pool{
 			DoubleRangeFilters: []*pb.DoubleRangeFilter{
-				&pb.DoubleRangeFilter{
+				{
 					DoubleArg: "field",
 					Min:       min,
 					Max:       max,
@@ -318,20 +318,20 @@ func multipleFilters(doubleRange, stringEquals, tagPresent bool) TestCase {
 		},
 		&pb.Pool{
 			DoubleRangeFilters: []*pb.DoubleRangeFilter{
-				&pb.DoubleRangeFilter{
+				{
 					DoubleArg: "a",
 					Min:       -1,
 					Max:       1,
 				},
 			},
 			StringEqualsFilters: []*pb.StringEqualsFilter{
-				&pb.StringEqualsFilter{
+				{
 					StringArg: "b",
 					Value:     "hi",
 				},
 			},
 			TagPresentFilters: []*pb.TagPresentFilter{
-				&pb.TagPresentFilter{
+				{
 					Tag: "yo",
 				},
 			},

--- a/internal/filter/testcases/testcases.go
+++ b/internal/filter/testcases/testcases.go
@@ -1,0 +1,340 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package testcases contains lists of ticket filtering test cases.
+package testcases
+
+import (
+	"fmt"
+	"math"
+
+	"open-match.dev/open-match/pkg/pb"
+)
+
+// TestCase defines a single filtering test case to run.
+type TestCase struct {
+	Name   string
+	Ticket *pb.Ticket
+	Pool   *pb.Pool
+}
+
+// IncludedTestCases returns a list of test cases where using the given filter,
+// the ticket is included in the result.
+func IncludedTestCases() []TestCase {
+	return []TestCase{
+		{
+			"no filters or fields",
+			&pb.Ticket{},
+			&pb.Pool{},
+		},
+
+		simpleDoubleRange("simpleInRange", 5, 0, 10),
+		simpleDoubleRange("exactMatch", 5, 5, 5),
+		simpleDoubleRange("infinityMax", math.Inf(1), 0, math.Inf(1)),
+		simpleDoubleRange("infinityMin", math.Inf(-1), math.Inf(-1), 0),
+
+		{
+			"String equals simple positive",
+			&pb.Ticket{
+				SearchFields: &pb.SearchFields{
+					StringArgs: map[string]string{
+						"field": "value",
+					},
+				},
+			},
+			&pb.Pool{
+				StringEqualsFilters: []*pb.StringEqualsFilter{
+					&pb.StringEqualsFilter{
+						StringArg: "field",
+						Value:     "value",
+					},
+				},
+			},
+		},
+
+		{
+			"TagPresent simple positive",
+			&pb.Ticket{
+				SearchFields: &pb.SearchFields{
+					Tags: []string{
+						"mytag",
+					},
+				},
+			},
+			&pb.Pool{
+				TagPresentFilters: []*pb.TagPresentFilter{
+					&pb.TagPresentFilter{
+						Tag: "mytag",
+					},
+				},
+			},
+		},
+
+		{
+			"TagPresent multiple all present",
+			&pb.Ticket{
+				SearchFields: &pb.SearchFields{
+					Tags: []string{
+						"A", "B", "C",
+					},
+				},
+			},
+			&pb.Pool{
+				TagPresentFilters: []*pb.TagPresentFilter{
+					&pb.TagPresentFilter{
+						Tag: "A",
+					},
+					&pb.TagPresentFilter{
+						Tag: "C",
+					},
+					&pb.TagPresentFilter{
+						Tag: "B",
+					},
+				},
+			},
+		},
+
+		multipleFilters(true, true, true),
+	}
+}
+
+// ExcludedTestCases returns a list of test cases where using the given filter,
+// the ticket is NOT included in the result.
+func ExcludedTestCases() []TestCase {
+	return []TestCase{
+		{
+			"DoubleRange no SearchFields",
+			&pb.Ticket{},
+			&pb.Pool{
+				DoubleRangeFilters: []*pb.DoubleRangeFilter{
+					&pb.DoubleRangeFilter{
+						DoubleArg: "field",
+						Min:       math.Inf(-1),
+						Max:       math.Inf(1),
+					},
+				},
+			},
+		},
+		{
+			"StringEquals no SearchFields",
+			&pb.Ticket{},
+			&pb.Pool{
+				StringEqualsFilters: []*pb.StringEqualsFilter{
+					&pb.StringEqualsFilter{
+						StringArg: "field",
+						Value:     "value",
+					},
+				},
+			},
+		},
+		{
+			"TagPresent no SearchFields",
+			&pb.Ticket{},
+			&pb.Pool{
+				TagPresentFilters: []*pb.TagPresentFilter{
+					&pb.TagPresentFilter{
+						Tag: "value",
+					},
+				},
+			},
+		},
+
+		{
+			"double range missing field",
+			&pb.Ticket{
+				SearchFields: &pb.SearchFields{
+					DoubleArgs: map[string]float64{
+						"otherfield": 0,
+					},
+				},
+			},
+			&pb.Pool{
+				DoubleRangeFilters: []*pb.DoubleRangeFilter{
+					&pb.DoubleRangeFilter{
+						DoubleArg: "field",
+						Min:       math.Inf(-1),
+						Max:       math.Inf(1),
+					},
+				},
+			},
+		},
+
+		simpleDoubleRange("valueTooLow", -1, 0, 10),
+		simpleDoubleRange("valueTooHigh", 11, 0, 10),
+		simpleDoubleRange("minIsNan", 5, math.NaN(), 10),
+		simpleDoubleRange("maxIsNan", 5, 0, math.NaN()),
+		simpleDoubleRange("minMaxAreNan", 5, math.NaN(), math.NaN()),
+		simpleDoubleRange("valueIsNan", math.NaN(), 0, 10),
+		simpleDoubleRange("valueIsNanInfRange", math.NaN(), math.Inf(-1), math.Inf(1)),
+		simpleDoubleRange("allAreNan", math.NaN(), math.NaN(), math.NaN()),
+
+		{
+			"String equals simple negative", // and case sensitivity
+			&pb.Ticket{
+				SearchFields: &pb.SearchFields{
+					StringArgs: map[string]string{
+						"field": "value",
+					},
+				},
+			},
+			&pb.Pool{
+				StringEqualsFilters: []*pb.StringEqualsFilter{
+					&pb.StringEqualsFilter{
+						StringArg: "field",
+						Value:     "VALUE",
+					},
+				},
+			},
+		},
+
+		{
+			"String equals missing field",
+			&pb.Ticket{
+				SearchFields: &pb.SearchFields{
+					StringArgs: map[string]string{
+						"otherfield": "othervalue",
+					},
+				},
+			},
+			&pb.Pool{
+				StringEqualsFilters: []*pb.StringEqualsFilter{
+					&pb.StringEqualsFilter{
+						StringArg: "field",
+						Value:     "value",
+					},
+				},
+			},
+		},
+
+		{
+			"TagPresent simple negative", // and case sensitivity
+			&pb.Ticket{
+				SearchFields: &pb.SearchFields{
+					Tags: []string{
+						"MYTAG",
+					},
+				},
+			},
+			&pb.Pool{
+				TagPresentFilters: []*pb.TagPresentFilter{
+					&pb.TagPresentFilter{
+						Tag: "mytag",
+					},
+				},
+			},
+		},
+
+		{
+			"TagPresent multiple with one missing",
+			&pb.Ticket{
+				SearchFields: &pb.SearchFields{
+					Tags: []string{
+						"A", "B", "C",
+					},
+				},
+			},
+			&pb.Pool{
+				TagPresentFilters: []*pb.TagPresentFilter{
+					&pb.TagPresentFilter{
+						Tag: "A",
+					},
+					&pb.TagPresentFilter{
+						Tag: "D",
+					},
+					&pb.TagPresentFilter{
+						Tag: "C",
+					},
+				},
+			},
+		},
+
+		multipleFilters(false, true, true),
+		multipleFilters(true, false, true),
+		multipleFilters(true, true, false),
+	}
+}
+
+func simpleDoubleRange(name string, value, min, max float64) TestCase {
+	return TestCase{
+		"double range " + name,
+		&pb.Ticket{
+			SearchFields: &pb.SearchFields{
+				DoubleArgs: map[string]float64{
+					"field": value,
+				},
+			},
+		},
+		&pb.Pool{
+			DoubleRangeFilters: []*pb.DoubleRangeFilter{
+				&pb.DoubleRangeFilter{
+					DoubleArg: "field",
+					Min:       min,
+					Max:       max,
+				},
+			},
+		},
+	}
+}
+
+func multipleFilters(doubleRange, stringEquals, tagPresent bool) TestCase {
+	a := float64(0)
+	if !doubleRange {
+		a = 10
+	}
+
+	b := "hi"
+	if !stringEquals {
+		b = "bye"
+	}
+
+	c := "yo"
+	if !tagPresent {
+		c = "cya"
+	}
+
+	return TestCase{
+		fmt.Sprintf("multiplefilters: %v, %v, %v", doubleRange, stringEquals, tagPresent),
+		&pb.Ticket{
+			SearchFields: &pb.SearchFields{
+				DoubleArgs: map[string]float64{
+					"a": a,
+				},
+				StringArgs: map[string]string{
+					"b": b,
+				},
+				Tags: []string{c},
+			},
+		},
+		&pb.Pool{
+			DoubleRangeFilters: []*pb.DoubleRangeFilter{
+				&pb.DoubleRangeFilter{
+					DoubleArg: "a",
+					Min:       -1,
+					Max:       1,
+				},
+			},
+			StringEqualsFilters: []*pb.StringEqualsFilter{
+				&pb.StringEqualsFilter{
+					StringArg: "b",
+					Value:     "hi",
+				},
+			},
+			TagPresentFilters: []*pb.TagPresentFilter{
+				&pb.TagPresentFilter{
+					Tag: "yo",
+				},
+			},
+		},
+	}
+}

--- a/internal/statestore/redis_indices.go
+++ b/internal/statestore/redis_indices.go
@@ -64,7 +64,7 @@ func extractIndexFilters(p *pb.Pool) []*indexFilter {
 			// Some bug in the redis stack doesn't properly reject all tickets for a
 			// NaN max, so just special case it.
 			return []*indexFilter{
-				&indexFilter{
+				{
 					name: "notafilter",
 					min:  math.NaN(),
 					max:  math.NaN(),

--- a/internal/statestore/redis_indices.go
+++ b/internal/statestore/redis_indices.go
@@ -60,6 +60,18 @@ func extractIndexFilters(p *pb.Pool) []*indexFilter {
 	filters := make([]*indexFilter, 0)
 
 	for _, f := range p.DoubleRangeFilters {
+		if math.IsNaN(f.Min) || math.IsNaN(f.Max) {
+			// Some bug in the redis stack doesn't properly reject all tickets for a
+			// NaN max, so just special case it.
+			return []*indexFilter{
+				&indexFilter{
+					name: "notafilter",
+					min:  math.NaN(),
+					max:  math.NaN(),
+				},
+			}
+		}
+
 		filters = append(filters, &indexFilter{
 			name: rangeIndexName(f.DoubleArg),
 			min:  f.Min,

--- a/internal/statestore/redis_indices.go
+++ b/internal/statestore/redis_indices.go
@@ -61,8 +61,10 @@ func extractIndexFilters(p *pb.Pool) []*indexFilter {
 
 	for _, f := range p.DoubleRangeFilters {
 		if math.IsNaN(f.Min) || math.IsNaN(f.Max) {
-			// Some bug in the redis stack doesn't properly reject all tickets for a
-			// NaN max, so just special case it.
+			// NaN, when compared with any value, should always be false.  As the
+			// definition of the range is min <= x && x <= max, this should be
+			// excluded whenever the min or max is NaN.  Redis doesn't actually follow
+			// this, so add a special case here to reject all tickets.
 			return []*indexFilter{
 				{
 					name: "notafilter",

--- a/test/e2e/query_tickets_test.go
+++ b/test/e2e/query_tickets_test.go
@@ -17,282 +17,145 @@
 package e2e
 
 import (
+	"context"
 	"io"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	internalTesting "open-match.dev/open-match/internal/testing"
+	"open-match.dev/open-match/internal/filter/testcases"
 	"open-match.dev/open-match/internal/testing/e2e"
-	e2eTesting "open-match.dev/open-match/internal/testing/e2e"
 	"open-match.dev/open-match/pkg/pb"
 )
 
-func TestQueryTickets(t *testing.T) {
-	tests := []struct {
-		description   string
-		pool          *pb.Pool
-		gotTickets    []*pb.Ticket
-		wantCode      codes.Code
-		wantTickets   []*pb.Ticket
-		wantPageCount int
-	}{
-		{
-			description:   "expects invalid argument code since pool is empty",
-			pool:          nil,
-			wantCode:      codes.InvalidArgument,
-			wantTickets:   nil,
-			wantPageCount: 0,
-		},
-		{
-			description: "expects response with no tickets since the store is empty",
-			gotTickets:  []*pb.Ticket{},
-			pool: &pb.Pool{
-				DoubleRangeFilters: []*pb.DoubleRangeFilter{{
-					DoubleArg: "ok",
-				}},
-			},
-			wantCode:      codes.OK,
-			wantTickets:   nil,
-			wantPageCount: 0,
-		},
-		{
-			description: "expects response with no tickets since all tickets in the store are filtered out",
-			gotTickets: internalTesting.GenerateFloatRangeTickets(
-				internalTesting.Property{Name: e2e.DoubleArgMMR, Min: 0, Max: 10, Interval: 2},
-				internalTesting.Property{Name: e2e.DoubleArgLevel, Min: 0, Max: 10, Interval: 2},
-			),
-			pool: &pb.Pool{
-				DoubleRangeFilters: []*pb.DoubleRangeFilter{{
-					DoubleArg: e2e.DoubleArgDefense,
-				}},
-			},
-			wantCode:      codes.OK,
-			wantTickets:   nil,
-			wantPageCount: 0,
-		},
-		{
-			description: "expects response with 5 tickets with e2e.FloatRangeDoubleArg1=2 and e2e.FloatRangeDoubleArg2 in range of [0,10)",
-			gotTickets: internalTesting.GenerateFloatRangeTickets(
-				internalTesting.Property{Name: e2e.DoubleArgMMR, Min: 0, Max: 10, Interval: 2},
-				internalTesting.Property{Name: e2e.DoubleArgLevel, Min: 0, Max: 10, Interval: 2},
-			),
-			pool: &pb.Pool{
-				DoubleRangeFilters: []*pb.DoubleRangeFilter{{
-					DoubleArg: e2e.DoubleArgMMR,
-					Min:       1,
-					Max:       3,
-				}},
-			},
-			wantCode: codes.OK,
-			wantTickets: internalTesting.GenerateFloatRangeTickets(
-				internalTesting.Property{Name: e2e.DoubleArgMMR, Min: 2, Max: 3, Interval: 2},
-				internalTesting.Property{Name: e2e.DoubleArgLevel, Min: 0, Max: 10, Interval: 2},
-			),
-			wantPageCount: 1,
-		},
-		{
-			// Test inclusive filters and paging works as expected
-			description: "expects response with 15 tickets with e2e.FloatRangeDoubleArg1=2,4,6 and e2e.FloatRangeDoubleArg2=[0,10)",
-			gotTickets: internalTesting.GenerateFloatRangeTickets(
-				internalTesting.Property{Name: e2e.DoubleArgMMR, Min: 0, Max: 10, Interval: 2},
-				internalTesting.Property{Name: e2e.DoubleArgLevel, Min: 0, Max: 10, Interval: 2},
-			),
-			pool: &pb.Pool{
-				DoubleRangeFilters: []*pb.DoubleRangeFilter{{
-					DoubleArg: e2e.DoubleArgMMR,
-					Min:       2,
-					Max:       6,
-				}},
-			},
-			wantCode: codes.OK,
-			wantTickets: internalTesting.GenerateFloatRangeTickets(
-				internalTesting.Property{Name: e2e.DoubleArgMMR, Min: 2, Max: 7, Interval: 2},
-				internalTesting.Property{Name: e2e.DoubleArgLevel, Min: 0, Max: 10, Interval: 2},
-			),
-			wantPageCount: 2,
-		},
-		{
-			description: "expects 1 ticket with tag e2eTesting.ModeDemo",
-			gotTickets: []*pb.Ticket{
-				{
-					SearchFields: &pb.SearchFields{
-						Tags: []string{
-							e2eTesting.ModeDemo,
-						},
-					},
-				},
-				{
-					SearchFields: &pb.SearchFields{
-						Tags: []string{
-							"Foo",
-						},
-					},
-				},
-			},
-			pool: &pb.Pool{
-				TagPresentFilters: []*pb.TagPresentFilter{{
-					Tag: e2e.ModeDemo,
-				}},
-			},
-			wantCode: codes.OK,
-			wantTickets: []*pb.Ticket{
-				{
-					SearchFields: &pb.SearchFields{
-						Tags: []string{
-							e2eTesting.ModeDemo,
-						},
-					},
-				},
-			},
-			wantPageCount: 1,
-		},
-		{
-			// Test StringEquals works as expected
-			description: "expects 1 ticket with property e2eTesting.Role maps to warrior",
-			gotTickets: []*pb.Ticket{
-				{
-					SearchFields: &pb.SearchFields{
-						StringArgs: map[string]string{
-							e2eTesting.Role: "warrior",
-						},
-					},
-				},
-				{
-					SearchFields: &pb.SearchFields{
-						StringArgs: map[string]string{
-							e2eTesting.Role: "rogue",
-						},
-					},
-				},
-			},
-			pool: &pb.Pool{
-				StringEqualsFilters: []*pb.StringEqualsFilter{
-					{
-						StringArg: e2e.Role,
-						Value:     "warrior",
-					},
-				},
-			},
-			wantCode: codes.OK,
-			wantTickets: []*pb.Ticket{
-				{
+func TestNoPool(t *testing.T) {
+	om, closer := e2e.New(t)
+	defer closer()
 
-					SearchFields: &pb.SearchFields{
-						StringArgs: map[string]string{
-							e2eTesting.Role: "warrior",
-						},
-					},
-				},
-			},
-			wantPageCount: 1,
-		},
-		{
-			// Test all tickets
-			description: "expects all 3 tickets when passing in a pool with no filters",
-			gotTickets: []*pb.Ticket{
-				{
-					SearchFields: &pb.SearchFields{
-						StringArgs: map[string]string{
-							e2eTesting.Role: "warrior",
-						},
-					},
-				},
-				{
-					SearchFields: &pb.SearchFields{
-						Tags: []string{
-							e2eTesting.ModeDemo,
-						},
-					},
-				},
-				{
-					SearchFields: &pb.SearchFields{
-						DoubleArgs: map[string]float64{
-							e2eTesting.DoubleArgMMR: 100,
-						},
-					},
-				},
-			},
-			pool:     &pb.Pool{},
-			wantCode: codes.OK,
-			wantTickets: []*pb.Ticket{
-				{
-					SearchFields: &pb.SearchFields{
-						StringArgs: map[string]string{
-							e2eTesting.Role: "warrior",
-						},
-					},
-				},
-				{
-					SearchFields: &pb.SearchFields{
-						Tags: []string{
-							e2eTesting.ModeDemo,
-						},
-					},
-				},
-				{
-					SearchFields: &pb.SearchFields{
-						DoubleArgs: map[string]float64{
-							e2eTesting.DoubleArgMMR: 100,
-						},
-					},
-				},
-			},
-			wantPageCount: 1,
-		},
+	q := om.MustQueryServiceGRPC()
+
+	stream, err := q.QueryTickets(context.Background(), &pb.QueryTicketsRequest{Pool: nil})
+	assert.Nil(t, err)
+
+	resp, err := stream.Recv()
+	assert.Equal(t, codes.InvalidArgument, status.Convert(err).Code())
+	assert.Nil(t, resp)
+}
+
+func TestNoTickets(t *testing.T) {
+	om, closer := e2e.New(t)
+	defer closer()
+
+	q := om.MustQueryServiceGRPC()
+	stream, err := q.QueryTickets(context.Background(), &pb.QueryTicketsRequest{Pool: &pb.Pool{}})
+	assert.Nil(t, err)
+
+	resp, err := stream.Recv()
+	assert.Equal(t, io.EOF, err)
+	assert.Nil(t, resp)
+}
+
+func TestPaging(t *testing.T) {
+	om, closer := e2e.New(t)
+	defer closer()
+
+	pageSize := 10 // TODO: read from config
+	if pageSize < 1 {
+		assert.Fail(t, "invalid page size")
 	}
 
-	t.Run("TestQueryTickets", func(t *testing.T) {
-		for _, test := range tests {
-			test := test
-			t.Run(test.description, func(t *testing.T) {
-				t.Parallel()
+	totalTickets := pageSize*5 + 1
+	expectedIds := map[string]struct{}{}
 
-				om, closer := e2e.New(t)
-				defer closer()
-				fe := om.MustFrontendGRPC()
-				mml := om.MustQueryServiceGRPC()
-				pageCounts := 0
-				ctx := om.Context()
+	fe := om.MustFrontendGRPC()
+	for i := 0; i < totalTickets; i++ {
+		resp, err := fe.CreateTicket(context.Background(), &pb.CreateTicketRequest{Ticket: &pb.Ticket{}})
+		assert.NotNil(t, resp)
+		assert.NotNil(t, resp.Ticket)
+		assert.Nil(t, err)
 
-				for _, ticket := range test.gotTickets {
-					resp, err := fe.CreateTicket(ctx, &pb.CreateTicketRequest{Ticket: ticket})
-					assert.NotNil(t, resp)
-					assert.Nil(t, err)
-				}
+		expectedIds[resp.Ticket.Id] = struct{}{}
+	}
 
-				stream, err := mml.QueryTickets(ctx, &pb.QueryTicketsRequest{Pool: test.pool})
-				assert.Nil(t, err)
+	q := om.MustQueryServiceGRPC()
+	stream, err := q.QueryTickets(context.Background(), &pb.QueryTicketsRequest{Pool: &pb.Pool{}})
+	assert.Nil(t, err)
 
-				var actualTickets []*pb.Ticket
+	foundIds := map[string]struct{}{}
 
-				for {
-					resp, err := stream.Recv()
-					if err == io.EOF {
-						break
-					}
-					if err != nil {
-						assert.Equal(t, test.wantCode, status.Convert(err).Code())
-						break
-					}
+	for i := 0; i < 5; i++ {
+		resp, err := stream.Recv()
+		assert.Nil(t, err)
+		assert.Equal(t, len(resp.Tickets), pageSize)
 
-					actualTickets = append(actualTickets, resp.Tickets...)
-					pageCounts++
-				}
-
-				require.Equal(t, len(test.wantTickets), len(actualTickets))
-				// Test fields by fields because of the randomness of the ticket ids...
-				// TODO: this makes testing overcomplicated. Should figure out a way to avoid the randomness
-				// This for loop also relies on the fact that redis range query and the ticket generator both returns tickets in sorted order.
-				// If this fact changes, we might need an ugly nested for loop to do the validness checks.
-				for i := 0; i < len(actualTickets); i++ {
-					assert.Equal(t, test.wantTickets[i].GetAssignment(), actualTickets[i].GetAssignment())
-					assert.Equal(t, test.wantTickets[i].GetSearchFields(), actualTickets[i].GetSearchFields())
-				}
-				assert.Equal(t, test.wantPageCount, pageCounts)
-			})
+		for _, ticket := range resp.Tickets {
+			foundIds[ticket.Id] = struct{}{}
 		}
-	})
+	}
+
+	resp, err := stream.Recv()
+	assert.Nil(t, err)
+	assert.Equal(t, len(resp.Tickets), 1)
+	foundIds[resp.Tickets[0].Id] = struct{}{}
+
+	assert.Equal(t, expectedIds, foundIds)
+
+	resp, err = stream.Recv()
+	assert.Equal(t, err, io.EOF)
+	assert.Nil(t, resp)
+}
+
+func TestTicketFound(t *testing.T) {
+	for _, tc := range testcases.IncludedTestCases() {
+		t.Run(tc.Name, func(t *testing.T) {
+			if !returnedByQuery(t, tc) {
+				assert.Fail(t, "Expected to find ticket in pool but didn't.")
+			}
+		})
+	}
+}
+
+func TestTicketNotFound(t *testing.T) {
+	for _, tc := range testcases.ExcludedTestCases() {
+		t.Run(tc.Name, func(t *testing.T) {
+			if returnedByQuery(t, tc) {
+				assert.Fail(t, "Expected to not find ticket in pool but did.")
+			}
+		})
+	}
+}
+
+func returnedByQuery(t *testing.T, tc testcases.TestCase) (found bool) {
+	om, closer := e2e.New(t)
+	defer closer()
+
+	{
+		fe := om.MustFrontendGRPC()
+		resp, err := fe.CreateTicket(context.Background(), &pb.CreateTicketRequest{Ticket: tc.Ticket})
+		assert.NotNil(t, resp)
+		assert.NotNil(t, resp.Ticket)
+		assert.Nil(t, err)
+	}
+
+	q := om.MustQueryServiceGRPC()
+	stream, err := q.QueryTickets(context.Background(), &pb.QueryTicketsRequest{Pool: tc.Pool})
+	assert.Nil(t, err)
+
+	tickets := []*pb.Ticket{}
+	for {
+		resp, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+		assert.Nil(t, err)
+
+		tickets = append(tickets, resp.Tickets...)
+	}
+
+	if len(tickets) > 1 {
+		assert.Fail(t, "More than one ticket found")
+	}
+
+	return len(tickets) == 1
 }

--- a/test/e2e/query_tickets_test.go
+++ b/test/e2e/query_tickets_test.go
@@ -85,7 +85,8 @@ func TestPaging(t *testing.T) {
 	foundIds := map[string]struct{}{}
 
 	for i := 0; i < 5; i++ {
-		resp, err := stream.Recv()
+		var resp *pb.QueryTicketsResponse
+		resp, err = stream.Recv()
 		assert.Nil(t, err)
 		assert.Equal(t, len(resp.Tickets), pageSize)
 
@@ -108,6 +109,7 @@ func TestPaging(t *testing.T) {
 
 func TestTicketFound(t *testing.T) {
 	for _, tc := range testcases.IncludedTestCases() {
+		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
 			if !returnedByQuery(t, tc) {
 				assert.Fail(t, "Expected to find ticket in pool but didn't.")
@@ -118,6 +120,7 @@ func TestTicketFound(t *testing.T) {
 
 func TestTicketNotFound(t *testing.T) {
 	for _, tc := range testcases.ExcludedTestCases() {
+		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
 			if returnedByQuery(t, tc) {
 				assert.Fail(t, "Expected to not find ticket in pool but did.")


### PR DESCRIPTION
Adding a filter package which will be used by the query cache to determine if a filter is within a given pool.

This comes with a suite of test cases which test individual tickets against a pool for fine grained testing.

Split the tests in query_tickets_test to handle a few special case tests more simply or thoroughly, and then use the above test cases for everything else.

This methodology found one bug with the redis implementation, where a max value on a double filter of NaN wouldn't properly exclude all tickets.  As such, added a special case for it.  (not that it will live long anyways, but it was any easy fix.)