### PR TITLE
Do some randomization on return order of tickets

### DIFF
--- a/internal/statestore/redis.go
+++ b/internal/statestore/redis.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"time"
 
 	"github.com/cenkalti/backoff"
@@ -476,6 +477,15 @@ func (rb *redisBackend) FilterTickets(ctx context.Context, pool *pb.Pool, pageSi
 	}
 
 	idSet = set.Difference(idSet, idsInIgnoreLists)
+
+	// Do a little randomization to prevent dependancy on return order.
+	if len(idSet) > 0 {
+		for i := 0; i < 20; i++ {
+			j := rand.Intn(len(idSet))
+			k := rand.Intn(len(idSet))
+			idSet[j], idSet[k] = idSet[k], idSet[j]
+		}
+	}
 
 	// TODO: finish reworking this after the proto changes.
 	for _, page := range idsToPages(idSet, pageSize) {

--- a/internal/statestore/redis.go
+++ b/internal/statestore/redis.go
@@ -478,7 +478,7 @@ func (rb *redisBackend) FilterTickets(ctx context.Context, pool *pb.Pool, pageSi
 
 	idSet = set.Difference(idSet, idsInIgnoreLists)
 
-	// Do a little randomization to prevent dependancy on return order.
+	// Do a little randomization to prevent dependency on return order.
 	if len(idSet) > 0 {
 		for i := 0; i < 20; i++ {
 			j := rand.Intn(len(idSet))

--- a/test/e2e/game_flow_test.go
+++ b/test/e2e/game_flow_test.go
@@ -157,16 +157,16 @@ func TestGameMatchWorkFlow(t *testing.T) {
 	}
 
 	// 2. Call backend.FetchMatches and expects two matches with the following tickets
-	matches := []*pb.Match{MustMakeMatch("ticket234", ticket2, ticket3, ticket4), MustMakeMatch("ticket5", ticket5)}
+	matches := []*pb.Match{MustMakeMatch(ticket2, ticket3, ticket4), MustMakeMatch(ticket5)}
 	validateFetchMatchesResponse(ctx, t, matches, be, fmReq)
 
 	// 3. Call backend.FetchMatches within storage.ignoreListTTL seconds and expects it return a match with ticket1 .
-	matches = []*pb.Match{MustMakeMatch("ticket12", ticket1)}
+	matches = []*pb.Match{MustMakeMatch(ticket1)}
 	validateFetchMatchesResponse(ctx, t, matches, be, fmReq)
 
 	// 4. Wait for storage.ignoreListTTL seconds and call backend.FetchMatches the third time, expect the same result as step 2.
 	time.Sleep(statestoreTesting.IgnoreListTTL)
-	matches = []*pb.Match{MustMakeMatch("ticket234", ticket2, ticket3, ticket4), MustMakeMatch("ticket5", ticket5)}
+	matches = []*pb.Match{MustMakeMatch(ticket2, ticket3, ticket4), MustMakeMatch(ticket5)}
 	validateFetchMatchesResponse(ctx, t, matches, be, fmReq)
 
 	// 5. Call backend.AssignTickets to assign DGSs for the tickets in FetchMatches' response
@@ -184,7 +184,7 @@ func TestGameMatchWorkFlow(t *testing.T) {
 
 	// 6. Call backend.FetchMatches and verify it no longer returns tickets got assigned in the previous step.
 	time.Sleep(statestoreTesting.IgnoreListTTL)
-	matches = []*pb.Match{MustMakeMatch("ticket12", ticket1)}
+	matches = []*pb.Match{MustMakeMatch(ticket1)}
 	validateFetchMatchesResponse(ctx, t, matches, be, fmReq)
 
 	// 7. Call frontend.DeleteTicket to delete the tickets returned in step 6.
@@ -215,8 +215,8 @@ func validateFetchMatchesResponse(ctx context.Context, t *testing.T, expectedMat
 	require.ElementsMatch(t, expectedMatches, matches)
 }
 
-func MustMakeMatch(profileName string, tickets ...*pb.Ticket) *pb.Match {
-	m, err := mmf.MakeMatch(profileName, tickets...)
+func MustMakeMatch(tickets ...*pb.Ticket) *pb.Match {
+	m, err := mmf.MakeMatch("test-profile", tickets...)
 	if err != nil {
 		panic(err)
 	}

--- a/test/e2e/minimatch_test.go
+++ b/test/e2e/minimatch_test.go
@@ -183,7 +183,7 @@ func TestMinimatch(t *testing.T) {
 					}
 
 					// Validate that all the pools have the expected tickets.
-					assert.Equal(t, poolTickets[pool.Name], want)
+					assert.ElementsMatch(t, poolTickets[pool.Name], want)
 				}
 
 				testFetchMatches(ctx, t, poolTickets, testProfiles, om, fc)

--- a/test/matchfunction/mmf/matchfunction.go
+++ b/test/matchfunction/mmf/matchfunction.go
@@ -66,6 +66,7 @@ func scoreCalculator(tickets []*pb.Ticket) float64 {
 	return matchScore
 }
 
+// MakeMatch creates a match given the provided tickets.
 func MakeMatch(profileName string, tickets ...*pb.Ticket) (*pb.Match, error) {
 	// Keep output deterministic
 	sort.Slice(tickets, func(i, j int) bool {

--- a/test/matchfunction/mmf/matchfunction.go
+++ b/test/matchfunction/mmf/matchfunction.go
@@ -20,10 +20,11 @@
 package mmf
 
 import (
+	"sort"
+
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/pkg/errors"
-	"github.com/rs/xid"
 	internalMmf "open-match.dev/open-match/internal/testing/mmf"
 	"open-match.dev/open-match/pkg/pb"
 )
@@ -41,22 +42,11 @@ func MakeMatches(params *internalMmf.MatchFunctionParams) ([]*pb.Match, error) {
 	var result []*pb.Match
 	for _, tickets := range params.PoolNameToTickets {
 		if len(tickets) != 0 {
-			evaluationInput, err := ptypes.MarshalAny(&pb.DefaultEvaluationCriteria{
-				Score: scoreCalculator(tickets),
-			})
+			m, err := MakeMatch(params.ProfileName, tickets...)
 			if err != nil {
-				return nil, errors.Wrap(err, "Failed to marshal DefaultEvaluationCriteria.")
+				return nil, err
 			}
-
-			result = append(result, &pb.Match{
-				MatchId:       xid.New().String(),
-				MatchProfile:  params.ProfileName,
-				MatchFunction: matchName,
-				Tickets:       tickets,
-				Extensions: map[string]*any.Any{
-					"evaluation_input": evaluationInput,
-				},
-			})
+			result = append(result, m)
 		}
 	}
 
@@ -74,4 +64,33 @@ func scoreCalculator(tickets []*pb.Ticket) float64 {
 		}
 	}
 	return matchScore
+}
+
+func MakeMatch(profileName string, tickets ...*pb.Ticket) (*pb.Match, error) {
+	// Keep output deterministic
+	sort.Slice(tickets, func(i, j int) bool {
+		return tickets[i].Id < tickets[j].Id
+	})
+
+	evaluationInput, err := ptypes.MarshalAny(&pb.DefaultEvaluationCriteria{
+		Score: scoreCalculator(tickets),
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to marshal DefaultEvaluationCriteria.")
+	}
+
+	id := "m"
+	for _, t := range tickets {
+		id += t.Id
+	}
+
+	return &pb.Match{
+		MatchId:       id,
+		MatchProfile:  profileName,
+		MatchFunction: matchName,
+		Tickets:       tickets,
+		Extensions: map[string]*any.Any{
+			"evaluation_input": evaluationInput,
+		},
+	}, nil
 }


### PR DESCRIPTION
This prevents clients from unintentionally depending on the return order of tickets.

This is currently happening with our tests, so this includes several fixes for the tests.