### PR TITLE
Fixed a ticket format that may result in serialization errors

### DIFF
--- a/third_party/google/api/backend.proto
+++ b/third_party/google/api/backend.proto
@@ -96,6 +96,25 @@ message BackendRule {
   string selector = 1;
 
   // The address of the API backend.
+  //
+  // The scheme is used to determine the backend protocol and security.
+  // The following schemes are accepted:
+  //
+  //    SCHEME        PROTOCOL    SECURITY
+  //    http://       HTTP        None
+  //    https://      HTTP        TLS
+  //    grpc://       gRPC        None
+  //    grpcs://      gRPC        TLS
+  //
+  // It is recommended to explicitly include a scheme. Leaving out the scheme
+  // may cause constrasting behaviors across platforms.
+  //
+  // If the port is unspecified, the default is:
+  // - 80 for schemes without TLS
+  // - 443 for schemes with TLS
+  //
+  // For HTTP backends, use [protocol][google.api.BackendRule.protocol]
+  // to specify the protocol version.
   string address = 2;
 
   // The number of seconds to wait for a response from a request. The default
@@ -121,9 +140,8 @@ message BackendRule {
   // For example, specifying `jwt_audience` implies that the backend expects
   // authentication via a JWT.
   //
-  // When authentication is unspecified, a JWT ID token will be generated with
-  // the value from [BackendRule.address][google.api.BackendRule.address] as jwt_audience, overrode to the
-  // HTTP "Authorization" request header and sent to the backend.
+  // When authentication is unspecified, the resulting behavior is the same
+  // as `disable_auth` set to `true`.
   //
   // Refer to https://developers.google.com/identity/protocols/OpenIDConnect for
   // JWT ID token.
@@ -133,14 +151,33 @@ message BackendRule {
     // to the backend.
     string jwt_audience = 7;
 
-    // When disable_auth is false,  a JWT ID token will be generated with the
-    // value from [BackendRule.address][google.api.BackendRule.address] as jwt_audience, overrode to the HTTP
-    // "Authorization" request header and sent to the backend.
-    //
     // When disable_auth is true, a JWT ID token won't be generated and the
     // original "Authorization" HTTP header will be preserved. If the header is
     // used to carry the original token and is expected by the backend, this
     // field must be set to true to preserve the header.
     bool disable_auth = 8;
   }
+
+  // The protocol used for sending a request to the backend.
+  // The supported values are "http/1.1" and "h2".
+  //
+  // The default value is inferred from the scheme in the
+  // [address][google.api.BackendRule.address] field:
+  //
+  //    SCHEME        PROTOCOL
+  //    http://       http/1.1
+  //    https://      http/1.1
+  //    grpc://       h2
+  //    grpcs://      h2
+  //
+  // For secure HTTP backends (https://) that support HTTP/2, set this field
+  // to "h2" for improved performance.
+  //
+  // Configuring this field to non-default values is only supported for secure
+  // HTTP backends. This field will be ignored for all other backends.
+  //
+  // See
+  // https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids
+  // for more details on the supported values.
+  string protocol = 9;
 }


### PR DESCRIPTION
We were using `proto.Marshal` and `proto.Unmarshal` to serial and de-serialize the tickets object. This flow works when we are using `SET` and `GET` against tickets but may result in serialization errors when we process tickets using `MSET` and `MGET`.

According to Redis command doc, this commit changed the serialization method from `proto.Marshal`/`proto.Unmarshal` to `proto.MarshalTextString`/`proto.UnmarshalText` in order to fix the potential issue.
> GET
 Get the value of key. If the key does not exist the special value nil is returned. An error is returned if the value stored at key is not a string, because GET only handles string values.