### PR TITLE
Removed ticket auto-expiring logic from statestore

### DIFF
--- a/install/helm/open-match/templates/om-configmap-default.yaml
+++ b/install/helm/open-match/templates/om-configmap-default.yaml
@@ -103,7 +103,6 @@ data:
         maxActive: {{ index .Values "open-match-core" "redis" "pool" "maxActive" }}
         idleTimeout: {{ index .Values "open-match-core" "redis" "pool" "idleTimeout" }}
         healthCheckTimeout: {{ index .Values "open-match-core" "redis" "pool" "healthCheckTimeout" }}
-      expiration: 43200
 
     telemetry:
       zpages:

--- a/internal/statestore/redis_test.go
+++ b/internal/statestore/redis_test.go
@@ -335,7 +335,6 @@ func createRedis(t *testing.T) (config.View, func()) {
 	cfg.Set("redis.pool.idleTimeout", time.Second)
 	cfg.Set("redis.pool.healthCheckTimeout", 100*time.Millisecond)
 	cfg.Set("redis.pool.maxActive", 1000)
-	cfg.Set("redis.expiration", 42000)
 	cfg.Set("storage.ignoreListTTL", "200ms")
 	cfg.Set("backoff.initialInterval", 100*time.Millisecond)
 	cfg.Set("backoff.randFactor", 0.5)


### PR DESCRIPTION
Resolved #815.

Per discussion, removed the `EXPIRE` logic from our statestore implementation.