### PR TITLE
forbid assignment on ticket create

### DIFF
--- a/internal/app/frontend/frontend_service.go
+++ b/internal/app/frontend/frontend_service.go
@@ -53,8 +53,11 @@ var (
 //   - If SearchFields exist in a Ticket, CreateTicket will also index these fields such that one can query the ticket with query.QueryTickets function.
 func (s *frontendService) CreateTicket(ctx context.Context, req *pb.CreateTicketRequest) (*pb.CreateTicketResponse, error) {
 	// Perform input validation.
-	if req.GetTicket() == nil {
+	if req.Ticket == nil {
 		return nil, status.Errorf(codes.InvalidArgument, ".ticket is required")
+	}
+	if req.Ticket.Assignment != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "tickets cannot be created with an assignment")
 	}
 
 	return doCreateTicket(ctx, req, s.store)

--- a/test/e2e/ticket_test.go
+++ b/test/e2e/ticket_test.go
@@ -302,6 +302,7 @@ func TestCreateTicketErrors(t *testing.T) {
 			"tickets cannot be created with an assignment",
 		},
 	} {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			om := e2e.New(t)
 			fe := om.MustFrontendGRPC()

--- a/test/e2e/ticket_test.go
+++ b/test/e2e/ticket_test.go
@@ -120,9 +120,6 @@ func TestTicketLifeCycle(t *testing.T) {
 				"test-property": 1,
 			},
 		},
-		Assignment: &pb.Assignment{
-			Connection: "test-tbd",
-		},
 	}
 
 	// Create a ticket, validate that it got an id and set its id in the expected ticket.
@@ -276,5 +273,45 @@ func TestReleaseTickets(t *testing.T) {
 		resp, err = stream.Recv()
 		assert.Equal(t, io.EOF, err)
 		assert.Nil(t, resp)
+	}
+}
+
+func TestCreateTicketErrors(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		req  *pb.CreateTicketRequest
+		code codes.Code
+		msg  string
+	}{
+		{
+			"missing ticket",
+			&pb.CreateTicketRequest{
+				Ticket: nil,
+			},
+			codes.InvalidArgument,
+			".ticket is required",
+		},
+		{
+			"already has assignment",
+			&pb.CreateTicketRequest{
+				Ticket: &pb.Ticket{
+					Assignment: &pb.Assignment{},
+				},
+			},
+			codes.InvalidArgument,
+			"tickets cannot be created with an assignment",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			om := e2e.New(t)
+			fe := om.MustFrontendGRPC()
+			ctx := om.Context()
+
+			resp, err := fe.CreateTicket(ctx, tt.req)
+			assert.Nil(t, resp)
+			s := status.Convert(err)
+			assert.Equal(t, tt.code, s.Code())
+			assert.Equal(t, s.Message(), tt.msg)
+		})
 	}
 }


### PR DESCRIPTION
Resolves #1033

- Add the check to frontend_service.
- Add test coverage for this check and for another pre-existing (but untested) check.
- Remove an unused assignment from a different test, as it's no longer valid.