### PR TITLE
Use consistent main code for mmf and evaluator

### DIFF
--- a/cmd/default-evaluator/main.go
+++ b/cmd/default-evaluator/main.go
@@ -11,14 +11,16 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package main
 
 import (
+	"open-match.dev/open-match/internal/app"
 	"open-match.dev/open-match/internal/app/evaluator"
 	"open-match.dev/open-match/internal/app/evaluator/defaulteval"
+	"open-match.dev/open-match/internal/config"
 )
 
 func main() {
-	// Invoke the harness to setup a GRPC service that handles requests to run the evaluator.
-	evaluator.RunEvaluator(defaulteval.Evaluate)
+	app.RunApplication("evaluator", config.Read, evaluator.BindServiceFor(defaulteval.Evaluate))
 }

--- a/internal/app/evaluator/evaluator.go
+++ b/internal/app/evaluator/evaluator.go
@@ -22,6 +22,7 @@ import (
 	"open-match.dev/open-match/pkg/pb"
 )
 
+// BindServiceFor creates the evaluator service and binds it to the serving harness.
 func BindServiceFor(eval Evaluator) func(p *rpc.ServerParams, cfg config.View) error {
 	return func(p *rpc.ServerParams, cfg config.View) error {
 		p.AddHandleFunc(func(s *grpc.Server) {

--- a/internal/app/evaluator/evaluator.go
+++ b/internal/app/evaluator/evaluator.go
@@ -16,35 +16,18 @@
 package evaluator
 
 import (
-	"github.com/spf13/viper"
 	"google.golang.org/grpc"
-	"open-match.dev/open-match/internal/app"
 	"open-match.dev/open-match/internal/config"
 	"open-match.dev/open-match/internal/rpc"
 	"open-match.dev/open-match/pkg/pb"
 )
 
-// RunEvaluator is a hook for the main() method in the main executable.
-func RunEvaluator(eval Evaluator) {
-	app.RunApplication("evaluator", getCfg, func(p *rpc.ServerParams, cfg config.View) error {
-		return BindService(p, cfg, eval)
-	})
-}
+func BindServiceFor(eval Evaluator) func(p *rpc.ServerParams, cfg config.View) error {
+	return func(p *rpc.ServerParams, cfg config.View) error {
+		p.AddHandleFunc(func(s *grpc.Server) {
+			pb.RegisterEvaluatorServer(s, &evaluatorService{evaluate: eval})
+		}, pb.RegisterEvaluatorHandlerFromEndpoint)
 
-// BindService creates the evaluator service to the server Params.
-func BindService(p *rpc.ServerParams, cfg config.View, eval Evaluator) error {
-	p.AddHandleFunc(func(s *grpc.Server) {
-		pb.RegisterEvaluatorServer(s, &evaluatorService{evaluate: eval})
-	}, pb.RegisterEvaluatorHandlerFromEndpoint)
-
-	return nil
-}
-
-func getCfg() (config.View, error) {
-	cfg := viper.New()
-	cfg.Set("api.evaluator.hostname", "om-evaluator")
-	cfg.Set("api.evaluator.grpcport", 50508)
-	cfg.Set("api.evaluator.httpport", 51508)
-
-	return cfg, nil
+		return nil
+	}
 }

--- a/internal/testing/e2e/in_memory.go
+++ b/internal/testing/e2e/in_memory.go
@@ -162,9 +162,7 @@ func createMatchFunctionForTest(t *testing.T, c *rpcTesting.TestContext) *rpcTes
 		cfg.Set("api.query.grpcport", c.GetGRPCPort())
 		cfg.Set("api.query.httpport", c.GetHTTPPort())
 
-		assert.Nil(t, internalMmf.BindService(p, cfg, &internalMmf.FunctionSettings{
-			Func: mmf.MakeMatches,
-		}))
+		assert.Nil(t, internalMmf.BindServiceFor(mmf.MakeMatches)(p, cfg))
 	})
 	return tc
 }
@@ -173,7 +171,7 @@ func createMatchFunctionForTest(t *testing.T, c *rpcTesting.TestContext) *rpcTes
 func createEvaluatorForTest(t *testing.T) *rpcTesting.TestContext {
 	tc := rpcTesting.MustServeInsecure(t, func(p *rpc.ServerParams) {
 		cfg := viper.New()
-		assert.Nil(t, evaluator.BindService(p, cfg, defaulteval.Evaluate))
+		assert.Nil(t, evaluator.BindServiceFor(defaulteval.Evaluate)(p, cfg))
 	})
 
 	return tc

--- a/internal/testing/mmf/matchfunction.go
+++ b/internal/testing/mmf/matchfunction.go
@@ -36,37 +36,3 @@ func BindServiceFor(mf MatchFunction) func(p *rpc.ServerParams, cfg config.View)
 		return nil
 	}
 }
-
-// // RunMatchFunction is a hook for the main() method in the main executable.
-// func RunMatchFunction(settings *FunctionSettings) {
-// 	app.RunApplication("functions", getCfg, func(p *rpc.ServerParams, cfg config.View) error {
-// 		return BindService(p, cfg, settings)
-// 	})
-// }
-
-// // BindService creates the function service to the server Params.
-// func BindService(p *rpc.ServerParams, cfg config.View, fs *FunctionSettings) error {
-// 	service, err := newMatchFunctionService(cfg, fs)
-// 	if err != nil {
-// 		return err
-// 	}
-
-// 	p.AddHandleFunc(func(s *grpc.Server) {
-// 		pb.RegisterMatchFunctionServer(s, service)
-// 	}, pb.RegisterMatchFunctionHandlerFromEndpoint)
-
-// 	return nil
-// }
-
-// func getCfg() (config.View, error) {
-// 	cfg := viper.New()
-
-// 	cfg.Set("api.functions.hostname", "om-function")
-// 	cfg.Set("api.functions.grpcport", 50502)
-// 	cfg.Set("api.functions.httpport", 51502)
-
-// 	cfg.Set("api.query.hostname", "om-query")
-// 	cfg.Set("api.query.grpcport", 50503)
-
-// 	return cfg, nil
-// }

--- a/internal/testing/mmf/matchfunction.go
+++ b/internal/testing/mmf/matchfunction.go
@@ -22,6 +22,7 @@ import (
 	"open-match.dev/open-match/pkg/pb"
 )
 
+// BindServiceFor creates the match function service and binds it to the serving harness.
 func BindServiceFor(mf MatchFunction) func(p *rpc.ServerParams, cfg config.View) error {
 	return func(p *rpc.ServerParams, cfg config.View) error {
 		service, err := newMatchFunctionService(cfg, mf)

--- a/internal/testing/mmf/matchfunction_service.go
+++ b/internal/testing/mmf/matchfunction_service.go
@@ -101,14 +101,14 @@ func (s *matchFunctionService) Run(req *pb.RunRequest, stream pb.MatchFunction_R
 	return nil
 }
 
-func newMatchFunctionService(cfg config.View, fs *FunctionSettings) (*matchFunctionService, error) {
+func newMatchFunctionService(cfg config.View, mf MatchFunction) (*matchFunctionService, error) {
 	conn, err := rpc.GRPCClientFromConfig(cfg, "api.query")
 	if err != nil {
 		logger.Errorf("Failed to get QueryService connection, %v.", err)
 		return nil, err
 	}
 
-	mmfService := &matchFunctionService{cfg: cfg, function: fs.Func, queryServiceClient: pb.NewQueryServiceClient(conn)}
+	mmfService := &matchFunctionService{cfg: cfg, function: mf, queryServiceClient: pb.NewQueryServiceClient(conn)}
 	return mmfService, nil
 }
 

--- a/test/matchfunction/main.go
+++ b/test/matchfunction/main.go
@@ -20,16 +20,12 @@
 package main
 
 import (
+	"open-match.dev/open-match/internal/app"
+	"open-match.dev/open-match/internal/config"
 	internalMmf "open-match.dev/open-match/internal/testing/mmf"
 	"open-match.dev/open-match/test/matchfunction/mmf"
 )
 
 func main() {
-	// Invoke the harness to setup a GRPC service that handles requests to run the
-	// match function. The harness itself queries open match for player pools for
-	// the specified request and passes the pools to the match function to generate
-	// proposals.
-	internalMmf.RunMatchFunction(&internalMmf.FunctionSettings{
-		Func: mmf.MakeMatches,
-	})
+	app.RunApplication("functions", config.Read, internalMmf.BindServiceFor(mmf.MakeMatches))
 }


### PR DESCRIPTION
This brings the test mmf and standard evaluator closer to the other commands.  So now they read the config instead of hardcoding it, and they use a bind function (though it's customized with the actual mmf or evaluator code.)

Also a small extra empty line to separate out license because it's not godoc.