### PR TITLE
Have 1.0 tutorials go mod files reference 1.0.0-rc.1

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -106,7 +106,7 @@ steps:
 
 - id: 'Test: Services'
   name: 'gcr.io/$PROJECT_ID/open-match-build'
-  args: ['make', 'GOPROXY=off', 'GOLANG_TEST_COUNT=10', 'test']
+  args: ['make', 'GOLANG_TEST_COUNT=10', 'test']
   volumes:
   - name: 'go-vol'
     path: '/go'

--- a/tutorials/custom_evaluator/director/go.mod
+++ b/tutorials/custom_evaluator/director/go.mod
@@ -4,7 +4,5 @@ go 1.14
 
 require (
 	google.golang.org/grpc v1.25.0
-	open-match.dev/open-match v0.0.0-dev
+	open-match.dev/open-match v1.0.0-rc.1
 )
-
-replace open-match.dev/open-match v0.0.0-dev => ../../../

--- a/tutorials/custom_evaluator/director/go.sum
+++ b/tutorials/custom_evaluator/director/go.sum
@@ -397,5 +397,7 @@ k8s.io/client-go v9.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodB
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 open-match.dev/open-match v0.8.0 h1:u2rfC9GeoDL6Qr6uP5AbRO/wmUxkGx4KYq7GpRrPmpQ=
 open-match.dev/open-match v0.8.0/go.mod h1:r4Rc4EugcwjUVjosceaApsC0qyvVHUFcqaV9L3KLnes=
+open-match.dev/open-match v1.0.0-rc.1 h1:akVXjbqp6WhG/g75G8tn3hQT6KyWqJG7gFc7ZOVxSBk=
+open-match.dev/open-match v1.0.0-rc.1/go.mod h1:hBk3r7rerpyMM0kA05QFGyb5HgYtdqlXiPt5kZ8UIBc=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/tutorials/custom_evaluator/evaluator/go.mod
+++ b/tutorials/custom_evaluator/evaluator/go.mod
@@ -5,7 +5,5 @@ go 1.14
 require (
 	github.com/sirupsen/logrus v1.4.2
 	google.golang.org/grpc v1.25.0
-	open-match.dev/open-match v0.0.0-dev
+	open-match.dev/open-match v1.0.0-rc.1
 )
-
-replace open-match.dev/open-match v0.0.0-dev => ../../../

--- a/tutorials/custom_evaluator/evaluator/go.sum
+++ b/tutorials/custom_evaluator/evaluator/go.sum
@@ -406,5 +406,7 @@ k8s.io/client-go v9.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodB
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 open-match.dev/open-match v0.8.0 h1:u2rfC9GeoDL6Qr6uP5AbRO/wmUxkGx4KYq7GpRrPmpQ=
 open-match.dev/open-match v0.8.0/go.mod h1:r4Rc4EugcwjUVjosceaApsC0qyvVHUFcqaV9L3KLnes=
+open-match.dev/open-match v1.0.0-rc.1 h1:akVXjbqp6WhG/g75G8tn3hQT6KyWqJG7gFc7ZOVxSBk=
+open-match.dev/open-match v1.0.0-rc.1/go.mod h1:hBk3r7rerpyMM0kA05QFGyb5HgYtdqlXiPt5kZ8UIBc=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/tutorials/custom_evaluator/frontend/go.mod
+++ b/tutorials/custom_evaluator/frontend/go.mod
@@ -4,7 +4,5 @@ go 1.14
 
 require (
 	google.golang.org/grpc v1.25.0
-	open-match.dev/open-match v0.0.0-dev
+	open-match.dev/open-match v1.0.0-rc.1
 )
-
-replace open-match.dev/open-match v0.0.0-dev => ../../../

--- a/tutorials/custom_evaluator/frontend/go.sum
+++ b/tutorials/custom_evaluator/frontend/go.sum
@@ -397,5 +397,7 @@ k8s.io/client-go v9.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodB
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 open-match.dev/open-match v0.8.0 h1:u2rfC9GeoDL6Qr6uP5AbRO/wmUxkGx4KYq7GpRrPmpQ=
 open-match.dev/open-match v0.8.0/go.mod h1:r4Rc4EugcwjUVjosceaApsC0qyvVHUFcqaV9L3KLnes=
+open-match.dev/open-match v1.0.0-rc.1 h1:akVXjbqp6WhG/g75G8tn3hQT6KyWqJG7gFc7ZOVxSBk=
+open-match.dev/open-match v1.0.0-rc.1/go.mod h1:hBk3r7rerpyMM0kA05QFGyb5HgYtdqlXiPt5kZ8UIBc=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/tutorials/custom_evaluator/matchfunction/go.mod
+++ b/tutorials/custom_evaluator/matchfunction/go.mod
@@ -4,7 +4,5 @@ go 1.14
 
 require (
 	google.golang.org/grpc v1.25.0
-	open-match.dev/open-match v0.0.0-dev
+	open-match.dev/open-match v1.0.0-rc.1
 )
-
-replace open-match.dev/open-match v0.0.0-dev => ../../../

--- a/tutorials/custom_evaluator/matchfunction/go.sum
+++ b/tutorials/custom_evaluator/matchfunction/go.sum
@@ -397,5 +397,7 @@ k8s.io/client-go v9.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodB
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 open-match.dev/open-match v0.8.0 h1:u2rfC9GeoDL6Qr6uP5AbRO/wmUxkGx4KYq7GpRrPmpQ=
 open-match.dev/open-match v0.8.0/go.mod h1:r4Rc4EugcwjUVjosceaApsC0qyvVHUFcqaV9L3KLnes=
+open-match.dev/open-match v1.0.0-rc.1 h1:akVXjbqp6WhG/g75G8tn3hQT6KyWqJG7gFc7ZOVxSBk=
+open-match.dev/open-match v1.0.0-rc.1/go.mod h1:hBk3r7rerpyMM0kA05QFGyb5HgYtdqlXiPt5kZ8UIBc=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/tutorials/custom_evaluator/solution/director/go.mod
+++ b/tutorials/custom_evaluator/solution/director/go.mod
@@ -4,7 +4,5 @@ go 1.14
 
 require (
 	google.golang.org/grpc v1.25.0
-	open-match.dev/open-match v0.0.0-dev
+	open-match.dev/open-match v1.0.0-rc.1
 )
-
-replace open-match.dev/open-match v0.0.0-dev => ../../../../

--- a/tutorials/custom_evaluator/solution/director/go.sum
+++ b/tutorials/custom_evaluator/solution/director/go.sum
@@ -397,5 +397,7 @@ k8s.io/client-go v9.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodB
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 open-match.dev/open-match v0.8.0 h1:u2rfC9GeoDL6Qr6uP5AbRO/wmUxkGx4KYq7GpRrPmpQ=
 open-match.dev/open-match v0.8.0/go.mod h1:r4Rc4EugcwjUVjosceaApsC0qyvVHUFcqaV9L3KLnes=
+open-match.dev/open-match v1.0.0-rc.1 h1:akVXjbqp6WhG/g75G8tn3hQT6KyWqJG7gFc7ZOVxSBk=
+open-match.dev/open-match v1.0.0-rc.1/go.mod h1:hBk3r7rerpyMM0kA05QFGyb5HgYtdqlXiPt5kZ8UIBc=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/tutorials/custom_evaluator/solution/evaluator/go.mod
+++ b/tutorials/custom_evaluator/solution/evaluator/go.mod
@@ -5,7 +5,5 @@ go 1.14
 require (
 	github.com/sirupsen/logrus v1.4.2
 	google.golang.org/grpc v1.25.0
-	open-match.dev/open-match v0.0.0-dev
+	open-match.dev/open-match v1.0.0-rc.1
 )
-
-replace open-match.dev/open-match v0.0.0-dev => ../../../../

--- a/tutorials/custom_evaluator/solution/evaluator/go.sum
+++ b/tutorials/custom_evaluator/solution/evaluator/go.sum
@@ -406,5 +406,7 @@ k8s.io/client-go v9.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodB
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 open-match.dev/open-match v0.8.0 h1:u2rfC9GeoDL6Qr6uP5AbRO/wmUxkGx4KYq7GpRrPmpQ=
 open-match.dev/open-match v0.8.0/go.mod h1:r4Rc4EugcwjUVjosceaApsC0qyvVHUFcqaV9L3KLnes=
+open-match.dev/open-match v1.0.0-rc.1 h1:akVXjbqp6WhG/g75G8tn3hQT6KyWqJG7gFc7ZOVxSBk=
+open-match.dev/open-match v1.0.0-rc.1/go.mod h1:hBk3r7rerpyMM0kA05QFGyb5HgYtdqlXiPt5kZ8UIBc=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/tutorials/custom_evaluator/solution/frontend/go.mod
+++ b/tutorials/custom_evaluator/solution/frontend/go.mod
@@ -4,7 +4,5 @@ go 1.14
 
 require (
 	google.golang.org/grpc v1.25.0
-	open-match.dev/open-match v0.0.0-dev
+	open-match.dev/open-match v1.0.0-rc.1
 )
-
-replace open-match.dev/open-match v0.0.0-dev => ../../../../

--- a/tutorials/custom_evaluator/solution/frontend/go.sum
+++ b/tutorials/custom_evaluator/solution/frontend/go.sum
@@ -397,5 +397,7 @@ k8s.io/client-go v9.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodB
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 open-match.dev/open-match v0.8.0 h1:u2rfC9GeoDL6Qr6uP5AbRO/wmUxkGx4KYq7GpRrPmpQ=
 open-match.dev/open-match v0.8.0/go.mod h1:r4Rc4EugcwjUVjosceaApsC0qyvVHUFcqaV9L3KLnes=
+open-match.dev/open-match v1.0.0-rc.1 h1:akVXjbqp6WhG/g75G8tn3hQT6KyWqJG7gFc7ZOVxSBk=
+open-match.dev/open-match v1.0.0-rc.1/go.mod h1:hBk3r7rerpyMM0kA05QFGyb5HgYtdqlXiPt5kZ8UIBc=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/tutorials/custom_evaluator/solution/matchfunction/go.mod
+++ b/tutorials/custom_evaluator/solution/matchfunction/go.mod
@@ -4,7 +4,5 @@ go 1.14
 
 require (
 	google.golang.org/grpc v1.25.0
-	open-match.dev/open-match v0.0.0-dev
+	open-match.dev/open-match v1.0.0-rc.1
 )
-
-replace open-match.dev/open-match v0.0.0-dev => ../../../../

--- a/tutorials/custom_evaluator/solution/matchfunction/go.sum
+++ b/tutorials/custom_evaluator/solution/matchfunction/go.sum
@@ -397,5 +397,7 @@ k8s.io/client-go v9.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodB
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 open-match.dev/open-match v0.8.0 h1:u2rfC9GeoDL6Qr6uP5AbRO/wmUxkGx4KYq7GpRrPmpQ=
 open-match.dev/open-match v0.8.0/go.mod h1:r4Rc4EugcwjUVjosceaApsC0qyvVHUFcqaV9L3KLnes=
+open-match.dev/open-match v1.0.0-rc.1 h1:akVXjbqp6WhG/g75G8tn3hQT6KyWqJG7gFc7ZOVxSBk=
+open-match.dev/open-match v1.0.0-rc.1/go.mod h1:hBk3r7rerpyMM0kA05QFGyb5HgYtdqlXiPt5kZ8UIBc=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/tutorials/default_evaluator/director/go.mod
+++ b/tutorials/default_evaluator/director/go.mod
@@ -4,7 +4,5 @@ go 1.14
 
 require (
 	google.golang.org/grpc v1.25.0
-	open-match.dev/open-match v0.0.0-dev
+	open-match.dev/open-match v1.0.0-rc.1
 )
-
-replace open-match.dev/open-match v0.0.0-dev => ../../../

--- a/tutorials/default_evaluator/director/go.sum
+++ b/tutorials/default_evaluator/director/go.sum
@@ -397,5 +397,7 @@ k8s.io/client-go v9.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodB
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 open-match.dev/open-match v0.8.0 h1:u2rfC9GeoDL6Qr6uP5AbRO/wmUxkGx4KYq7GpRrPmpQ=
 open-match.dev/open-match v0.8.0/go.mod h1:r4Rc4EugcwjUVjosceaApsC0qyvVHUFcqaV9L3KLnes=
+open-match.dev/open-match v1.0.0-rc.1 h1:akVXjbqp6WhG/g75G8tn3hQT6KyWqJG7gFc7ZOVxSBk=
+open-match.dev/open-match v1.0.0-rc.1/go.mod h1:hBk3r7rerpyMM0kA05QFGyb5HgYtdqlXiPt5kZ8UIBc=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/tutorials/default_evaluator/frontend/go.mod
+++ b/tutorials/default_evaluator/frontend/go.mod
@@ -4,7 +4,5 @@ go 1.14
 
 require (
 	google.golang.org/grpc v1.25.0
-	open-match.dev/open-match v0.0.0-dev
+	open-match.dev/open-match v1.0.0-rc.1
 )
-
-replace open-match.dev/open-match v0.0.0-dev => ../../../

--- a/tutorials/default_evaluator/frontend/go.sum
+++ b/tutorials/default_evaluator/frontend/go.sum
@@ -397,5 +397,7 @@ k8s.io/client-go v9.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodB
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 open-match.dev/open-match v0.8.0 h1:u2rfC9GeoDL6Qr6uP5AbRO/wmUxkGx4KYq7GpRrPmpQ=
 open-match.dev/open-match v0.8.0/go.mod h1:r4Rc4EugcwjUVjosceaApsC0qyvVHUFcqaV9L3KLnes=
+open-match.dev/open-match v1.0.0-rc.1 h1:akVXjbqp6WhG/g75G8tn3hQT6KyWqJG7gFc7ZOVxSBk=
+open-match.dev/open-match v1.0.0-rc.1/go.mod h1:hBk3r7rerpyMM0kA05QFGyb5HgYtdqlXiPt5kZ8UIBc=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/tutorials/default_evaluator/matchfunction/go.mod
+++ b/tutorials/default_evaluator/matchfunction/go.mod
@@ -4,7 +4,5 @@ go 1.14
 
 require (
 	google.golang.org/grpc v1.25.0
-	open-match.dev/open-match v0.0.0-dev
+	open-match.dev/open-match v1.0.0-rc.1
 )
-
-replace open-match.dev/open-match v0.0.0-dev => ../../../

--- a/tutorials/default_evaluator/matchfunction/go.sum
+++ b/tutorials/default_evaluator/matchfunction/go.sum
@@ -397,5 +397,7 @@ k8s.io/client-go v9.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodB
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 open-match.dev/open-match v0.8.0 h1:u2rfC9GeoDL6Qr6uP5AbRO/wmUxkGx4KYq7GpRrPmpQ=
 open-match.dev/open-match v0.8.0/go.mod h1:r4Rc4EugcwjUVjosceaApsC0qyvVHUFcqaV9L3KLnes=
+open-match.dev/open-match v1.0.0-rc.1 h1:akVXjbqp6WhG/g75G8tn3hQT6KyWqJG7gFc7ZOVxSBk=
+open-match.dev/open-match v1.0.0-rc.1/go.mod h1:hBk3r7rerpyMM0kA05QFGyb5HgYtdqlXiPt5kZ8UIBc=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/tutorials/default_evaluator/solution/director/go.mod
+++ b/tutorials/default_evaluator/solution/director/go.mod
@@ -4,7 +4,5 @@ go 1.14
 
 require (
 	google.golang.org/grpc v1.25.0
-	open-match.dev/open-match v0.0.0-dev
+	open-match.dev/open-match v1.0.0-rc.1
 )
-
-replace open-match.dev/open-match v0.0.0-dev => ../../../../

--- a/tutorials/default_evaluator/solution/director/go.sum
+++ b/tutorials/default_evaluator/solution/director/go.sum
@@ -397,5 +397,7 @@ k8s.io/client-go v9.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodB
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 open-match.dev/open-match v0.8.0 h1:u2rfC9GeoDL6Qr6uP5AbRO/wmUxkGx4KYq7GpRrPmpQ=
 open-match.dev/open-match v0.8.0/go.mod h1:r4Rc4EugcwjUVjosceaApsC0qyvVHUFcqaV9L3KLnes=
+open-match.dev/open-match v1.0.0-rc.1 h1:akVXjbqp6WhG/g75G8tn3hQT6KyWqJG7gFc7ZOVxSBk=
+open-match.dev/open-match v1.0.0-rc.1/go.mod h1:hBk3r7rerpyMM0kA05QFGyb5HgYtdqlXiPt5kZ8UIBc=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/tutorials/default_evaluator/solution/frontend/go.mod
+++ b/tutorials/default_evaluator/solution/frontend/go.mod
@@ -4,7 +4,5 @@ go 1.14
 
 require (
 	google.golang.org/grpc v1.25.0
-	open-match.dev/open-match v0.0.0-dev
+	open-match.dev/open-match v1.0.0-rc.1
 )
-
-replace open-match.dev/open-match v0.0.0-dev => ../../../../

--- a/tutorials/default_evaluator/solution/frontend/go.sum
+++ b/tutorials/default_evaluator/solution/frontend/go.sum
@@ -397,5 +397,7 @@ k8s.io/client-go v9.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodB
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 open-match.dev/open-match v0.8.0 h1:u2rfC9GeoDL6Qr6uP5AbRO/wmUxkGx4KYq7GpRrPmpQ=
 open-match.dev/open-match v0.8.0/go.mod h1:r4Rc4EugcwjUVjosceaApsC0qyvVHUFcqaV9L3KLnes=
+open-match.dev/open-match v1.0.0-rc.1 h1:akVXjbqp6WhG/g75G8tn3hQT6KyWqJG7gFc7ZOVxSBk=
+open-match.dev/open-match v1.0.0-rc.1/go.mod h1:hBk3r7rerpyMM0kA05QFGyb5HgYtdqlXiPt5kZ8UIBc=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/tutorials/default_evaluator/solution/matchfunction/go.mod
+++ b/tutorials/default_evaluator/solution/matchfunction/go.mod
@@ -5,7 +5,5 @@ go 1.14
 require (
 	github.com/golang/protobuf v1.3.2
 	google.golang.org/grpc v1.25.0
-	open-match.dev/open-match v0.0.0-dev
+	open-match.dev/open-match v1.0.0-rc.1
 )
-
-replace open-match.dev/open-match v0.0.0-dev => ../../../../

--- a/tutorials/default_evaluator/solution/matchfunction/go.sum
+++ b/tutorials/default_evaluator/solution/matchfunction/go.sum
@@ -397,5 +397,7 @@ k8s.io/client-go v9.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodB
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 open-match.dev/open-match v0.8.0 h1:u2rfC9GeoDL6Qr6uP5AbRO/wmUxkGx4KYq7GpRrPmpQ=
 open-match.dev/open-match v0.8.0/go.mod h1:r4Rc4EugcwjUVjosceaApsC0qyvVHUFcqaV9L3KLnes=
+open-match.dev/open-match v1.0.0-rc.1 h1:akVXjbqp6WhG/g75G8tn3hQT6KyWqJG7gFc7ZOVxSBk=
+open-match.dev/open-match v1.0.0-rc.1/go.mod h1:hBk3r7rerpyMM0kA05QFGyb5HgYtdqlXiPt5kZ8UIBc=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/tutorials/matchmaker101/director/go.mod
+++ b/tutorials/matchmaker101/director/go.mod
@@ -4,7 +4,5 @@ go 1.14
 
 require (
 	google.golang.org/grpc v1.25.0
-	open-match.dev/open-match v0.0.0-dev
+	open-match.dev/open-match v1.0.0-rc.1
 )
-
-replace open-match.dev/open-match v0.0.0-dev => ../../../

--- a/tutorials/matchmaker101/director/go.sum
+++ b/tutorials/matchmaker101/director/go.sum
@@ -383,5 +383,7 @@ k8s.io/api v0.0.0-20191004102255-dacd7df5a50b/go.mod h1:iuAfoD4hCxJ8Onx9kaTIt30j
 k8s.io/apimachinery v0.0.0-20191004074956-01f8b7d1121a/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
 k8s.io/client-go v0.0.0-20191004102537-eb5b9a8cfde7/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
+open-match.dev/open-match v1.0.0-rc.1 h1:akVXjbqp6WhG/g75G8tn3hQT6KyWqJG7gFc7ZOVxSBk=
+open-match.dev/open-match v1.0.0-rc.1/go.mod h1:hBk3r7rerpyMM0kA05QFGyb5HgYtdqlXiPt5kZ8UIBc=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/tutorials/matchmaker101/frontend/go.mod
+++ b/tutorials/matchmaker101/frontend/go.mod
@@ -4,7 +4,5 @@ go 1.14
 
 require (
 	google.golang.org/grpc v1.25.0
-	open-match.dev/open-match v0.0.0-dev
+	open-match.dev/open-match v1.0.0-rc.1
 )
-
-replace open-match.dev/open-match v0.0.0-dev => ../../../

--- a/tutorials/matchmaker101/frontend/go.sum
+++ b/tutorials/matchmaker101/frontend/go.sum
@@ -397,5 +397,7 @@ k8s.io/client-go v9.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodB
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 open-match.dev/open-match v0.8.0 h1:u2rfC9GeoDL6Qr6uP5AbRO/wmUxkGx4KYq7GpRrPmpQ=
 open-match.dev/open-match v0.8.0/go.mod h1:r4Rc4EugcwjUVjosceaApsC0qyvVHUFcqaV9L3KLnes=
+open-match.dev/open-match v1.0.0-rc.1 h1:akVXjbqp6WhG/g75G8tn3hQT6KyWqJG7gFc7ZOVxSBk=
+open-match.dev/open-match v1.0.0-rc.1/go.mod h1:hBk3r7rerpyMM0kA05QFGyb5HgYtdqlXiPt5kZ8UIBc=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/tutorials/matchmaker101/matchfunction/go.mod
+++ b/tutorials/matchmaker101/matchfunction/go.mod
@@ -4,7 +4,5 @@ go 1.14
 
 require (
 	google.golang.org/grpc v1.25.0
-	open-match.dev/open-match v0.0.0-dev
+	open-match.dev/open-match v1.0.0-rc.1
 )
-
-replace open-match.dev/open-match v0.0.0-dev => ../../../

--- a/tutorials/matchmaker101/matchfunction/go.sum
+++ b/tutorials/matchmaker101/matchfunction/go.sum
@@ -397,5 +397,7 @@ k8s.io/client-go v9.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodB
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 open-match.dev/open-match v0.8.0 h1:u2rfC9GeoDL6Qr6uP5AbRO/wmUxkGx4KYq7GpRrPmpQ=
 open-match.dev/open-match v0.8.0/go.mod h1:r4Rc4EugcwjUVjosceaApsC0qyvVHUFcqaV9L3KLnes=
+open-match.dev/open-match v1.0.0-rc.1 h1:akVXjbqp6WhG/g75G8tn3hQT6KyWqJG7gFc7ZOVxSBk=
+open-match.dev/open-match v1.0.0-rc.1/go.mod h1:hBk3r7rerpyMM0kA05QFGyb5HgYtdqlXiPt5kZ8UIBc=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/tutorials/matchmaker101/solution/director/go.mod
+++ b/tutorials/matchmaker101/solution/director/go.mod
@@ -4,7 +4,5 @@ go 1.14
 
 require (
 	google.golang.org/grpc v1.25.0
-	open-match.dev/open-match v0.0.0-dev
+	open-match.dev/open-match v1.0.0-rc.1
 )
-
-replace open-match.dev/open-match v0.0.0-dev => ../../../../

--- a/tutorials/matchmaker101/solution/director/go.sum
+++ b/tutorials/matchmaker101/solution/director/go.sum
@@ -397,5 +397,7 @@ k8s.io/client-go v9.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodB
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 open-match.dev/open-match v0.8.0 h1:u2rfC9GeoDL6Qr6uP5AbRO/wmUxkGx4KYq7GpRrPmpQ=
 open-match.dev/open-match v0.8.0/go.mod h1:r4Rc4EugcwjUVjosceaApsC0qyvVHUFcqaV9L3KLnes=
+open-match.dev/open-match v1.0.0-rc.1 h1:akVXjbqp6WhG/g75G8tn3hQT6KyWqJG7gFc7ZOVxSBk=
+open-match.dev/open-match v1.0.0-rc.1/go.mod h1:hBk3r7rerpyMM0kA05QFGyb5HgYtdqlXiPt5kZ8UIBc=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/tutorials/matchmaker101/solution/frontend/go.mod
+++ b/tutorials/matchmaker101/solution/frontend/go.mod
@@ -4,7 +4,5 @@ go 1.14
 
 require (
 	google.golang.org/grpc v1.25.0
-	open-match.dev/open-match v0.0.0-dev
+	open-match.dev/open-match v1.0.0-rc.1
 )
-
-replace open-match.dev/open-match v0.0.0-dev => ../../../../

--- a/tutorials/matchmaker101/solution/frontend/go.sum
+++ b/tutorials/matchmaker101/solution/frontend/go.sum
@@ -397,5 +397,7 @@ k8s.io/client-go v9.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodB
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 open-match.dev/open-match v0.8.0 h1:u2rfC9GeoDL6Qr6uP5AbRO/wmUxkGx4KYq7GpRrPmpQ=
 open-match.dev/open-match v0.8.0/go.mod h1:r4Rc4EugcwjUVjosceaApsC0qyvVHUFcqaV9L3KLnes=
+open-match.dev/open-match v1.0.0-rc.1 h1:akVXjbqp6WhG/g75G8tn3hQT6KyWqJG7gFc7ZOVxSBk=
+open-match.dev/open-match v1.0.0-rc.1/go.mod h1:hBk3r7rerpyMM0kA05QFGyb5HgYtdqlXiPt5kZ8UIBc=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/tutorials/matchmaker101/solution/matchfunction/go.mod
+++ b/tutorials/matchmaker101/solution/matchfunction/go.mod
@@ -4,7 +4,5 @@ go 1.14
 
 require (
 	google.golang.org/grpc v1.25.0
-	open-match.dev/open-match v0.0.0-dev
+	open-match.dev/open-match v1.0.0-rc.1
 )
-
-replace open-match.dev/open-match v0.0.0-dev => ../../../../

--- a/tutorials/matchmaker101/solution/matchfunction/go.sum
+++ b/tutorials/matchmaker101/solution/matchfunction/go.sum
@@ -397,5 +397,7 @@ k8s.io/client-go v9.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodB
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 open-match.dev/open-match v0.8.0 h1:u2rfC9GeoDL6Qr6uP5AbRO/wmUxkGx4KYq7GpRrPmpQ=
 open-match.dev/open-match v0.8.0/go.mod h1:r4Rc4EugcwjUVjosceaApsC0qyvVHUFcqaV9L3KLnes=
+open-match.dev/open-match v1.0.0-rc.1 h1:akVXjbqp6WhG/g75G8tn3hQT6KyWqJG7gFc7ZOVxSBk=
+open-match.dev/open-match v1.0.0-rc.1/go.mod h1:hBk3r7rerpyMM0kA05QFGyb5HgYtdqlXiPt5kZ8UIBc=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/tutorials/matchmaker102/director/go.mod
+++ b/tutorials/matchmaker102/director/go.mod
@@ -4,7 +4,5 @@ go 1.14
 
 require (
 	google.golang.org/grpc v1.25.0
-	open-match.dev/open-match v0.0.0-dev
+	open-match.dev/open-match v1.0.0-rc.1
 )
-
-replace open-match.dev/open-match v0.0.0-dev => ../../../

--- a/tutorials/matchmaker102/director/go.sum
+++ b/tutorials/matchmaker102/director/go.sum
@@ -397,5 +397,7 @@ k8s.io/client-go v9.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodB
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 open-match.dev/open-match v0.8.0 h1:u2rfC9GeoDL6Qr6uP5AbRO/wmUxkGx4KYq7GpRrPmpQ=
 open-match.dev/open-match v0.8.0/go.mod h1:r4Rc4EugcwjUVjosceaApsC0qyvVHUFcqaV9L3KLnes=
+open-match.dev/open-match v1.0.0-rc.1 h1:akVXjbqp6WhG/g75G8tn3hQT6KyWqJG7gFc7ZOVxSBk=
+open-match.dev/open-match v1.0.0-rc.1/go.mod h1:hBk3r7rerpyMM0kA05QFGyb5HgYtdqlXiPt5kZ8UIBc=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/tutorials/matchmaker102/frontend/go.mod
+++ b/tutorials/matchmaker102/frontend/go.mod
@@ -4,7 +4,5 @@ go 1.14
 
 require (
 	google.golang.org/grpc v1.25.0
-	open-match.dev/open-match v0.0.0-dev
+	open-match.dev/open-match v1.0.0-rc.1
 )
-
-replace open-match.dev/open-match v0.0.0-dev => ../../../

--- a/tutorials/matchmaker102/frontend/go.sum
+++ b/tutorials/matchmaker102/frontend/go.sum
@@ -397,5 +397,7 @@ k8s.io/client-go v9.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodB
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 open-match.dev/open-match v0.8.0 h1:u2rfC9GeoDL6Qr6uP5AbRO/wmUxkGx4KYq7GpRrPmpQ=
 open-match.dev/open-match v0.8.0/go.mod h1:r4Rc4EugcwjUVjosceaApsC0qyvVHUFcqaV9L3KLnes=
+open-match.dev/open-match v1.0.0-rc.1 h1:akVXjbqp6WhG/g75G8tn3hQT6KyWqJG7gFc7ZOVxSBk=
+open-match.dev/open-match v1.0.0-rc.1/go.mod h1:hBk3r7rerpyMM0kA05QFGyb5HgYtdqlXiPt5kZ8UIBc=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/tutorials/matchmaker102/matchfunction/go.mod
+++ b/tutorials/matchmaker102/matchfunction/go.mod
@@ -4,7 +4,5 @@ go 1.14
 
 require (
 	google.golang.org/grpc v1.25.0
-	open-match.dev/open-match v0.0.0-dev
+	open-match.dev/open-match v1.0.0-rc.1
 )
-
-replace open-match.dev/open-match v0.0.0-dev => ../../../

--- a/tutorials/matchmaker102/matchfunction/go.sum
+++ b/tutorials/matchmaker102/matchfunction/go.sum
@@ -397,5 +397,7 @@ k8s.io/client-go v9.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodB
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 open-match.dev/open-match v0.8.0 h1:u2rfC9GeoDL6Qr6uP5AbRO/wmUxkGx4KYq7GpRrPmpQ=
 open-match.dev/open-match v0.8.0/go.mod h1:r4Rc4EugcwjUVjosceaApsC0qyvVHUFcqaV9L3KLnes=
+open-match.dev/open-match v1.0.0-rc.1 h1:akVXjbqp6WhG/g75G8tn3hQT6KyWqJG7gFc7ZOVxSBk=
+open-match.dev/open-match v1.0.0-rc.1/go.mod h1:hBk3r7rerpyMM0kA05QFGyb5HgYtdqlXiPt5kZ8UIBc=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/tutorials/matchmaker102/solution/director/go.mod
+++ b/tutorials/matchmaker102/solution/director/go.mod
@@ -4,7 +4,5 @@ go 1.14
 
 require (
 	google.golang.org/grpc v1.25.0
-	open-match.dev/open-match v0.0.0-dev
+	open-match.dev/open-match v1.0.0-rc.1
 )
-
-replace open-match.dev/open-match v0.0.0-dev => ../../../../

--- a/tutorials/matchmaker102/solution/director/go.sum
+++ b/tutorials/matchmaker102/solution/director/go.sum
@@ -397,5 +397,7 @@ k8s.io/client-go v9.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodB
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 open-match.dev/open-match v0.8.0 h1:u2rfC9GeoDL6Qr6uP5AbRO/wmUxkGx4KYq7GpRrPmpQ=
 open-match.dev/open-match v0.8.0/go.mod h1:r4Rc4EugcwjUVjosceaApsC0qyvVHUFcqaV9L3KLnes=
+open-match.dev/open-match v1.0.0-rc.1 h1:akVXjbqp6WhG/g75G8tn3hQT6KyWqJG7gFc7ZOVxSBk=
+open-match.dev/open-match v1.0.0-rc.1/go.mod h1:hBk3r7rerpyMM0kA05QFGyb5HgYtdqlXiPt5kZ8UIBc=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/tutorials/matchmaker102/solution/frontend/go.mod
+++ b/tutorials/matchmaker102/solution/frontend/go.mod
@@ -4,7 +4,5 @@ go 1.14
 
 require (
 	google.golang.org/grpc v1.25.0
-	open-match.dev/open-match v0.0.0-dev
+	open-match.dev/open-match v1.0.0-rc.1
 )
-
-replace open-match.dev/open-match v0.0.0-dev => ../../../../

--- a/tutorials/matchmaker102/solution/frontend/go.sum
+++ b/tutorials/matchmaker102/solution/frontend/go.sum
@@ -397,5 +397,7 @@ k8s.io/client-go v9.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodB
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 open-match.dev/open-match v0.8.0 h1:u2rfC9GeoDL6Qr6uP5AbRO/wmUxkGx4KYq7GpRrPmpQ=
 open-match.dev/open-match v0.8.0/go.mod h1:r4Rc4EugcwjUVjosceaApsC0qyvVHUFcqaV9L3KLnes=
+open-match.dev/open-match v1.0.0-rc.1 h1:akVXjbqp6WhG/g75G8tn3hQT6KyWqJG7gFc7ZOVxSBk=
+open-match.dev/open-match v1.0.0-rc.1/go.mod h1:hBk3r7rerpyMM0kA05QFGyb5HgYtdqlXiPt5kZ8UIBc=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/tutorials/matchmaker102/solution/matchfunction/go.mod
+++ b/tutorials/matchmaker102/solution/matchfunction/go.mod
@@ -4,7 +4,5 @@ go 1.14
 
 require (
 	google.golang.org/grpc v1.25.0
-	open-match.dev/open-match v0.0.0-dev
+	open-match.dev/open-match v1.0.0-rc.1
 )
-
-replace open-match.dev/open-match v0.0.0-dev => ../../../../

--- a/tutorials/matchmaker102/solution/matchfunction/go.sum
+++ b/tutorials/matchmaker102/solution/matchfunction/go.sum
@@ -397,5 +397,7 @@ k8s.io/client-go v9.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodB
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 open-match.dev/open-match v0.8.0 h1:u2rfC9GeoDL6Qr6uP5AbRO/wmUxkGx4KYq7GpRrPmpQ=
 open-match.dev/open-match v0.8.0/go.mod h1:r4Rc4EugcwjUVjosceaApsC0qyvVHUFcqaV9L3KLnes=
+open-match.dev/open-match v1.0.0-rc.1 h1:akVXjbqp6WhG/g75G8tn3hQT6KyWqJG7gFc7ZOVxSBk=
+open-match.dev/open-match v1.0.0-rc.1/go.mod h1:hBk3r7rerpyMM0kA05QFGyb5HgYtdqlXiPt5kZ8UIBc=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=


### PR DESCRIPTION
This fixes the breakage where within a dockerfile they're referencing a the root go.mod which doesn't exist.