### PR TITLE
Disable swaggerui installation via helm

### DIFF
--- a/install/helm/open-match/templates/swaggerui.yaml
+++ b/install/helm/open-match/templates/swaggerui.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if index .Values "open-match-core" "enabled" }}
+{{- if index .Values "open-match-core" "swaggerui" "enabled" }}
 kind: Service
 apiVersion: v1
 metadata:

--- a/install/helm/open-match/values-production.yaml
+++ b/install/helm/open-match/values-production.yaml
@@ -181,6 +181,8 @@ open-match-core:
       maxActive: 500
       idleTimeout: 0
       healthCheckTimeout: 300ms
+  swaggerui:
+    enabled: false
 
 # Controls if users need to install scale testing setup for Open Match.
 open-match-scale:

--- a/install/helm/open-match/values.yaml
+++ b/install/helm/open-match/values.yaml
@@ -166,6 +166,8 @@ open-match-core:
       maxActive: 0
       idleTimeout: 0
       healthCheckTimeout: 300ms
+  swaggerui:
+    enabled: true
 
 # Controls if users need to install scale testing setup for Open Match.
 open-match-scale:


### PR DESCRIPTION
This commit added the ability to control the installation of swaggerui via helm. The basic `values.yaml` file has swaggerui enabled by default while the production one has it disabled.

Resolved #1140 