### PR TITLE
fix release.sh not knowing the right images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@
 # If you want information on how to edit this file checkout,
 # http://makefiletutorial.com/
 
-BASE_VERSION = 0.0.0-dev
+BASE_VERSION = 1.0.0-rc.1
 SHORT_SHA = $(shell git rev-parse --short=7 HEAD | tr -d [:punct:])
 BRANCH_NAME = $(shell git rev-parse --abbrev-ref HEAD | tr -d [:punct:])
 VERSION = $(BASE_VERSION)-$(SHORT_SHA)
@@ -214,6 +214,9 @@ local-cloud-build: gcloud
 ## images are specified by the IMAGES variable.  Image commands ommit the
 ## "openmatch-" prefix on the image name and tags.
 ##
+
+list-images:
+	@echo $(IMAGES)
 
 #######################################
 ## build-images / build-<image name>-image: builds images locally

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@
 # If you want information on how to edit this file checkout,
 # http://makefiletutorial.com/
 
-BASE_VERSION = 1.0.0-rc.1
+BASE_VERSION = 0.0.0-dev
 SHORT_SHA = $(shell git rev-parse --short=7 HEAD | tr -d [:punct:])
 BRANCH_NAME = $(shell git rev-parse --abbrev-ref HEAD | tr -d [:punct:])
 VERSION = $(BASE_VERSION)-$(SHORT_SHA)

--- a/docs/governance/templates/release.sh
+++ b/docs/governance/templates/release.sh
@@ -12,24 +12,13 @@ SOURCE_VERSION=$1
 DEST_VERSION=$2
 SOURCE_PROJECT_ID=open-match-build
 DEST_PROJECT_ID=open-match-public-images
-IMAGE_NAMES="openmatch-backend openmatch-frontend openmatch-query openmatch-synchronizer openmatch-minimatch openmatch-demo-first-match openmatch-mmf-go-soloduel openmatch-mmf-go-pool openmatch-evaluator-go-simple openmatch-swaggerui openmatch-reaper"
+IMAGE_NAMES=$(make list-images)
 
 for name in $IMAGE_NAMES
 do
-    source_image=gcr.io/$SOURCE_PROJECT_ID/$name:$SOURCE_VERSION
-    dest_image=gcr.io/$DEST_PROJECT_ID/$name:$DEST_VERSION
+    source_image=gcr.io/$SOURCE_PROJECT_ID/openmatch-$name:$SOURCE_VERSION
+    dest_image=gcr.io/$DEST_PROJECT_ID/openmatch-$name:$DEST_VERSION
     docker pull $source_image
     docker tag $source_image $dest_image
     docker push $dest_image
-done
-
-echo "=============================================================="
-echo "=============================================================="
-echo "=============================================================="
-echo "=============================================================="
-
-echo "Add these lines to your release notes:"
-for name in $IMAGE_NAMES
-do
-    echo "docker pull gcr.io/$DEST_PROJECT_ID/$name:$DEST_VERSION"
 done


### PR DESCRIPTION
With this change, there is one source of truth, so things won't get out of sync.

Also removed the "copy to release notes" note, because we're not doing that anymore.