### PR TITLE
Remove errant closing of already closed listeners

### DIFF
--- a/internal/appmain/appmain.go
+++ b/internal/appmain/appmain.go
@@ -173,7 +173,7 @@ func NewApplication(serviceName string, bindService Bind, getCfg func() (config.
 		_ = surpressedErr
 		return nil, err
 	}
-	b.AddCloser(s.Stop)
+	b.AddCloserErr(s.Stop)
 
 	return a, nil
 }

--- a/internal/rpc/insecure.go
+++ b/internal/rpc/insecure.go
@@ -85,19 +85,10 @@ func (s *insecureServer) start(params *ServerParams) error {
 	return nil
 }
 
-func (s *insecureServer) stop() {
+func (s *insecureServer) stop() error {
+	// the servers also close their respective listeners.
 	s.grpcServer.Stop()
-	if err := s.grpcListener.Close(); err != nil {
-		serverLogger.Debugf("error closing gRPC listener: %s", err)
-	}
-
-	if err := s.httpServer.Close(); err != nil {
-		serverLogger.Debugf("error closing HTTP server: %s", err)
-	}
-
-	if err := s.httpListener.Close(); err != nil {
-		serverLogger.Debugf("error closing HTTP listener: %s", err)
-	}
+	return s.httpListener.Close()
 }
 
 func newInsecureServer(grpcL, httpL net.Listener) *insecureServer {

--- a/internal/rpc/tls_server.go
+++ b/internal/rpc/tls_server.go
@@ -125,19 +125,10 @@ func (s *tlsServer) start(params *ServerParams) error {
 	return nil
 }
 
-func (s *tlsServer) stop() {
+func (s *tlsServer) stop() error {
+	// the servers also close their respective listeners.
 	s.grpcServer.Stop()
-	if err := s.grpcListener.Close(); err != nil {
-		serverLogger.Debugf("error closing gRPC-TLS listener: %s", err)
-	}
-
-	if err := s.httpServer.Close(); err != nil {
-		serverLogger.Debugf("error closing HTTPS server: %s", err)
-	}
-
-	if err := s.httpListener.Close(); err != nil {
-		serverLogger.Debugf("error closing HTTPS listener: %s", err)
-	}
+	return s.httpListener.Close()
 }
 
 func newTLSServer(grpcL, httpL net.Listener) *tlsServer {


### PR DESCRIPTION
When debugging, I saw that this would always log an useless error.  This is because both grpc and http servers will always close their listener when they themselves close.  As such, this statement always logs that it can't use a closed listener, even when it's trying to close the listener.

Also moved from logging the error to returning it, so that errors with closing are more noticeable.