### PR TITLE
Use Helm release to name resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -363,7 +363,7 @@ install-scale-chart: install-chart-prerequisite build/toolchain/bin/helm$(EXE_EX
 install-ci-chart: install-chart-prerequisite build/toolchain/bin/helm$(EXE_EXTENSION) install/helm/open-match/secrets/
 	$(HELM) upgrade $(OPEN_MATCH_HELM_NAME) $(HELM_UPGRADE_FLAGS) --atomic install/helm/open-match $(HELM_IMAGE_FLAGS) \
 		--set query.replicas=1,frontend.replicas=1,backend.replicas=1 \
-		--set evaluator.hostName=test \
+		--set evaluator.hostName=open-match-test \
 		--set evaluator.grpcPort=50509 \
 		--set evaluator.httpPort=51509 \
 		--set open-match-core.registrationInterval=200ms \

--- a/Makefile
+++ b/Makefile
@@ -412,6 +412,7 @@ install/yaml/03-prometheus-chart.yaml: build/toolchain/bin/helm$(EXE_EXTENSION)
 		--set global.telemetry.prometheus.enabled=true \
 		install/helm/open-match > install/yaml/03-prometheus-chart.yaml
 
+# We have to hard-code the Prometheus Server URL as we are excluding Prometheus, so Helm cannot determine the URL from the Prometheus subchart
 install/yaml/04-grafana-chart.yaml: build/toolchain/bin/helm$(EXE_EXTENSION)
 	mkdir -p install/yaml/
 	$(HELM) template $(OPEN_MATCH_HELM_NAME) $(HELM_TEMPLATE_FLAGS) $(HELM_IMAGE_FLAGS) \
@@ -419,6 +420,7 @@ install/yaml/04-grafana-chart.yaml: build/toolchain/bin/helm$(EXE_EXTENSION)
 		--set open-match-core.redis.enabled=false \
 		--set open-match-telemetry.enabled=true \
 		--set global.telemetry.grafana.enabled=true \
+		--set-string global.telemetry.grafana.prometheusServer="http://$(OPEN_MATCH_HELM_NAME)-prometheus-server.$(OPEN_MATCH_KUBERNETES_NAMESPACE).svc.cluster.local:80/" \
 		install/helm/open-match > install/yaml/04-grafana-chart.yaml
 
 install/yaml/05-jaeger-chart.yaml: build/toolchain/bin/helm$(EXE_EXTENSION)

--- a/Makefile
+++ b/Makefile
@@ -389,9 +389,12 @@ install/yaml/: TAG = $(BASE_VERSION)
 endif
 install/yaml/: update-chart-deps install/yaml/install.yaml install/yaml/01-open-match-core.yaml install/yaml/02-open-match-demo.yaml install/yaml/03-prometheus-chart.yaml install/yaml/04-grafana-chart.yaml install/yaml/05-jaeger-chart.yaml install/yaml/06-open-match-override-configmap.yaml install/yaml/07-open-match-default-evaluator.yaml
 
+# We have to hard-code the Jaeger endpoints as we are excluding Jaeger, so Helm cannot determine the endpoints from the Jaeger subchart
 install/yaml/01-open-match-core.yaml: build/toolchain/bin/helm$(EXE_EXTENSION)
 	mkdir -p install/yaml/
 	$(HELM) template $(OPEN_MATCH_HELM_NAME) $(HELM_TEMPLATE_FLAGS) $(HELM_IMAGE_FLAGS) \
+		--set-string global.telemetry.jaeger.agentEndpoint="$(OPEN_MATCH_HELM_NAME)-jaeger-agent:6831" \
+		--set-string global.telemetry.jaeger.collectorEndpoint="http://$(OPEN_MATCH_HELM_NAME)-jaeger-collector:14268/api/traces" \
 		install/helm/open-match > install/yaml/01-open-match-core.yaml
 
 install/yaml/02-open-match-demo.yaml: build/toolchain/bin/helm$(EXE_EXTENSION)

--- a/Makefile
+++ b/Makefile
@@ -462,7 +462,7 @@ set-redis-password:
 		read REDIS_PASSWORD; \
 		stty echo; \
 		printf "\n"; \
-		$(KUBECTL) create secret generic om-redis -n $(OPEN_MATCH_KUBERNETES_NAMESPACE) --from-literal=redis-password=$$REDIS_PASSWORD --dry-run -o yaml | $(KUBECTL) replace -f - --force
+		$(KUBECTL) create secret generic open-match-redis -n $(OPEN_MATCH_KUBERNETES_NAMESPACE) --from-literal=redis-password=$$REDIS_PASSWORD --dry-run -o yaml | $(KUBECTL) replace -f - --force
 
 install-toolchain: install-kubernetes-tools install-protoc-tools install-openmatch-tools
 install-kubernetes-tools: build/toolchain/bin/kubectl$(EXE_EXTENSION) build/toolchain/bin/helm$(EXE_EXTENSION) build/toolchain/bin/minikube$(EXE_EXTENSION) build/toolchain/bin/terraform$(EXE_EXTENSION)

--- a/docs/development.md
+++ b/docs/development.md
@@ -111,8 +111,8 @@ While iterating on the project, you may need to:
 ## Accessing logs
 To look at Open Match core services' logs, run:
 ```bash
-# Replace om-frontend with the service name that you would like to access
-kubectl logs -n open-match svc/om-frontend
+# Replace open-match-frontend with the service name that you would like to access
+kubectl logs -n open-match svc/open-match-frontend
 ```
 
 ## API References

--- a/examples/demo/components/clients/clients.go
+++ b/examples/demo/components/clients/clients.go
@@ -81,7 +81,7 @@ func runScenario(ctx context.Context, name string, update updater.SetFunc) {
 	update(s)
 
 	// See https://open-match.dev/site/docs/guides/api/
-	conn, err := grpc.Dial("om-frontend.open-match.svc.cluster.local:50504", grpc.WithInsecure())
+	conn, err := grpc.Dial("open-match-frontend.open-match.svc.cluster.local:50504", grpc.WithInsecure())
 	if err != nil {
 		panic(err)
 	}

--- a/examples/demo/components/director/director.go
+++ b/examples/demo/components/director/director.go
@@ -68,7 +68,7 @@ func run(ds *components.DemoShared) {
 	ds.Update(s)
 
 	// See https://open-match.dev/site/docs/guides/api/
-	conn, err := grpc.Dial("om-backend.open-match.svc.cluster.local:50505", grpc.WithInsecure())
+	conn, err := grpc.Dial("open-match-backend.open-match.svc.cluster.local:50505", grpc.WithInsecure())
 	if err != nil {
 		panic(err)
 	}

--- a/examples/functions/golang/soloduel/main.go
+++ b/examples/functions/golang/soloduel/main.go
@@ -24,8 +24,8 @@ import (
 )
 
 const (
-	queryServiceAddr = "om-query.open-match.svc.cluster.local:50503" // Address of the QueryService endpoint.
-	serverPort       = 50502                                         // The port for hosting the Match Function.
+	queryServiceAddr = "open-match-query.open-match.svc.cluster.local:50503" // Address of the QueryService endpoint.
+	serverPort       = 50502                                                 // The port for hosting the Match Function.
 )
 
 func main() {

--- a/examples/scale/mmf/mmf.go
+++ b/examples/scale/mmf/mmf.go
@@ -39,7 +39,7 @@ var (
 func Run() {
 	activeScenario := scenarios.ActiveScenario
 
-	conn, err := grpc.Dial("om-query.open-match.svc.cluster.local:50503", utilTesting.NewGRPCDialOptions(logger)...)
+	conn, err := grpc.Dial("open-match-query.open-match.svc.cluster.local:50503", utilTesting.NewGRPCDialOptions(logger)...)
 	if err != nil {
 		logger.Fatalf("Failed to connect to Open Match, got %v", err)
 	}

--- a/examples/scale/scenarios/scenarios.go
+++ b/examples/scale/scenarios/scenarios.go
@@ -28,7 +28,7 @@ import (
 )
 
 var (
-	queryServiceAddress = "om-query.open-match.svc.cluster.local:50503" // Address of the QueryService Endpoint.
+	queryServiceAddress = "open-match-query.open-match.svc.cluster.local:50503" // Address of the QueryService Endpoint.
 
 	logger = logrus.WithFields(logrus.Fields{
 		"app": "scale",

--- a/install/helm/open-match/subcharts/open-match-customize/templates/_helpers.tpl
+++ b/install/helm/open-match/subcharts/open-match-customize/templates/_helpers.tpl
@@ -1,0 +1,20 @@
+{*
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*}
+
+{{/* vim: set filetype=mustache: */}}
+{{- define "openmatchcustomize.function.hostName" -}}
+{{- .Values.function.hostName | default (printf "%s-function" (include "openmatch.fullname" . ) ) -}}
+{{- end -}}

--- a/install/helm/open-match/subcharts/open-match-customize/templates/evaluator.yaml
+++ b/install/helm/open-match/subcharts/open-match-customize/templates/evaluator.yaml
@@ -18,7 +18,7 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: {{ .Values.evaluator.hostName }}
+  name: {{ include "openmatch.evaluator.hostName" . }}
   namespace: {{ .Release.Namespace }}
   annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
   labels:
@@ -46,20 +46,20 @@ spec:
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ .Values.evaluator.hostName }}
+  name: {{ include "openmatch.evaluator.hostName" . }}
   namespace: {{ .Release.Namespace }}
   annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ .Values.evaluator.hostName }}
+    name: {{ include "openmatch.evaluator.hostName" . }}
   {{- include "openmatch.HorizontalPodAutoscaler.spec.common" . | nindent 2 }}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.evaluator.hostName }}
+  name: {{ include "openmatch.evaluator.hostName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "openmatch.name" . }}
@@ -87,7 +87,7 @@ spec:
         {{- include "openmatch.volumes.tls" . | nindent 8}}
       serviceAccountName: {{ include "openmatch.serviceAccount.name" . }}
       containers:
-      - name: {{ .Values.evaluator.hostName }}
+      - name: {{ include "openmatch.evaluator.hostName" . }}
         volumeMounts:
           {{- include "openmatch.volumemounts.configs" (dict "configs" .Values.evaluatorConfigs) | nindent 10 }}
           {{- include "openmatch.volumemounts.tls" . | nindent 10 }}

--- a/install/helm/open-match/subcharts/open-match-customize/templates/evaluator.yaml
+++ b/install/helm/open-match/subcharts/open-match-customize/templates/evaluator.yaml
@@ -85,7 +85,7 @@ spec:
       volumes:
         {{- include "openmatch.volumes.configs" (dict "configs" .Values.evaluatorConfigs) | nindent 8}}
         {{- include "openmatch.volumes.tls" . | nindent 8}}
-      serviceAccountName: {{ .Values.global.kubernetes.serviceAccount }}
+      serviceAccountName: {{ include "openmatch.serviceAccount.name" . }}
       containers:
       - name: {{ .Values.evaluator.hostName }}
         volumeMounts:

--- a/install/helm/open-match/subcharts/open-match-customize/templates/evaluator.yaml
+++ b/install/helm/open-match/subcharts/open-match-customize/templates/evaluator.yaml
@@ -83,7 +83,7 @@ spec:
         release: {{ .Release.Name }}
     spec:
       volumes:
-        {{- include "openmatch.volumes.configs" (dict "configs" .Values.evaluatorConfigs) | nindent 8}}
+        {{- include "openmatch.volumes.configs" (. | merge (dict "configs" .Values.evaluatorConfigs)) | nindent 8}}
         {{- include "openmatch.volumes.tls" . | nindent 8}}
       serviceAccountName: {{ include "openmatch.serviceAccount.name" . }}
       containers:

--- a/install/helm/open-match/subcharts/open-match-customize/templates/matchfunctions.yaml
+++ b/install/helm/open-match/subcharts/open-match-customize/templates/matchfunctions.yaml
@@ -86,7 +86,7 @@ spec:
       volumes:
         {{- include "openmatch.volumes.configs" (dict "configs" .Values.mmfConfigs) | nindent 8}}
         {{- include "openmatch.volumes.tls" . | nindent 8}}
-      serviceAccountName: {{ .Values.global.kubernetes.serviceAccount }}
+      serviceAccountName: {{ include "openmatch.serviceAccount.name" . }}
       containers:
       - name: {{ .Values.function.hostName }}
         volumeMounts:

--- a/install/helm/open-match/subcharts/open-match-customize/templates/matchfunctions.yaml
+++ b/install/helm/open-match/subcharts/open-match-customize/templates/matchfunctions.yaml
@@ -18,7 +18,7 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: {{ .Values.function.hostName }}
+  name: {{ include "openmatchcustomize.function.hostName" . }}
   namespace: {{ .Release.Namespace }}
   annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
   labels:
@@ -46,20 +46,20 @@ spec:
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ .Values.function.hostName }}
+  name: {{ include "openmatchcustomize.function.hostName" . }}
   namespace: {{ .Release.Namespace }}
   annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ .Values.function.hostName }}
+    name: {{ include "openmatchcustomize.function.hostName" . }}
   {{- include "openmatch.HorizontalPodAutoscaler.spec.common" . | nindent 2 }}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.function.hostName }}
+  name: {{ include "openmatchcustomize.function.hostName" . }}
   namespace: {{ .Release.Namespace }}
   annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
   labels:
@@ -88,7 +88,7 @@ spec:
         {{- include "openmatch.volumes.tls" . | nindent 8}}
       serviceAccountName: {{ include "openmatch.serviceAccount.name" . }}
       containers:
-      - name: {{ .Values.function.hostName }}
+      - name: {{ include "openmatchcustomize.function.hostName" . }}
         volumeMounts:
           {{- include "openmatch.volumemounts.configs" (dict "configs" .Values.mmfConfigs) | nindent 10 }}
           {{- include "openmatch.volumemounts.tls" . | nindent 10 }}

--- a/install/helm/open-match/subcharts/open-match-customize/templates/matchfunctions.yaml
+++ b/install/helm/open-match/subcharts/open-match-customize/templates/matchfunctions.yaml
@@ -84,7 +84,7 @@ spec:
         release: {{ .Release.Name }}
     spec:
       volumes:
-        {{- include "openmatch.volumes.configs" (dict "configs" .Values.mmfConfigs) | nindent 8}}
+        {{- include "openmatch.volumes.configs" (. | merge (dict "configs" .Values.mmfConfigs)) | nindent 8}}
         {{- include "openmatch.volumes.tls" . | nindent 8}}
       serviceAccountName: {{ include "openmatch.serviceAccount.name" . }}
       containers:

--- a/install/helm/open-match/subcharts/open-match-customize/values.yaml
+++ b/install/helm/open-match/subcharts/open-match-customize/values.yaml
@@ -35,11 +35,13 @@ evaluatorConfigs:
   default:
     volumeName: om-config-volume-default
     mountPath: /app/config/default
-    configName: om-configmap-default
+    # This will be parsed through the `tpl` function.
+    configName: '{{ include "openmatch.configmap.default" . }}'
   customize:
     volumeName: om-config-volume-override
     mountPath: /app/config/override
-    configName: om-configmap-override
+    # This will be parsed through the `tpl` function.
+    configName: '{{ include "openmatch.configmap.override" . }}'
 
 mmfConfigs:
   # We use harness to implement the MMFs. MMF itself only requires one configmap but harness expects two,
@@ -48,8 +50,10 @@ mmfConfigs:
   default:
     volumeName: om-config-volume-default
     mountPath: /app/config/default
-    configName: om-configmap-default
+    # This will be parsed through the `tpl` function.
+    configName: '{{ include "openmatch.configmap.default" . }}'
   customize:
     volumeName: om-config-volume-override
     mountPath: /app/config/override
-    configName: om-configmap-override
+    # This will be parsed through the `tpl` function.
+    configName: '{{ include "openmatch.configmap.override" . }}'

--- a/install/helm/open-match/subcharts/open-match-scale/templates/_helpers.tpl
+++ b/install/helm/open-match/subcharts/open-match-scale/templates/_helpers.tpl
@@ -1,0 +1,44 @@
+{*
+ Copyright 2019 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*}
+
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+Instead of .Chart.Name, we hard-code "open-match" as we need to call this from subcharts, but get the
+same result as if called from this chart.
+*/}}
+{{- define "openmatch.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default "open-match" .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "openmatch.scaleBackend.hostName" -}}
+{{- .Values.scaleBackend.hostName | default (printf "%s-scale-backend" (include "openmatch.fullname" . ) ) -}}
+{{- end -}}
+
+{{- define "openmatch.scaleFrontend.hostName" -}}
+{{- .Values.scaleFrontend.hostName | default (printf "%s-scale-frontend" (include "openmatch.fullname" . ) ) -}}
+{{- end -}}

--- a/install/helm/open-match/subcharts/open-match-scale/templates/_helpers.tpl
+++ b/install/helm/open-match/subcharts/open-match-scale/templates/_helpers.tpl
@@ -19,14 +19,12 @@
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
-Instead of .Chart.Name, we hard-code "open-match" as we need to call this from subcharts, but get the
-same result as if called from this chart.
 */}}
-{{- define "openmatch.fullname" -}}
+{{- define "openmatchscale.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
-{{- $name := default "open-match" .Values.nameOverride }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
 {{- if contains $name .Release.Name }}
 {{- .Release.Name | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -35,10 +33,10 @@ same result as if called from this chart.
 {{- end }}
 {{- end }}
 
-{{- define "openmatch.scaleBackend.hostName" -}}
-{{- .Values.scaleBackend.hostName | default (printf "%s-scale-backend" (include "openmatch.fullname" . ) ) -}}
+{{- define "openmatchscale.scaleBackend.hostName" -}}
+{{- .Values.scaleBackend.hostName | default (printf "%s-backend" (include "openmatchscale.fullname" . ) ) -}}
 {{- end -}}
 
-{{- define "openmatch.scaleFrontend.hostName" -}}
-{{- .Values.scaleFrontend.hostName | default (printf "%s-scale-frontend" (include "openmatch.fullname" . ) ) -}}
+{{- define "openmatchscale.scaleFrontend.hostName" -}}
+{{- .Values.scaleFrontend.hostName | default (printf "%s-frontend" (include "openmatchscale.fullname" . ) ) -}}
 {{- end -}}

--- a/install/helm/open-match/subcharts/open-match-scale/templates/scale-backend.yaml
+++ b/install/helm/open-match/subcharts/open-match-scale/templates/scale-backend.yaml
@@ -61,7 +61,7 @@ spec:
       volumes:
         {{- include "openmatch.volumes.configs" (dict "configs" .Values.configs) | nindent 8}}
         {{- include "openmatch.volumes.tls" . | nindent 8}}
-      serviceAccountName: {{ .Values.global.kubernetes.serviceAccount }}
+      serviceAccountName: {{ include "openmatch.serviceAccount.name" . }}
       containers:
       - name: {{ .Values.scaleBackend.hostName }}
         volumeMounts:

--- a/install/helm/open-match/subcharts/open-match-scale/templates/scale-backend.yaml
+++ b/install/helm/open-match/subcharts/open-match-scale/templates/scale-backend.yaml
@@ -59,7 +59,7 @@ spec:
         release: {{ .Release.Name }}
     spec:
       volumes:
-        {{- include "openmatch.volumes.configs" (dict "configs" .Values.configs) | nindent 8}}
+        {{- include "openmatch.volumes.configs" (. | merge (dict "configs" .Values.configs)) | nindent 8}}
         {{- include "openmatch.volumes.tls" . | nindent 8}}
       serviceAccountName: {{ include "openmatch.serviceAccount.name" . }}
       containers:

--- a/install/helm/open-match/subcharts/open-match-scale/templates/scale-backend.yaml
+++ b/install/helm/open-match/subcharts/open-match-scale/templates/scale-backend.yaml
@@ -15,7 +15,7 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: {{ include "openmatch.scaleBackend.hostName" . }}
+  name: {{ include "openmatchscale.scaleBackend.hostName" . }}
   namespace: {{ .Release.Namespace }}
   annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
   labels:
@@ -34,7 +34,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "openmatch.scaleBackend.hostName" . }}
+  name: {{ include "openmatchscale.scaleBackend.hostName" . }}
   namespace: {{ .Release.Namespace }}
   annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
   labels:
@@ -63,7 +63,7 @@ spec:
         {{- include "openmatch.volumes.tls" . | nindent 8}}
       serviceAccountName: {{ include "openmatch.serviceAccount.name" . }}
       containers:
-      - name: {{ include "openmatch.scaleBackend.hostName" . }}
+      - name: {{ include "openmatchscale.scaleBackend.hostName" . }}
         volumeMounts:
           {{- include "openmatch.volumemounts.configs" (dict "configs" .Values.configs) | nindent 10 }}
           {{- include "openmatch.volumemounts.tls" . | nindent 10 }}

--- a/install/helm/open-match/subcharts/open-match-scale/templates/scale-backend.yaml
+++ b/install/helm/open-match/subcharts/open-match-scale/templates/scale-backend.yaml
@@ -15,7 +15,7 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: {{ .Values.scaleBackend.hostName }}
+  name: {{ include "openmatch.scaleBackend.hostName" . }}
   namespace: {{ .Release.Namespace }}
   annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
   labels:
@@ -34,7 +34,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.scaleBackend.hostName }}
+  name: {{ include "openmatch.scaleBackend.hostName" . }}
   namespace: {{ .Release.Namespace }}
   annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
   labels:
@@ -63,7 +63,7 @@ spec:
         {{- include "openmatch.volumes.tls" . | nindent 8}}
       serviceAccountName: {{ include "openmatch.serviceAccount.name" . }}
       containers:
-      - name: {{ .Values.scaleBackend.hostName }}
+      - name: {{ include "openmatch.scaleBackend.hostName" . }}
         volumeMounts:
           {{- include "openmatch.volumemounts.configs" (dict "configs" .Values.configs) | nindent 10 }}
           {{- include "openmatch.volumemounts.tls" . | nindent 10 }}

--- a/install/helm/open-match/subcharts/open-match-scale/templates/scale-frontend.yaml
+++ b/install/helm/open-match/subcharts/open-match-scale/templates/scale-frontend.yaml
@@ -61,7 +61,7 @@ spec:
       volumes:
         {{- include "openmatch.volumes.configs" (dict "configs" .Values.configs) | nindent 8}}
         {{- include "openmatch.volumes.tls" . | nindent 8}}
-      serviceAccountName: {{ .Values.global.kubernetes.serviceAccount }}
+      serviceAccountName: {{ include "openmatch.serviceAccount.name" . }}
       containers:
       - name: {{ .Values.scaleFrontend.hostName }}
         volumeMounts:

--- a/install/helm/open-match/subcharts/open-match-scale/templates/scale-frontend.yaml
+++ b/install/helm/open-match/subcharts/open-match-scale/templates/scale-frontend.yaml
@@ -15,7 +15,7 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: {{ .Values.scaleFrontend.hostName }}
+  name: {{ include "openmatch.scaleFrontend.hostName" . }}
   namespace: {{ .Release.Namespace }}
   annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
   labels:
@@ -34,7 +34,7 @@ spec:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ .Values.scaleFrontend.hostName }}
+  name: {{ include "openmatch.scaleFrontend.hostName" . }}
   namespace: {{ .Release.Namespace }}
   annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
   labels:
@@ -63,7 +63,7 @@ spec:
         {{- include "openmatch.volumes.tls" . | nindent 8}}
       serviceAccountName: {{ include "openmatch.serviceAccount.name" . }}
       containers:
-      - name: {{ .Values.scaleFrontend.hostName }}
+      - name: {{ include "openmatch.scaleFrontend.hostName" . }}
         volumeMounts:
           {{- include "openmatch.volumemounts.configs" (dict "configs" .Values.configs) | nindent 10 }}
           {{- include "openmatch.volumemounts.tls" . | nindent 10 }}

--- a/install/helm/open-match/subcharts/open-match-scale/templates/scale-frontend.yaml
+++ b/install/helm/open-match/subcharts/open-match-scale/templates/scale-frontend.yaml
@@ -59,7 +59,7 @@ spec:
         release: {{ .Release.Name }}
     spec:
       volumes:
-        {{- include "openmatch.volumes.configs" (dict "configs" .Values.configs) | nindent 8}}
+        {{- include "openmatch.volumes.configs" (. | merge (dict "configs" .Values.configs)) | nindent 8}}
         {{- include "openmatch.volumes.tls" . | nindent 8}}
       serviceAccountName: {{ include "openmatch.serviceAccount.name" . }}
       containers:

--- a/install/helm/open-match/subcharts/open-match-scale/templates/scale-frontend.yaml
+++ b/install/helm/open-match/subcharts/open-match-scale/templates/scale-frontend.yaml
@@ -15,7 +15,7 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: {{ include "openmatch.scaleFrontend.hostName" . }}
+  name: {{ include "openmatchscale.scaleFrontend.hostName" . }}
   namespace: {{ .Release.Namespace }}
   annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
   labels:
@@ -34,7 +34,7 @@ spec:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ include "openmatch.scaleFrontend.hostName" . }}
+  name: {{ include "openmatchscale.scaleFrontend.hostName" . }}
   namespace: {{ .Release.Namespace }}
   annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
   labels:
@@ -63,7 +63,7 @@ spec:
         {{- include "openmatch.volumes.tls" . | nindent 8}}
       serviceAccountName: {{ include "openmatch.serviceAccount.name" . }}
       containers:
-      - name: {{ include "openmatch.scaleFrontend.hostName" . }}
+      - name: {{ include "openmatchscale.scaleFrontend.hostName" . }}
         volumeMounts:
           {{- include "openmatch.volumemounts.configs" (dict "configs" .Values.configs) | nindent 10 }}
           {{- include "openmatch.volumemounts.tls" . | nindent 10 }}

--- a/install/helm/open-match/subcharts/open-match-scale/templates/scale-grafana-dashboard.yaml
+++ b/install/helm/open-match/subcharts/open-match-scale/templates/scale-grafana-dashboard.yaml
@@ -16,7 +16,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: open-match-scale-dashboard
+  name: {{ include "openmatch.fullname" . }}-scale-dashboard
   namespace: {{ .Release.Namespace }}
   labels:
      grafana_dashboard: "1"

--- a/install/helm/open-match/subcharts/open-match-scale/templates/scale-grafana-dashboard.yaml
+++ b/install/helm/open-match/subcharts/open-match-scale/templates/scale-grafana-dashboard.yaml
@@ -16,7 +16,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "openmatch.fullname" . }}-scale-dashboard
+  name: {{ include "openmatchscale.fullname" . }}-dashboard
   namespace: {{ .Release.Namespace }}
   labels:
      grafana_dashboard: "1"

--- a/install/helm/open-match/subcharts/open-match-scale/values.yaml
+++ b/install/helm/open-match/subcharts/open-match-scale/values.yaml
@@ -28,8 +28,10 @@ configs:
   default:
     volumeName: om-config-volume-default
     mountPath: /app/config/default
-    configName: om-configmap-default
+    # This will be parsed through the `tpl` function.
+    configName: '{{ include "openmatch.configmap.default" . }}'
   override:
     volumeName: om-config-volume-override
     mountPath: /app/config/override
-    configName: om-configmap-override
+    # This will be parsed through the `tpl` function.
+    configName: '{{ include "openmatch.configmap.override" . }}'

--- a/install/helm/open-match/subcharts/open-match-scale/values.yaml
+++ b/install/helm/open-match/subcharts/open-match-scale/values.yaml
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 scaleFrontend:
-  hostName: om-scale-frontend
+  hostName:
   httpPort: 51509
   replicas: 1
   image: openmatch-scale-frontend
 
 scaleBackend:
-  hostName: om-scale-backend
+  hostName:
   httpPort: 51509
   replicas: 1
   image: openmatch-scale-backend

--- a/install/helm/open-match/subcharts/open-match-telemetry/dashboards/go-processes.json
+++ b/install/helm/open-match/subcharts/open-match-telemetry/dashboards/go-processes.json
@@ -62,7 +62,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg by (pod_name) (\n  sum(\n    rate(container_cpu_usage_seconds_total{pod_name=~\"om-.*\", container_name!=\"POD\"}[5m])\n  ) by (pod_name, container_name) \n  \n  /\n  \n  sum(\n    container_spec_cpu_quota{pod_name=~\"om-.*\", container_name!=\"POD\"} / container_spec_cpu_period{pod_name=~\"om-.*\", container_name!=\"POD\"}\n  ) by (pod_name, container_name) \n  \n  * \n  \n  100\n)",
+          "expr": "avg by (pod_name) (\n\nsum(\n  rate(container_cpu_usage_seconds_total{container_name!=\"POD\"}[5m]) * on (pod_name) group_left(label_app) max by (pod_name, label_app) (label_replace(kube_pod_labels{label_app=\"open-match\"}, \"pod_name\", \"$1\", \"pod\", \"(.*)\"))\n) by (pod_name, container_name)\n\n/\n\nsum(\n  (container_spec_cpu_quota{container_name!=\"POD\"} * on (pod_name) group_left(label_app) max by (pod_name, label_app) (label_replace(kube_pod_labels{label_app=\"open-match\"}, \"pod_name\", \"$1\", \"pod\", \"(.*)\")))\n  /\n  (container_spec_cpu_period{container_name!=\"POD\"} * on (pod_name) group_left(label_app) max by (pod_name, label_app) (label_replace(kube_pod_labels{label_app=\"open-match\"}, \"pod_name\", \"$1\", \"pod\", \"(.*)\")))\n) by (pod_name, container_name)\n\n*\n\n100\n)\n",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{pod_name}}",
@@ -155,7 +155,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg by (component) (go_goroutines{app=~\"open-match\", kubernetes_pod_name=~\"om-.*\"})",
+          "expr": "avg by (component) (go_goroutines{app=~\"open-match\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{component}}",
@@ -256,7 +256,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg by (component,app) (process_resident_memory_bytes{app=~\"open-match\", kubernetes_pod_name=~\"om-.*\"})",
+          "expr": "avg by (component,app) (process_resident_memory_bytes{app=~\"open-match\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{component}} - resident",
@@ -265,7 +265,7 @@
           "step": 4
         },
         {
-          "expr": "avg by (component,app) (process_virtual_memory_bytes{app=~\"open-match\", kubernetes_pod_name=~\"om-.*\"})",
+          "expr": "avg by (component,app) (process_virtual_memory_bytes{app=~\"open-match\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{component}} - virtual",
@@ -365,7 +365,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg by (component) (deriv(process_resident_memory_bytes{app=~\"open-match\", kubernetes_pod_name=~\"om-.*\"}[$interval]))",
+          "expr": "avg by (component) (deriv(process_resident_memory_bytes{app=~\"open-match\"}[$interval]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{component}} - resident",
@@ -374,7 +374,7 @@
           "step": 4
         },
         {
-          "expr": "avg by (component) (deriv(process_virtual_memory_bytes{app=~\"open-match\", kubernetes_pod_name=~\"om-.*\"}[$interval]))",
+          "expr": "avg by (component) (deriv(process_virtual_memory_bytes{app=~\"open-match\"}[$interval]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{component}} - virtual",
@@ -475,7 +475,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg by (component) (go_memstats_alloc_bytes{app=~\"open-match\", kubernetes_pod_name=~\"om-.*\"})",
+          "expr": "avg by (component) (go_memstats_alloc_bytes{app=~\"open-match\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{component}} - bytes allocated",
@@ -484,7 +484,7 @@
           "step": 4
         },
         {
-          "expr": "avg by (component) (rate(go_memstats_alloc_bytes_total{app=~\"open-match\", kubernetes_pod_name=~\"om-.*\"}[$interval]))",
+          "expr": "avg by (component) (rate(go_memstats_alloc_bytes_total{app=~\"open-match\"}[$interval]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{component}} - alloc rate",
@@ -493,7 +493,7 @@
           "step": 4
         },
         {
-          "expr": "avg by (component) (go_memstats_stack_inuse_bytes{app=~\"open-match\", kubernetes_pod_name=~\"om-.*\"})",
+          "expr": "avg by (component) (go_memstats_stack_inuse_bytes{app=~\"open-match\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{component}} - stack inuse",
@@ -502,7 +502,7 @@
           "step": 4
         },
         {
-          "expr": "avg by (component) (go_memstats_heap_inuse_bytes{app=~\"open-match\", kubernetes_pod_name=~\"om-.*\"})",
+          "expr": "avg by (component) (go_memstats_heap_inuse_bytes{app=~\"open-match\"})",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -604,7 +604,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg by (component) (deriv(go_memstats_alloc_bytes{app=~\"open-match\", kubernetes_pod_name=~\"om-.*\"}[$interval]))",
+          "expr": "avg by (component) (deriv(go_memstats_alloc_bytes{app=~\"open-match\"}[$interval]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{component}} - bytes allocated",
@@ -613,7 +613,7 @@
           "step": 4
         },
         {
-          "expr": "avg by (component) (deriv(go_memstats_stack_inuse_bytes{app=~\"open-match\", kubernetes_pod_name=~\"om-.*\"}[$interval]))",
+          "expr": "avg by (component) (deriv(go_memstats_stack_inuse_bytes{app=~\"open-match\"}[$interval]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{component}} - stack inuse",
@@ -622,7 +622,7 @@
           "step": 4
         },
         {
-          "expr": "avg by (component) (deriv(go_memstats_heap_inuse_bytes{app=~\"open-match\", kubernetes_pod_name=~\"om-.*\"}[$interval]))",
+          "expr": "avg by (component) (deriv(go_memstats_heap_inuse_bytes{app=~\"open-match\"}[$interval]))",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 2,
@@ -719,7 +719,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg by (component) (process_open_fds{app=~\"open-match\", kubernetes_pod_name=~\"om-.*\"})",
+          "expr": "avg by (component) (process_open_fds{app=~\"open-match\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{component}}",
@@ -815,7 +815,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg by (component) (deriv(process_open_fds{app=~\"open-match\", kubernetes_pod_name=~\"om-.*\"}[$interval]))",
+          "expr": "avg by (component) (deriv(process_open_fds{app=~\"open-match\"}[$interval]))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{component}}",
@@ -911,7 +911,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg by (component, quantile) (go_gc_duration_seconds{app=~\"open-match\", kubernetes_pod_name=~\"om-.*\"})",
+          "expr": "avg by (component, quantile) (go_gc_duration_seconds{app=~\"open-match\"})",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{component}}: {{quantile}}",

--- a/install/helm/open-match/subcharts/open-match-telemetry/dashboards/redis.json
+++ b/install/helm/open-match/subcharts/open-match-telemetry/dashboards/redis.json
@@ -348,14 +348,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(container_cpu_usage_seconds_total{pod_name=~\"om-redis.*\", name!~\".*prometheus.*\", image!=\"\", container_name!=\"POD\"}[5m])) by (pod_name)",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{name!~\".*prometheus.*\", image!=\"\", container_name!=\"POD\"}[5m]) * on (pod_name) group_left(label_app) max by (pod_name, label_app) (label_replace(kube_pod_labels{label_app=\"redis\"}, \"pod_name\", \"$1\", \"pod\", \"(.*)\"))) by (pod_name)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{pod_name}} usage",
           "refId": "A"
         },
         {
-          "expr": "sum(kube_pod_container_resource_limits_cpu_cores{pod=~\"om-redis.*\"}) by (pod)",
+          "expr": "sum(kube_pod_container_resource_limits_cpu_cores * on (pod) group_left(label_app) max by (pod, label_app) (kube_pod_labels{label_app=\"redis\"})) by (pod)",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 1,
@@ -363,7 +363,7 @@
           "refId": "B"
         },
         {
-          "expr": "sum(kube_pod_container_resource_requests_cpu_cores{pod=~\"om-redis.*\"}) by (pod)",
+          "expr": "sum(kube_pod_container_resource_requests_cpu_cores * on (pod) group_left(label_app) max by (pod, label_app) (kube_pod_labels{label_app=\"redis\"})) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "request",

--- a/install/helm/open-match/subcharts/open-match-telemetry/templates/default-grafana-dashboards.yaml
+++ b/install/helm/open-match/subcharts/open-match-telemetry/templates/default-grafana-dashboards.yaml
@@ -16,7 +16,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: open-match-dashboards
+  name: {{ include "openmatch.fullname" . }}-dashboards
   labels:
      grafana_dashboard: "1"
 data:

--- a/install/helm/open-match/subcharts/open-match-telemetry/templates/default-grafana-datasource.yaml
+++ b/install/helm/open-match/subcharts/open-match-telemetry/templates/default-grafana-datasource.yaml
@@ -1,0 +1,31 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{- if .Values.global.telemetry.grafana.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "openmatch.fullname" . }}-datasource
+  labels:
+     grafana_datasource: "1"
+data:
+    datasource.yaml: |-
+      apiVersion: 1
+      datasources:
+      - name: Prometheus
+        type: prometheus
+        url: {{ tpl .Values.global.telemetry.grafana.prometheusServer . }}
+        access: proxy
+        isDefault: true
+{{- end }}

--- a/install/helm/open-match/subcharts/open-match-telemetry/values.yaml
+++ b/install/helm/open-match/subcharts/open-match-telemetry/values.yaml
@@ -142,17 +142,10 @@ grafana:
   notifiers: {}
   sidecar:
     dashboards:
-        enabled: true
+      enabled: true
+    datasources:
+      enabled: true
   plugins: grafana-piechart-panel
-  datasources:
-    datasources.yaml:
-      apiVersion: 1
-      datasources:
-      - name: Prometheus
-        type: prometheus
-        url: http://open-match-prometheus-server.{{ .Release.Namespace }}.svc.cluster.local:80/
-        access: proxy
-        isDefault: true
 
 jaeger:
   enabled: true

--- a/install/helm/open-match/templates/_helpers.tpl
+++ b/install/helm/open-match/templates/_helpers.tpl
@@ -192,6 +192,22 @@ targetCPUUtilizationPercentage: {{ .Values.global.kubernetes.horizontalPodAutoSc
 {{- printf "%s-configmap-override" (include "openmatch.fullname" . ) -}}
 {{- end -}}
 
+{{- define "openmatch.jaeger.agent" -}}
+{{- if index .Values "open-match-telemetry" "enabled" -}}
+{{- if index .Values "open-match-telemetry" "jaeger" "enabled" -}}
+{{ include "call-nested" (list . "open-match-telemetry.jaeger" "jaeger.agent.name") }}:6831
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "openmatch.jaeger.collector" -}}
+{{- if index .Values "open-match-telemetry" "enabled" -}}
+{{- if index .Values "open-match-telemetry" "jaeger" "enabled" -}}
+http://{{ include "call-nested" (list . "open-match-telemetry.jaeger" "jaeger.collector.name") }}:14268/api/traces
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
 {{/*
 Call templates from sub-charts in a synthesized context, workaround for https://github.com/helm/helm/issues/3920
 Mainly useful for things like `{{ include "call-nested" (list . "redis" "redis.fullname") }}`

--- a/install/helm/open-match/templates/_helpers.tpl
+++ b/install/helm/open-match/templates/_helpers.tpl
@@ -94,10 +94,10 @@ resources:
 {{- if .Values.global.tls.enabled }}
 - name: tls-server-volume
   secret:
-    secretName: om-tls-server
+    secretName: {{ include "openmatch.fullname" . }}-tls-server
 - name: root-ca-volume
   secret:
-    secretName: om-tls-rootca
+    secretName: {{ include "openmatch.fullname" . }}-tls-rootca
 {{- end -}}
 {{- end -}}
 

--- a/install/helm/open-match/templates/_helpers.tpl
+++ b/install/helm/open-match/templates/_helpers.tpl
@@ -23,6 +23,24 @@ Expand the name of the chart.
 {{- end -}}
 
 {{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "openmatch.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
 Render chart metadata labels: "chart", "heritage" unless "openmatch.noChartMeta" is set.
 */}}
 {{- define "openmatch.chartmeta" -}}

--- a/install/helm/open-match/templates/_helpers.tpl
+++ b/install/helm/open-match/templates/_helpers.tpl
@@ -26,12 +26,14 @@ Expand the name of the chart.
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
+Instead of .Chart.Name, we hard-code "open-match" as we need to call this from subcharts, but get the
+same result as if called from this chart.
 */}}
 {{- define "openmatch.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- $name := default "open-match" .Values.nameOverride }}
 {{- if contains $name .Release.Name }}
 {{- .Release.Name | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -152,6 +154,10 @@ readinessProbe:
 minReplicas: {{ .Values.global.kubernetes.horizontalPodAutoScaler.minReplicas }}
 maxReplicas: {{ .Values.global.kubernetes.horizontalPodAutoScaler.maxReplicas }}
 targetCPUUtilizationPercentage: {{ .Values.global.kubernetes.horizontalPodAutoScaler.targetCPUUtilizationPercentage }}
+{{- end -}}
+
+{{- define "openmatch.serviceAccount.name" -}}
+{{- .Values.global.kubernetes.serviceAccount | default (printf "%s-unprivileged-service" (include "openmatch.fullname" . ) ) -}}
 {{- end -}}
 
 {{/*

--- a/install/helm/open-match/templates/_helpers.tpl
+++ b/install/helm/open-match/templates/_helpers.tpl
@@ -160,6 +160,30 @@ targetCPUUtilizationPercentage: {{ .Values.global.kubernetes.horizontalPodAutoSc
 {{- .Values.global.kubernetes.serviceAccount | default (printf "%s-unprivileged-service" (include "openmatch.fullname" . ) ) -}}
 {{- end -}}
 
+{{- define "openmatch.swaggerui.hostName" -}}
+{{- .Values.swaggerui.hostName | default (printf "%s-swaggerui" (include "openmatch.fullname" . ) ) -}}
+{{- end -}}
+
+{{- define "openmatch.query.hostName" -}}
+{{- .Values.query.hostName | default (printf "%s-query" (include "openmatch.fullname" . ) ) -}}
+{{- end -}}
+
+{{- define "openmatch.frontend.hostName" -}}
+{{- .Values.frontend.hostName | default (printf "%s-frontend" (include "openmatch.fullname" . ) ) -}}
+{{- end -}}
+
+{{- define "openmatch.backend.hostName" -}}
+{{- .Values.backend.hostName | default (printf "%s-backend" (include "openmatch.fullname" . ) ) -}}
+{{- end -}}
+
+{{- define "openmatch.synchronizer.hostName" -}}
+{{- .Values.synchronizer.hostName | default (printf "%s-synchronizer" (include "openmatch.fullname" . ) ) -}}
+{{- end -}}
+
+{{- define "openmatch.evaluator.hostName" -}}
+{{- .Values.evaluator.hostName | default (printf "%s-evaluator" (include "openmatch.fullname" . ) ) -}}
+{{- end -}}
+
 {{/*
 Call templates from sub-charts in a synthesized context, workaround for https://github.com/helm/helm/issues/3920
 Mainly useful for things like `{{ include "call-nested" (list . "redis" "redis.fullname") }}`

--- a/install/helm/open-match/templates/_helpers.tpl
+++ b/install/helm/open-match/templates/_helpers.tpl
@@ -77,7 +77,7 @@ resources:
 {{- range $configIndex, $configValues := .configs }}
 - name: {{ $configValues.volumeName }}
   configMap:
-    name: {{ $configValues.configName }}
+    name: {{ tpl $configValues.configName $ }}
 {{- end }}
 {{- end -}}
 
@@ -182,6 +182,14 @@ targetCPUUtilizationPercentage: {{ .Values.global.kubernetes.horizontalPodAutoSc
 
 {{- define "openmatch.evaluator.hostName" -}}
 {{- .Values.evaluator.hostName | default (printf "%s-evaluator" (include "openmatch.fullname" . ) ) -}}
+{{- end -}}
+
+{{- define "openmatch.configmap.default" -}}
+{{- printf "%s-configmap-default" (include "openmatch.fullname" . ) -}}
+{{- end -}}
+
+{{- define "openmatch.configmap.override" -}}
+{{- printf "%s-configmap-override" (include "openmatch.fullname" . ) -}}
 {{- end -}}
 
 {{/*

--- a/install/helm/open-match/templates/backend.yaml
+++ b/install/helm/open-match/templates/backend.yaml
@@ -85,7 +85,7 @@ spec:
         {{- include "openmatch.volumes.configs" (dict "configs" .Values.configs) | nindent 8}}
         {{- include "openmatch.volumes.tls" . | nindent 8}}
         {{- include "openmatch.volumes.withredis" . | nindent 8}}
-      serviceAccountName: {{ .Values.global.kubernetes.serviceAccount }}
+      serviceAccountName: {{ include "openmatch.serviceAccount.name" . }}
       containers:
       - name: {{ .Values.backend.hostName }}
         volumeMounts:

--- a/install/helm/open-match/templates/backend.yaml
+++ b/install/helm/open-match/templates/backend.yaml
@@ -16,7 +16,7 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: {{ .Values.backend.hostName }}
+  name: {{ include "openmatch.backend.hostName" . }}
   namespace: {{ .Release.Namespace }}
   annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
   labels:
@@ -44,19 +44,19 @@ spec:
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ .Values.backend.hostName }}
+  name: {{ include "openmatch.backend.hostName" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ .Values.backend.hostName }}
+    name: {{ include "openmatch.backend.hostName" . }}
   {{- include "openmatch.HorizontalPodAutoscaler.spec.common" . | nindent 2 }}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.backend.hostName }}
+  name: {{ include "openmatch.backend.hostName" . }}
   namespace: {{ .Release.Namespace }}
   annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
   labels:
@@ -87,7 +87,7 @@ spec:
         {{- include "openmatch.volumes.withredis" . | nindent 8}}
       serviceAccountName: {{ include "openmatch.serviceAccount.name" . }}
       containers:
-      - name: {{ .Values.backend.hostName }}
+      - name: {{ include "openmatch.backend.hostName" . }}
         volumeMounts:
           {{- include "openmatch.volumemounts.configs" (dict "configs" .Values.configs) | nindent 10 }}
           {{- include "openmatch.volumemounts.tls" . | nindent 10 }}

--- a/install/helm/open-match/templates/backend.yaml
+++ b/install/helm/open-match/templates/backend.yaml
@@ -82,7 +82,7 @@ spec:
     spec:
       {{- include "openmatch.labels.nodegrouping" . | nindent 6 }}
       volumes:
-        {{- include "openmatch.volumes.configs" (dict "configs" .Values.configs) | nindent 8}}
+        {{- include "openmatch.volumes.configs" (. | merge (dict "configs" .Values.configs)) | nindent 8}}
         {{- include "openmatch.volumes.tls" . | nindent 8}}
         {{- include "openmatch.volumes.withredis" . | nindent 8}}
       serviceAccountName: {{ include "openmatch.serviceAccount.name" . }}

--- a/install/helm/open-match/templates/frontend.yaml
+++ b/install/helm/open-match/templates/frontend.yaml
@@ -16,7 +16,7 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: {{ .Values.frontend.hostName }}
+  name: {{ include "openmatch.frontend.hostName" . }}
   namespace: {{ .Release.Namespace }}
   annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
   labels:
@@ -44,19 +44,19 @@ spec:
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ .Values.frontend.hostName }}
+  name: {{ include "openmatch.frontend.hostName" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ .Values.frontend.hostName }}
+    name: {{ include "openmatch.frontend.hostName" . }}
   {{- include "openmatch.HorizontalPodAutoscaler.spec.common" . | nindent 2 }}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.frontend.hostName }}
+  name: {{ include "openmatch.frontend.hostName" . }}
   namespace: {{ .Release.Namespace }}
   annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
   labels:
@@ -87,7 +87,7 @@ spec:
         {{- include "openmatch.volumes.withredis" . | nindent 8}}
       serviceAccountName: {{ include "openmatch.serviceAccount.name" . }}
       containers:
-      - name: {{ .Values.frontend.hostName }}
+      - name: {{ include "openmatch.frontend.hostName" . }}
         volumeMounts:
           {{- include "openmatch.volumemounts.configs" (dict "configs" .Values.configs) | nindent 10 }}
           {{- include "openmatch.volumemounts.tls" . | nindent 10 }}

--- a/install/helm/open-match/templates/frontend.yaml
+++ b/install/helm/open-match/templates/frontend.yaml
@@ -82,7 +82,7 @@ spec:
     spec:
       {{- include "openmatch.labels.nodegrouping" . | nindent 6 }}
       volumes:
-        {{- include "openmatch.volumes.configs" (dict "configs" .Values.configs) | nindent 8}}
+        {{- include "openmatch.volumes.configs" (. | merge (dict "configs" .Values.configs)) | nindent 8}}
         {{- include "openmatch.volumes.tls" . | nindent 8}}
         {{- include "openmatch.volumes.withredis" . | nindent 8}}
       serviceAccountName: {{ include "openmatch.serviceAccount.name" . }}

--- a/install/helm/open-match/templates/frontend.yaml
+++ b/install/helm/open-match/templates/frontend.yaml
@@ -85,7 +85,7 @@ spec:
         {{- include "openmatch.volumes.configs" (dict "configs" .Values.configs) | nindent 8}}
         {{- include "openmatch.volumes.tls" . | nindent 8}}
         {{- include "openmatch.volumes.withredis" . | nindent 8}}
-      serviceAccountName: {{ .Values.global.kubernetes.serviceAccount }}
+      serviceAccountName: {{ include "openmatch.serviceAccount.name" . }}
       containers:
       - name: {{ .Values.frontend.hostName }}
         volumeMounts:

--- a/install/helm/open-match/templates/om-configmap-default.yaml
+++ b/install/helm/open-match/templates/om-configmap-default.yaml
@@ -50,23 +50,23 @@ data:
 
     api:
       backend:
-        hostname: "{{ .Values.backend.hostName }}"
+        hostname: "{{ include "openmatch.backend.hostName" . }}"
         grpcport: "{{ .Values.backend.grpcPort }}"
         httpport: "{{ .Values.backend.httpPort }}"
       frontend:
-        hostname: "{{ .Values.frontend.hostName }}"
+        hostname: "{{ include "openmatch.frontend.hostName" . }}"
         grpcport: "{{ .Values.frontend.grpcPort }}"
         httpport: "{{ .Values.frontend.httpPort }}"
       query:
-        hostname: "{{ .Values.query.hostName }}"
+        hostname: "{{ include "openmatch.query.hostName" . }}"
         grpcport: "{{ .Values.query.grpcPort }}"
         httpport: "{{ .Values.query.httpPort }}"
       synchronizer:
-        hostname: "{{ .Values.synchronizer.hostName }}"
+        hostname: "{{ include "openmatch.synchronizer.hostName" . }}"
         grpcport: "{{ .Values.synchronizer.grpcPort }}"
         httpport: "{{ .Values.synchronizer.httpPort }}"
       swaggerui:
-        hostname: "{{ .Values.swaggerui.hostName }}"
+        hostname: "{{ include "openmatch.swaggerui.hostName" . }}"
         httpport: "{{ .Values.swaggerui.httpPort }}"
 
       # Configurations for api.test and api.scale are used for testing.

--- a/install/helm/open-match/templates/om-configmap-default.yaml
+++ b/install/helm/open-match/templates/om-configmap-default.yaml
@@ -16,7 +16,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: om-configmap-default
+  name: {{ include "openmatch.configmap.default" . }}
   namespace: {{ .Release.Namespace }}
   annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
   labels:

--- a/install/helm/open-match/templates/om-configmap-default.yaml
+++ b/install/helm/open-match/templates/om-configmap-default.yaml
@@ -119,8 +119,8 @@ data:
         enable: "{{ .Values.global.telemetry.zpages.enabled }}"
       jaeger:
         enable: "{{ .Values.global.telemetry.jaeger.enabled }}"
-        agentEndpoint: "{{ .Values.global.telemetry.jaeger.agentEndpoint }}"
-        collectorEndpoint: "{{ .Values.global.telemetry.jaeger.collectorEndpoint }}"
+        agentEndpoint: "{{ tpl .Values.global.telemetry.jaeger.agentEndpoint . }}"
+        collectorEndpoint: "{{ tpl .Values.global.telemetry.jaeger.collectorEndpoint . }}"
       prometheus:
         enable: "{{ .Values.global.telemetry.prometheus.enabled }}"
         endpoint: "{{ .Values.global.telemetry.prometheus.endpoint }}"

--- a/install/helm/open-match/templates/om-configmap-default.yaml
+++ b/install/helm/open-match/templates/om-configmap-default.yaml
@@ -90,11 +90,11 @@ data:
 {{- if index .Values "redis" "sentinel" "enabled"}}
       sentinelPort: {{ .Values.redis.sentinel.port }}
       sentinelMaster: {{ .Values.redis.sentinel.masterSet }}
-      sentinelHostname: {{ .Values.redis.fullnameOverride }}
+      sentinelHostname: {{ include "call-nested" (list . "redis" "redis.fullname") }}
       sentinelUsePassword: {{ .Values.redis.sentinel.usePassword }}
 {{- else}}
       # Open Match's default Redis setups
-      hostname: {{ .Values.redis.fullnameOverride }}-master.{{ .Release.Namespace }}.svc.cluster.local
+      hostname: {{ include "call-nested" (list . "redis" "redis.fullname") }}-master.{{ .Release.Namespace }}.svc.cluster.local
       port: {{ .Values.redis.redisPort }}
       user: {{ .Values.redis.user }}
 {{- end}}

--- a/install/helm/open-match/templates/om-configmap-default.yaml
+++ b/install/helm/open-match/templates/om-configmap-default.yaml
@@ -71,7 +71,7 @@ data:
 
       # Configurations for api.test and api.scale are used for testing.
       test:
-        hostname: "test"
+        hostname: "{{ include "openmatch.fullname" . }}-test"
         grpcport: "50509"
         httpport: "51509"
       scale:

--- a/install/helm/open-match/templates/om-configmap-override.yaml
+++ b/install/helm/open-match/templates/om-configmap-override.yaml
@@ -42,7 +42,7 @@ data:
     queryPageSize: {{ index .Values "open-match-core" "queryPageSize" }}
     api:
       evaluator:
-        hostname: "{{ .Values.evaluator.hostName }}"
+        hostname: "{{ include "openmatch.evaluator.hostName" . }}"
         grpcport: "{{ .Values.evaluator.grpcPort }}"
         httpport: "{{ .Values.evaluator.httpPort }}"
 {{- end }}

--- a/install/helm/open-match/templates/om-configmap-override.yaml
+++ b/install/helm/open-match/templates/om-configmap-override.yaml
@@ -16,7 +16,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: om-configmap-override
+  name: {{ include "openmatch.configmap.override" . }}
   namespace: {{ .Release.Namespace }}
   annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
   labels:

--- a/install/helm/open-match/templates/podsecuritypolicy.yaml
+++ b/install/helm/open-match/templates/podsecuritypolicy.yaml
@@ -14,11 +14,11 @@
 
 {{- if index .Values "open-match-core" "enabled" }}
 {{- if empty .Values.ci }}
-# om-redis-podsecuritypolicy is the least restricted PSP used to create privileged pods to disable THP in host kernel.
+# This is the least restricted PSP used to create privileged pods to disable THP in host kernel.
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: om-redis-podsecuritypolicy
+  name: {{ include "openmatch.fullname" . }}-redis-podsecuritypolicy
   namespace: {{ .Release.Namespace }}
   annotations:
     {{- include "openmatch.chartmeta" . | nindent 4 }}
@@ -51,11 +51,11 @@ spec:
   fsGroup:
     rule: 'RunAsAny'
 ---
-# om-core-podsecuritypolicy does not allow creating privileged pods and restrict binded pods to use the specified port ranges.
+# This does not allow creating privileged pods and restrict binded pods to use the specified port ranges.
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: om-core-podsecuritypolicy
+  name: {{ include "openmatch.fullname" . }}-core-podsecuritypolicy
   namespace: {{ .Release.Namespace }}
   annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
   labels:

--- a/install/helm/open-match/templates/query.yaml
+++ b/install/helm/open-match/templates/query.yaml
@@ -16,7 +16,7 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: {{ .Values.query.hostName }}
+  name: {{ include "openmatch.query.hostName" . }}
   namespace: {{ .Release.Namespace }}
   annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
   labels:
@@ -44,19 +44,19 @@ spec:
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ .Values.query.hostName }}
+  name: {{ include "openmatch.query.hostName" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ .Values.query.hostName }}
+    name: {{ include "openmatch.query.hostName" . }}
   {{- include "openmatch.HorizontalPodAutoscaler.spec.common" . | nindent 2 }}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.query.hostName }}
+  name: {{ include "openmatch.query.hostName" . }}
   namespace: {{ .Release.Namespace }}
   annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
   labels:
@@ -87,7 +87,7 @@ spec:
         {{- include "openmatch.volumes.withredis" . | nindent 8 }}
       serviceAccountName: {{ include "openmatch.serviceAccount.name" . }}
       containers:
-      - name: {{ .Values.query.hostName }}
+      - name: {{ include "openmatch.query.hostName" . }}
         volumeMounts:
           {{- include "openmatch.volumemounts.configs" (dict "configs" .Values.configs) | nindent 10 }}
           {{- include "openmatch.volumemounts.tls" . | nindent 10 }}

--- a/install/helm/open-match/templates/query.yaml
+++ b/install/helm/open-match/templates/query.yaml
@@ -82,7 +82,7 @@ spec:
     spec:
       {{- include "openmatch.labels.nodegrouping" . | nindent 6 }}
       volumes:
-        {{- include "openmatch.volumes.configs" (dict "configs" .Values.configs) | nindent 8}}
+        {{- include "openmatch.volumes.configs" (. | merge (dict "configs" .Values.configs)) | nindent 8}}
         {{- include "openmatch.volumes.tls" . | nindent 8}}
         {{- include "openmatch.volumes.withredis" . | nindent 8 }}
       serviceAccountName: {{ include "openmatch.serviceAccount.name" . }}

--- a/install/helm/open-match/templates/query.yaml
+++ b/install/helm/open-match/templates/query.yaml
@@ -85,7 +85,7 @@ spec:
         {{- include "openmatch.volumes.configs" (dict "configs" .Values.configs) | nindent 8}}
         {{- include "openmatch.volumes.tls" . | nindent 8}}
         {{- include "openmatch.volumes.withredis" . | nindent 8 }}
-      serviceAccountName: {{ .Values.global.kubernetes.serviceAccount }}
+      serviceAccountName: {{ include "openmatch.serviceAccount.name" . }}
       containers:
       - name: {{ .Values.query.hostName }}
         volumeMounts:

--- a/install/helm/open-match/templates/service-account.yaml
+++ b/install/helm/open-match/templates/service-account.yaml
@@ -29,7 +29,7 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.global.kubernetes.serviceAccount }}
+  name: {{ include "openmatch.serviceAccount.name" . }}
   namespace: {{ .Release.Namespace }}
   annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
   labels:

--- a/install/helm/open-match/templates/service-account.yaml
+++ b/install/helm/open-match/templates/service-account.yaml
@@ -40,7 +40,7 @@ automountServiceAccountToken: true
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: om-service-role
+  name: {{ include "openmatch.fullname" . }}-service-role
   namespace: {{ .Release.Namespace }}
   annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
   labels:
@@ -56,11 +56,10 @@ rules:
   verbs:
   - use
 ---
-# This applies om-service-role to the open-match unprivileged service account under the release namespace. 
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: om-service-role-binding
+  name: {{ include "openmatch.fullname" . }}-service-role-binding
   namespace: {{ .Release.Namespace }}
   annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
   labels:
@@ -72,13 +71,13 @@ subjects:
   apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: Role
-  name: om-service-role
+  name: {{ include "openmatch.fullname" . }}-service-role
   apiGroup: rbac.authorization.k8s.io
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: om-redis-role
+  name: {{ include "openmatch.fullname" . }}-redis-role
   namespace: {{ .Release.Namespace }}
   annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
   labels:
@@ -94,11 +93,10 @@ rules:
   verbs:
   - use
 ---
-# This applies om-redis role to the om-redis privileged service account under the release namespace.
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: om-redis-role-binding
+  name: {{ include "openmatch.fullname" . }}-redis-role-binding
   namespace: {{ .Release.Namespace }}
   annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
   labels:
@@ -110,6 +108,6 @@ subjects:
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
-  name: om-redis-role
+  name: {{ include "openmatch.fullname" . }}-redis-role
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/install/helm/open-match/templates/service-account.yaml
+++ b/install/helm/open-match/templates/service-account.yaml
@@ -47,13 +47,12 @@ metadata:
     app: {{ template "openmatch.name" . }}
     release: {{ .Release.Name }}
 rules:
-# Define om-service-role to use om-core-podsecuritypolicy
 - apiGroups:
   - extensions
   resources:
   - podsecuritypolicies
   resourceNames:
-  - om-core-podsecuritypolicy
+  - {{ include "openmatch.fullname" . }}-core-podsecuritypolicy
   verbs:
   - use
 ---
@@ -86,13 +85,12 @@ metadata:
     app: {{ template "openmatch.name" . }}
     release: {{ .Release.Name }}
 rules:
-# Define om-redis-role to use om-redis-podsecuritypolicy
 - apiGroups:
   - extensions
   resources:
   - podsecuritypolicies
   resourceNames:
-  - om-redis-podsecuritypolicy
+  - {{ include "openmatch.fullname" . }}-redis-podsecuritypolicy
   verbs:
   - use
 ---

--- a/install/helm/open-match/templates/service-account.yaml
+++ b/install/helm/open-match/templates/service-account.yaml
@@ -108,7 +108,7 @@ metadata:
     release: {{ .Release.Name }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.redis.serviceAccount.name }} # Redis service account
+  name: {{ include "call-nested" (list . "redis" "redis.serviceAccountName") }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role

--- a/install/helm/open-match/templates/swaggerui.yaml
+++ b/install/helm/open-match/templates/swaggerui.yaml
@@ -61,7 +61,7 @@ spec:
     spec:
       {{- include "openmatch.labels.nodegrouping" . | nindent 6 }}
       volumes:
-        {{- include "openmatch.volumes.configs" (dict "configs" .Values.configs) | nindent 8}}
+        {{- include "openmatch.volumes.configs" (. | merge (dict "configs" .Values.configs)) | nindent 8}}
         {{- include "openmatch.volumes.tls" . | nindent 8}}
       serviceAccountName: {{ include "openmatch.serviceAccount.name" . }}
       containers:

--- a/install/helm/open-match/templates/swaggerui.yaml
+++ b/install/helm/open-match/templates/swaggerui.yaml
@@ -16,7 +16,7 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: {{ .Values.swaggerui.hostName }}
+  name: {{ include "openmatch.swaggerui.hostName" . }}
   namespace: {{ .Release.Namespace }}
   annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
   labels:
@@ -36,7 +36,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.swaggerui.hostName }}
+  name: {{ include "openmatch.swaggerui.hostName" . }}
   namespace: {{ .Release.Namespace }}
   annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
   labels:
@@ -65,7 +65,7 @@ spec:
         {{- include "openmatch.volumes.tls" . | nindent 8}}
       serviceAccountName: {{ include "openmatch.serviceAccount.name" . }}
       containers:
-      - name: {{ .Values.swaggerui.hostName }}
+      - name: {{ include "openmatch.swaggerui.hostName" . }}
         volumeMounts:
           {{- include "openmatch.volumemounts.configs" (dict "configs" .Values.configs) | nindent 10 }}
           {{- include "openmatch.volumemounts.tls" . | nindent 10 }}

--- a/install/helm/open-match/templates/swaggerui.yaml
+++ b/install/helm/open-match/templates/swaggerui.yaml
@@ -63,7 +63,7 @@ spec:
       volumes:
         {{- include "openmatch.volumes.configs" (dict "configs" .Values.configs) | nindent 8}}
         {{- include "openmatch.volumes.tls" . | nindent 8}}
-      serviceAccountName: {{ .Values.global.kubernetes.serviceAccount }}
+      serviceAccountName: {{ include "openmatch.serviceAccount.name" . }}
       containers:
       - name: {{ .Values.swaggerui.hostName }}
         volumeMounts:

--- a/install/helm/open-match/templates/synchronizer.yaml
+++ b/install/helm/open-match/templates/synchronizer.yaml
@@ -69,7 +69,7 @@ spec:
         {{- include "openmatch.volumes.configs" (dict "configs" .Values.configs) | nindent 8}}
         {{- include "openmatch.volumes.tls" . | nindent 8}}
         {{- include "openmatch.volumes.withredis" . | nindent 8 }}
-      serviceAccountName: {{ .Values.global.kubernetes.serviceAccount }}
+      serviceAccountName: {{ include "openmatch.serviceAccount.name" . }}
       containers:
       - name: {{ .Values.synchronizer.hostName }}
         volumeMounts:

--- a/install/helm/open-match/templates/synchronizer.yaml
+++ b/install/helm/open-match/templates/synchronizer.yaml
@@ -16,7 +16,7 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: {{ .Values.synchronizer.hostName }}
+  name: {{ include "openmatch.synchronizer.hostName" . }}
   namespace: {{ .Release.Namespace }}
   annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
   labels:
@@ -40,7 +40,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Values.synchronizer.hostName }}
+  name: {{ include "openmatch.synchronizer.hostName" . }}
   namespace: {{ .Release.Namespace }}
   annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
   labels:
@@ -71,7 +71,7 @@ spec:
         {{- include "openmatch.volumes.withredis" . | nindent 8 }}
       serviceAccountName: {{ include "openmatch.serviceAccount.name" . }}
       containers:
-      - name: {{ .Values.synchronizer.hostName }}
+      - name: {{ include "openmatch.synchronizer.hostName" . }}
         volumeMounts:
           {{- include "openmatch.volumemounts.configs" (dict "configs" .Values.configs) | nindent 10 }}
           {{- include "openmatch.volumemounts.tls" . | nindent 10 }}

--- a/install/helm/open-match/templates/synchronizer.yaml
+++ b/install/helm/open-match/templates/synchronizer.yaml
@@ -66,7 +66,7 @@ spec:
     spec:
       {{- include "openmatch.labels.nodegrouping" . | nindent 6 }}
       volumes:
-        {{- include "openmatch.volumes.configs" (dict "configs" .Values.configs) | nindent 8}}
+        {{- include "openmatch.volumes.configs" (. | merge (dict "configs" .Values.configs)) | nindent 8}}
         {{- include "openmatch.volumes.tls" . | nindent 8}}
         {{- include "openmatch.volumes.withredis" . | nindent 8 }}
       serviceAccountName: {{ include "openmatch.serviceAccount.name" . }}

--- a/install/helm/open-match/templates/tests/om-test-role-binding.yaml
+++ b/install/helm/open-match/templates/tests/om-test-role-binding.yaml
@@ -14,11 +14,10 @@
 
 {{- if .Values.ci }}
 
-# This applies om-test-role to the open-match-test-service account under the release namespace. 
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: om-test-role-binding
+  name: {{ include "openmatch.fullname" . }}-test-role-binding
   namespace: {{ .Release.Namespace }}
   annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
   labels:
@@ -26,11 +25,11 @@ metadata:
     release: {{ .Release.Name }}
 subjects:
 - kind: ServiceAccount
-  name: open-match-test-service
+  name: {{ include "openmatch.fullname" . }}-test-service
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
-  name: om-test-role
+  name: {{ include "openmatch.fullname" . }}-test-role
   apiGroup: rbac.authorization.k8s.io
 
 {{- end }}

--- a/install/helm/open-match/templates/tests/om-test-role.yaml
+++ b/install/helm/open-match/templates/tests/om-test-role.yaml
@@ -24,13 +24,12 @@ metadata:
     app: {{ template "openmatch.name" . }}
     release: {{ .Release.Name }}
 rules:
-# Define om-test-role to use om-core-podsecuritypolicy
 - apiGroups:
   - extensions
   resources:
   - podsecuritypolicies
   resourceNames:
-  - om-core-podsecuritypolicy
+  - {{ include "openmatch.fullname" . }}-core-podsecuritypolicy
   verbs:
   - use
 # Grant om-test-role get & list permission for k8s endpoints and pods resources

--- a/install/helm/open-match/templates/tests/om-test-role.yaml
+++ b/install/helm/open-match/templates/tests/om-test-role.yaml
@@ -17,7 +17,7 @@
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: om-test-role
+  name: {{ include "openmatch.fullname" . }}-test-role
   namespace: {{ .Release.Namespace }}
   annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
   labels:
@@ -32,7 +32,7 @@ rules:
   - {{ include "openmatch.fullname" . }}-core-podsecuritypolicy
   verbs:
   - use
-# Grant om-test-role get & list permission for k8s endpoints and pods resources
+# Grant this role get & list permission for k8s endpoints and pods resources
 # Required for e2e in-cluster testing.
 - apiGroups:
   - ""

--- a/install/helm/open-match/templates/tests/om-test-service-account.yaml
+++ b/install/helm/open-match/templates/tests/om-test-service-account.yaml
@@ -14,11 +14,11 @@
 
 {{- if .Values.ci }}
 
-# Create a service account for open-match-test services.
+# Create a service account for test services.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: open-match-test-service
+  name: {{ include "openmatch.fullname" . }}-test-service
   namespace: {{ .Release.Namespace }}
   annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
   labels:

--- a/install/helm/open-match/templates/tests/om-test.yaml
+++ b/install/helm/open-match/templates/tests/om-test.yaml
@@ -17,7 +17,7 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: test
+  name: {{ include "openmatch.fullname" . }}-test
   namespace: {{ .Release.Namespace }}
   annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
   labels:
@@ -40,7 +40,7 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
-  name: test
+  name: {{ include "openmatch.fullname" . }}-test
   namespace: {{ .Release.Namespace }}
   annotations: 
     {{- include "openmatch.chartmeta" . | nindent 4 }}
@@ -52,7 +52,7 @@ metadata:
 spec:
   # Specifies the duration in seconds relative to the startTime that the job may be active before the system tries to terminate it.
   activeDeadlineSeconds: 900
-  serviceAccountName: open-match-test-service
+  serviceAccountName: {{ include "openmatch.fullname" . }}-test-service
   automountServiceAccountToken: true
   volumes:
   - configMap:
@@ -64,7 +64,7 @@ spec:
       name: om-configmap-override
     name: om-config-volume-override
   containers:
-  - name: "test"
+  - name: {{ include "openmatch.fullname" . }}-test
     volumeMounts:
     - mountPath: /app/config/default
       name: om-config-volume-default

--- a/install/helm/open-match/templates/tests/om-test.yaml
+++ b/install/helm/open-match/templates/tests/om-test.yaml
@@ -57,11 +57,11 @@ spec:
   volumes:
   - configMap:
       defaultMode: 420
-      name: om-configmap-default
+      name: {{ include "openmatch.configmap.default" . }}
     name: om-config-volume-default
   - configMap:
       defaultMode: 420
-      name: om-configmap-override
+      name: {{ include "openmatch.configmap.override" . }}
     name: om-config-volume-override
   containers:
   - name: {{ include "openmatch.fullname" . }}-test

--- a/install/helm/open-match/templates/tls-secret.yaml
+++ b/install/helm/open-match/templates/tls-secret.yaml
@@ -33,7 +33,7 @@ kind: Secret
 metadata:
   name: om-tls-server
   namespace: {{ .Release.Namespace }}
-  annotations: {{- include "openmatch.chartmeta" . | nindent 2 }}
+  annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
   labels:
     app: {{ template "openmatch.name" . }}
     component: tls

--- a/install/helm/open-match/templates/tls-secret.yaml
+++ b/install/helm/open-match/templates/tls-secret.yaml
@@ -17,7 +17,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: om-tls-rootca
+  name: {{ include "openmatch.fullname" . }}-tls-rootca
   namespace: {{ .Release.Namespace }}
   annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
   labels:
@@ -31,7 +31,7 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: om-tls-server
+  name: {{ include "openmatch.fullname" . }}-tls-server
   namespace: {{ .Release.Namespace }}
   annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
   labels:

--- a/install/helm/open-match/values-production.yaml
+++ b/install/helm/open-match/values-production.yaml
@@ -282,8 +282,8 @@ global:
       enabled: true
     jaeger:
       enabled: false
-      agentEndpoint: "open-match-jaeger-agent:6831"
-      collectorEndpoint: "http://open-match-jaeger-collector:14268/api/traces"
+      agentEndpoint: '{{ include "openmatch.jaeger.agent" . }}'
+      collectorEndpoint: '{{ include "openmatch.jaeger.collector" . }}'
     prometheus:
       enabled: false
       endpoint: "/metrics"

--- a/install/helm/open-match/values-production.yaml
+++ b/install/helm/open-match/values-production.yaml
@@ -222,7 +222,6 @@ open-match-customize:
   enabled: false
   evaluator: *evaluator
   function: *function
-  query: *query
   # You can override the evaluator/mmf image
   # evaluator:
   #   image: [YOUR_EVALUATOR_IMAGE]

--- a/install/helm/open-match/values-production.yaml
+++ b/install/helm/open-match/values-production.yaml
@@ -208,8 +208,6 @@ open-match-core:
 open-match-scale:
   # Switch the value between true/false to turn on/off this subchart
   enabled: false
-  frontend: *frontend
-  backend: *backend
 
 # Controls if users need to install the monitoring tools in Open Match.
 open-match-telemetry:

--- a/install/helm/open-match/values-production.yaml
+++ b/install/helm/open-match/values-production.yaml
@@ -244,8 +244,8 @@ global:
       limits:
         memory: 3Gi
         cpu: 2
-    # Defines a service account which provides an identity for processes that run in a Pod in Open Match.
-    serviceAccount: open-match-unprivileged-service
+    # Overrides the name of the service account which provides an identity for processes that run in a Pod in Open Match.
+    serviceAccount:
     # Use this field if you need to override the port type for all services defined in this chart
     service:
       portType:

--- a/install/helm/open-match/values-production.yaml
+++ b/install/helm/open-match/values-production.yaml
@@ -94,11 +94,13 @@ configs:
   default:
     volumeName: om-config-volume-default
     mountPath: /app/config/default
-    configName: om-configmap-default
+    # This will be parsed through the `tpl` function.
+    configName: '{{ include "openmatch.configmap.default" . }}'
   override:
     volumeName: om-config-volume-override
     mountPath: /app/config/override
-    configName: om-configmap-override
+    # This will be parsed through the `tpl` function.
+    configName: '{{ include "openmatch.configmap.override" . }}'
 
 # Override Redis settings
 # https://hub.helm.sh/charts/stable/redis

--- a/install/helm/open-match/values-production.yaml
+++ b/install/helm/open-match/values-production.yaml
@@ -104,7 +104,6 @@ configs:
 # https://hub.helm.sh/charts/stable/redis
 # https://github.com/helm/charts/tree/master/stable/redis
 redis:
-  fullnameOverride: om-redis
   redisPort: 6379
   usePassword: false
   usePasswordFile: false
@@ -133,7 +132,6 @@ redis:
     slaveCount: 3
   serviceAccount:
     create: true
-    name: open-match-redis-service
   slave:
     persistence:
       enabled: false

--- a/install/helm/open-match/values-production.yaml
+++ b/install/helm/open-match/values-production.yaml
@@ -23,7 +23,7 @@
 # Begins the configuration section for `query` component in Open Match.
 # query:
 #
-#   # Specifies om-query as the in-cluster domain name for the `query` service.
+#   # Override the default in-cluster domain name for the `query` service to om-query.
 #   hostName: om-query
 #
 #   # Specifies the port for receiving RESTful HTTP requests in the `query` service.
@@ -44,46 +44,46 @@
 #   # Specifies the image name to be used in a Kubernetes pod for `query` compoenent.
 #   image: openmatch-query
 swaggerui: &swaggerui
-  hostName: om-swaggerui
+  hostName:
   httpPort: 51500
   portType: ClusterIP
   replicas: 1
   image: openmatch-swaggerui
 query: &query
-  hostName: om-query
+  hostName:
   grpcPort: 50503
   httpPort: 51503
   portType: ClusterIP
   replicas: 3
   image: openmatch-query
 frontend: &frontend
-  hostName: om-frontend
+  hostName:
   grpcPort: 50504
   httpPort: 51504
   portType: ClusterIP
   replicas: 3
   image: openmatch-frontend
 backend: &backend
-  hostName: om-backend
+  hostName:
   grpcPort: 50505
   httpPort: 51505
   portType: ClusterIP
   replicas: 3
   image: openmatch-backend
 synchronizer: &synchronizer
-  hostName: om-synchronizer
+  hostName:
   grpcPort: 50506
   httpPort: 51506
   portType: ClusterIP
   replicas: 1
   image: openmatch-synchronizer
 evaluator: &evaluator
-  hostName: om-evaluator
+  hostName:
   grpcPort: 50508
   httpPort: 51508
   replicas: 3
 function: &function
-  hostName: om-function
+  hostName:
   grpcPort: 50502
   httpPort: 51502
   replicas: 3

--- a/install/helm/open-match/values-production.yaml
+++ b/install/helm/open-match/values-production.yaml
@@ -89,7 +89,7 @@ function: &function
   replicas: 3
 
 # Specifies the location and name of the Open Match application-level config volumes.
-  # Used in template: `openmatch.volumemounts.configs` and `openmatch.volumes.configs` under `templates/_helpers.tpl` file.
+# Used in template: `openmatch.volumemounts.configs` and `openmatch.volumes.configs` under `templates/_helpers.tpl` file.
 configs:
   default:
     volumeName: om-config-volume-default
@@ -174,7 +174,7 @@ open-match-core:
   enabled: true
 
   # Length of time between first fetch matches call, and when no further fetch
-  # matches calls will join the current evaluation/synchronization cycle, 
+  # matches calls will join the current evaluation/synchronization cycle,
   # instead waiting for the next cycle.
   registrationInterval: 250ms
   # Length of time after match function as started before it will be canceled,
@@ -195,7 +195,7 @@ open-match-core:
     # Otherwise the default is set to the om-redis instance.
     hostname: # Your redis server address
     port: 6379
-    user: 
+    user:
     pool:
       maxIdle: 500
       maxActive: 500
@@ -274,7 +274,6 @@ global:
     registry: gcr.io/open-match-public-images
     tag: 0.0.0-dev
     pullPolicy: Always
-
 
   # Expose the telemetry configurations to all subcharts because prometheus, for example,
   # requires pod-level annotation to customize its scrape path.

--- a/install/helm/open-match/values.yaml
+++ b/install/helm/open-match/values.yaml
@@ -267,8 +267,8 @@ global:
       enabled: true
     jaeger:
       enabled: false
-      agentEndpoint: "open-match-jaeger-agent:6831"
-      collectorEndpoint: "http://open-match-jaeger-collector:14268/api/traces"
+      agentEndpoint: '{{ include "openmatch.jaeger.agent" . }}'
+      collectorEndpoint: '{{ include "openmatch.jaeger.collector" . }}'
     prometheus:
       enabled: false
       endpoint: "/metrics"

--- a/install/helm/open-match/values.yaml
+++ b/install/helm/open-match/values.yaml
@@ -193,8 +193,6 @@ open-match-core:
 open-match-scale:
   # Switch the value between true/false to turn on/off this subchart
   enabled: false
-  frontend: *frontend
-  backend: *backend
 
 # Controls if users need to install the monitoring tools in Open Match.
 open-match-telemetry:

--- a/install/helm/open-match/values.yaml
+++ b/install/helm/open-match/values.yaml
@@ -278,3 +278,5 @@ global:
       prefix: "open_match"
     grafana:
       enabled: false
+      # This will be called with `tpl` in the open-match-telemetry subchart namespace.
+      prometheusServer: 'http://{{ include "call-nested" (list . "prometheus" "prometheus.server.fullname") }}.{{ .Release.Namespace }}.svc.cluster.local:80/'

--- a/install/helm/open-match/values.yaml
+++ b/install/helm/open-match/values.yaml
@@ -159,7 +159,7 @@ open-match-core:
   enabled: true
 
   # Length of time between first fetch matches call, and when no further fetch
-  # matches calls will join the current evaluation/synchronization cycle, 
+  # matches calls will join the current evaluation/synchronization cycle,
   # instead waiting for the next cycle.
   registrationInterval: 250ms
   # Length of time after match function as started before it will be canceled,
@@ -180,7 +180,7 @@ open-match-core:
     # Otherwise the default is set to the om-redis instance.
     hostname: # Your redis server address
     port: 6379
-    user: 
+    user:
     pool:
       maxIdle: 200
       maxActive: 0
@@ -259,7 +259,6 @@ global:
     registry: gcr.io/open-match-public-images
     tag: 0.0.0-dev
     pullPolicy: Always
-
 
   # Expose the telemetry configurations to all subcharts because prometheus, for example,
   # requires pod-level annotation to customize its scrape path.

--- a/install/helm/open-match/values.yaml
+++ b/install/helm/open-match/values.yaml
@@ -94,11 +94,13 @@ configs:
   default:
     volumeName: om-config-volume-default
     mountPath: /app/config/default
-    configName: om-configmap-default
+    # This will be parsed through the `tpl` function.
+    configName: '{{ include "openmatch.configmap.default" . }}'
   override:
     volumeName: om-config-volume-override
     mountPath: /app/config/override
-    configName: om-configmap-override
+    # This will be parsed through the `tpl` function.
+    configName: '{{ include "openmatch.configmap.override" . }}'
 
 # Override Redis settings
 # https://hub.helm.sh/charts/stable/redis

--- a/install/helm/open-match/values.yaml
+++ b/install/helm/open-match/values.yaml
@@ -23,7 +23,7 @@
 # Begins the configuration section for `query` component in Open Match.
 # query:
 #
-#   # Specifies om-query as the in-cluster domain name for the `query` service.
+#   # Override the default in-cluster domain name for the `query` service to om-query.
 #   hostName: om-query
 #
 #   # Specifies the port for receiving RESTful HTTP requests in the `query` service.
@@ -44,46 +44,46 @@
 #   # Specifies the image name to be used in a Kubernetes pod for `query` compoenent.
 #   image: openmatch-query
 swaggerui: &swaggerui
-  hostName: om-swaggerui
+  hostName:
   httpPort: 51500
   portType: ClusterIP
   replicas: 1
   image: openmatch-swaggerui
 query: &query
-  hostName: om-query
+  hostName:
   grpcPort: 50503
   httpPort: 51503
   portType: ClusterIP
   replicas: 3
   image: openmatch-query
 frontend: &frontend
-  hostName: om-frontend
+  hostName:
   grpcPort: 50504
   httpPort: 51504
   portType: ClusterIP
   replicas: 3
   image: openmatch-frontend
 backend: &backend
-  hostName: om-backend
+  hostName:
   grpcPort: 50505
   httpPort: 51505
   portType: ClusterIP
   replicas: 3
   image: openmatch-backend
 synchronizer: &synchronizer
-  hostName: om-synchronizer
+  hostName:
   grpcPort: 50506
   httpPort: 51506
   portType: ClusterIP
   replicas: 1
   image: openmatch-synchronizer
 evaluator: &evaluator
-  hostName: om-evaluator
+  hostName:
   grpcPort: 50508
   httpPort: 51508
   replicas: 3
 function: &function
-  hostName: om-function
+  hostName:
   grpcPort: 50502
   httpPort: 51502
   replicas: 3

--- a/install/helm/open-match/values.yaml
+++ b/install/helm/open-match/values.yaml
@@ -104,7 +104,6 @@ configs:
 # https://hub.helm.sh/charts/stable/redis
 # https://github.com/helm/charts/tree/master/stable/redis
 redis:
-  fullnameOverride: om-redis
   redisPort: 6379
   usePassword: false
   usePasswordFile: false
@@ -128,7 +127,6 @@ redis:
     slaveCount: 2
   serviceAccount:
     create: true
-    name: open-match-redis-service
   sysctlImage:
     # Enable this setting in production if you are running Open Match under Linux environment
     enabled: false

--- a/install/helm/open-match/values.yaml
+++ b/install/helm/open-match/values.yaml
@@ -229,8 +229,8 @@ global:
       limits:
         memory: 100Mi
         cpu: 100m
-    # Defines a service account which provides an identity for processes that run in a Pod in Open Match.
-    serviceAccount: open-match-unprivileged-service
+    # Overrides the name of the service account which provides an identity for processes that run in a Pod in Open Match.
+    serviceAccount:
     # Use this field if you need to override the port type for all services defined in this chart
     service:
       portType:

--- a/install/helm/open-match/values.yaml
+++ b/install/helm/open-match/values.yaml
@@ -207,7 +207,6 @@ open-match-customize:
   enabled: false
   evaluator: *evaluator
   function: *function
-  query: *query
   # You can override the evaluator/mmf image
   # evaluator:
   #   image: [YOUR_EVALUATOR_IMAGE]

--- a/internal/testing/e2e/common.go
+++ b/internal/testing/e2e/common.go
@@ -237,8 +237,8 @@ telemetry:
     enable: "true"
   jaeger:
     enable: "false"
-    agentEndpoint: "open-match-jaeger-agent:6831"
-    collectorEndpoint: "http://open-match-jaeger-collector:14268/api/traces"
+    agentEndpoint: ""
+    collectorEndpoint: ""
   prometheus:
     enable: "false"
     endpoint: "/metrics"

--- a/internal/testing/e2e/common.go
+++ b/internal/testing/e2e/common.go
@@ -209,11 +209,11 @@ api:
   scale:
     httpport: "51509"
   evaluator:
-    hostname: "test"
+    hostname: "open-match-test"
     grpcport: "50509"
     httpport: "51509"
   test:
-    hostname: "test"
+    hostname: "open-match-test"
     grpcport: "50509"
     httpport: "51509"
 

--- a/internal/testing/e2e/common.go
+++ b/internal/testing/e2e/common.go
@@ -220,7 +220,7 @@ api:
 redis:
   sentinelPort: 26379
   sentinelMaster: om-redis-master
-  sentinelHostname: om-redis
+  sentinelHostname: open-match-redis
   sentinelUsePassword: 
   usePassword: false
   passwordPath: /opt/bitnami/redis/secrets/redis-password

--- a/internal/testing/e2e/common.go
+++ b/internal/testing/e2e/common.go
@@ -188,23 +188,23 @@ backoff:
 
 api:
   backend:
-    hostname: "om-backend"
+    hostname: "open-match-backend"
     grpcport: "50505"
     httpport: "51505"
   frontend:
-    hostname: "om-frontend"
+    hostname: "open-match-frontend"
     grpcport: "50504"
     httpport: "51504"
   query:
-    hostname: "om-query"
+    hostname: "open-match-query"
     grpcport: "50503"
     httpport: "51503"
   synchronizer:
-    hostname: "om-synchronizer"
+    hostname: "open-match-synchronizer"
     grpcport: "50506"
     httpport: "51506"
   swaggerui:
-    hostname: "om-swaggerui"
+    hostname: "open-match-swaggerui"
     httpport: "51500"
   scale:
     httpport: "51509"

--- a/tools/certgen/certgen.go
+++ b/tools/certgen/certgen.go
@@ -30,16 +30,16 @@ var (
 	// serviceAddresses is a list of all the HTTP hostname:port combinations for generating a TLS certificate.
 	// It appears that gRPC does not care about validating the port number so we only add the HTTP addresses here.
 	serviceAddressList = []string{
-		"om-backend:51505",
+		"open-match-backend:51505",
 		"om-demo:51507",
 		"om-demoevaluator:51508",
 		"om-demofunction:51502",
 		"om-e2eevaluator:51518",
 		"om-e2ematchfunction:51512",
-		"om-frontend:51504",
-		"om-query:51503",
-		"om-swaggerui:51500",
-		"om-synchronizer:51506",
+		"open-match-frontend:51504",
+		"open-match-query:51503",
+		"open-match-swaggerui:51500",
+		"open-match-synchronizer:51506",
 	}
 	caFlag                    = flag.Bool("ca", false, "Create a root certificate. Use if you want a chain of trust with other certificates.")
 	rootPublicCertificateFlag = flag.String("rootpubliccertificate", "", "(optional) Path to root certificate file. If set the output certificate is rooted from this certificate.")

--- a/tutorials/custom_evaluator/director/main.go
+++ b/tutorials/custom_evaluator/director/main.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	// The endpoint for the Open Match Backend service.
-	omBackendEndpoint = "om-backend.open-match.svc.cluster.local:50505"
+	omBackendEndpoint = "open-match-backend.open-match.svc.cluster.local:50505"
 	// The Host and Port for the Match Function service endpoint.
 	functionHostName       = "custom-eval-tutorial-matchfunction.custom-eval-tutorial.svc.cluster.local"
 	functionPort     int32 = 50502

--- a/tutorials/custom_evaluator/frontend/main.go
+++ b/tutorials/custom_evaluator/frontend/main.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	// The endpoint for the Open Match Frontend service.
-	omFrontendEndpoint = "om-frontend.open-match.svc.cluster.local:50504"
+	omFrontendEndpoint = "open-match-frontend.open-match.svc.cluster.local:50504"
 	// Number of tickets created per iteration
 	ticketsPerIter = 20
 )

--- a/tutorials/custom_evaluator/matchfunction/main.go
+++ b/tutorials/custom_evaluator/matchfunction/main.go
@@ -28,8 +28,8 @@ import (
 // with which the Match Function communicates to query the Tickets.
 
 const (
-	queryServiceAddress = "om-query.open-match.svc.cluster.local:50503" // Address of the QueryService endpoint.
-	serverPort          = 50502                                         // The port for hosting the Match Function.
+	queryServiceAddress = "open-match-query.open-match.svc.cluster.local:50503" // Address of the QueryService endpoint.
+	serverPort          = 50502                                                 // The port for hosting the Match Function.
 )
 
 func main() {

--- a/tutorials/custom_evaluator/solution/director/main.go
+++ b/tutorials/custom_evaluator/solution/director/main.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	// The endpoint for the Open Match Backend service.
-	omBackendEndpoint = "om-backend.open-match.svc.cluster.local:50505"
+	omBackendEndpoint = "open-match-backend.open-match.svc.cluster.local:50505"
 	// The Host and Port for the Match Function service endpoint.
 	functionHostName       = "custom-eval-tutorial-matchfunction.custom-eval-tutorial.svc.cluster.local"
 	functionPort     int32 = 50502

--- a/tutorials/custom_evaluator/solution/frontend/main.go
+++ b/tutorials/custom_evaluator/solution/frontend/main.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	// The endpoint for the Open Match Frontend service.
-	omFrontendEndpoint = "om-frontend.open-match.svc.cluster.local:50504"
+	omFrontendEndpoint = "open-match-frontend.open-match.svc.cluster.local:50504"
 	// Number of tickets created per iteration
 	ticketsPerIter = 20
 )

--- a/tutorials/custom_evaluator/solution/matchfunction/main.go
+++ b/tutorials/custom_evaluator/solution/matchfunction/main.go
@@ -28,8 +28,8 @@ import (
 // with which the Match Function communicates to query the Tickets.
 
 const (
-	queryServiceAddress = "om-query.open-match.svc.cluster.local:50503" // Address of the QueryService endpoint.
-	serverPort          = 50502                                         // The port for hosting the Match Function.
+	queryServiceAddress = "open-match-query.open-match.svc.cluster.local:50503" // Address of the QueryService endpoint.
+	serverPort          = 50502                                                 // The port for hosting the Match Function.
 )
 
 func main() {

--- a/tutorials/default_evaluator/director/main.go
+++ b/tutorials/default_evaluator/director/main.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	// The endpoint for the Open Match Backend service.
-	omBackendEndpoint = "om-backend.open-match.svc.cluster.local:50505"
+	omBackendEndpoint = "open-match-backend.open-match.svc.cluster.local:50505"
 	// The Host and Port for the Match Function service endpoint.
 	functionHostName       = "default-eval-tutorial-matchfunction.default-eval-tutorial.svc.cluster.local"
 	functionPort     int32 = 50502

--- a/tutorials/default_evaluator/frontend/main.go
+++ b/tutorials/default_evaluator/frontend/main.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	// The endpoint for the Open Match Frontend service.
-	omFrontendEndpoint = "om-frontend.open-match.svc.cluster.local:50504"
+	omFrontendEndpoint = "open-match-frontend.open-match.svc.cluster.local:50504"
 	// Number of tickets created per iteration
 	ticketsPerIter = 20
 )

--- a/tutorials/default_evaluator/matchfunction/main.go
+++ b/tutorials/default_evaluator/matchfunction/main.go
@@ -28,8 +28,8 @@ import (
 // with which the Match Function communicates to query the Tickets.
 
 const (
-	queryServiceAddress = "om-query.open-match.svc.cluster.local:50503" // Address of the QueryService endpoint.
-	serverPort          = 50502                                         // The port for hosting the Match Function.
+	queryServiceAddress = "open-match-query.open-match.svc.cluster.local:50503" // Address of the QueryService endpoint.
+	serverPort          = 50502                                                 // The port for hosting the Match Function.
 )
 
 func main() {

--- a/tutorials/default_evaluator/solution/director/main.go
+++ b/tutorials/default_evaluator/solution/director/main.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	// The endpoint for the Open Match Backend service.
-	omBackendEndpoint = "om-backend.open-match.svc.cluster.local:50505"
+	omBackendEndpoint = "open-match-backend.open-match.svc.cluster.local:50505"
 	// The Host and Port for the Match Function service endpoint.
 	functionHostName       = "default-eval-tutorial-matchfunction.default-eval-tutorial.svc.cluster.local"
 	functionPort     int32 = 50502

--- a/tutorials/default_evaluator/solution/frontend/main.go
+++ b/tutorials/default_evaluator/solution/frontend/main.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	// The endpoint for the Open Match Frontend service.
-	omFrontendEndpoint = "om-frontend.open-match.svc.cluster.local:50504"
+	omFrontendEndpoint = "open-match-frontend.open-match.svc.cluster.local:50504"
 	// Number of tickets created per iteration
 	ticketsPerIter = 20
 )

--- a/tutorials/default_evaluator/solution/matchfunction/main.go
+++ b/tutorials/default_evaluator/solution/matchfunction/main.go
@@ -28,8 +28,8 @@ import (
 // with which the Match Function communicates to query the Tickets.
 
 const (
-	queryServiceAddress = "om-query.open-match.svc.cluster.local:50503" // Address of the QueryService endpoint.
-	serverPort          = 50502                                         // The port for hosting the Match Function.
+	queryServiceAddress = "open-match-query.open-match.svc.cluster.local:50503" // Address of the QueryService endpoint.
+	serverPort          = 50502                                                 // The port for hosting the Match Function.
 )
 
 func main() {

--- a/tutorials/matchmaker101/director/main.go
+++ b/tutorials/matchmaker101/director/main.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	// The endpoint for the Open Match Backend service.
-	omBackendEndpoint = "om-backend.open-match.svc.cluster.local:50505"
+	omBackendEndpoint = "open-match-backend.open-match.svc.cluster.local:50505"
 	// The Host and Port for the Match Function service endpoint.
 	functionHostName       = "mm101-tutorial-matchfunction.mm101-tutorial.svc.cluster.local"
 	functionPort     int32 = 50502

--- a/tutorials/matchmaker101/frontend/main.go
+++ b/tutorials/matchmaker101/frontend/main.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	// The endpoint for the Open Match Frontend service.
-	omFrontendEndpoint = "om-frontend.open-match.svc.cluster.local:50504"
+	omFrontendEndpoint = "open-match-frontend.open-match.svc.cluster.local:50504"
 	// Number of tickets created per iteration
 	ticketsPerIter = 20
 )

--- a/tutorials/matchmaker101/matchfunction/main.go
+++ b/tutorials/matchmaker101/matchfunction/main.go
@@ -28,8 +28,8 @@ import (
 // with which the Match Function communicates to query the Tickets.
 
 const (
-	queryServiceAddress = "om-query.open-match.svc.cluster.local:50503" // Address of the QueryService endpoint.
-	serverPort          = 50502                                         // The port for hosting the Match Function.
+	queryServiceAddress = "open-match-query.open-match.svc.cluster.local:50503" // Address of the QueryService endpoint.
+	serverPort          = 50502                                                 // The port for hosting the Match Function.
 )
 
 func main() {

--- a/tutorials/matchmaker101/solution/director/main.go
+++ b/tutorials/matchmaker101/solution/director/main.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	// The endpoint for the Open Match Backend service.
-	omBackendEndpoint = "om-backend.open-match.svc.cluster.local:50505"
+	omBackendEndpoint = "open-match-backend.open-match.svc.cluster.local:50505"
 	// The Host and Port for the Match Function service endpoint.
 	functionHostName       = "mm101-tutorial-matchfunction.mm101-tutorial.svc.cluster.local"
 	functionPort     int32 = 50502

--- a/tutorials/matchmaker101/solution/frontend/main.go
+++ b/tutorials/matchmaker101/solution/frontend/main.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	// The endpoint for the Open Match Frontend service.
-	omFrontendEndpoint = "om-frontend.open-match.svc.cluster.local:50504"
+	omFrontendEndpoint = "open-match-frontend.open-match.svc.cluster.local:50504"
 	// Number of tickets created per iteration
 	ticketsPerIter = 20
 )

--- a/tutorials/matchmaker101/solution/matchfunction/main.go
+++ b/tutorials/matchmaker101/solution/matchfunction/main.go
@@ -28,8 +28,8 @@ import (
 // with which the Match Function communicates to query the Tickets.
 
 const (
-	queryServiceAddress = "om-query.open-match.svc.cluster.local:50503" // Address of the QueryService endpoint.
-	serverPort          = 50502                                         // The port for hosting the Match Function.
+	queryServiceAddress = "open-match-query.open-match.svc.cluster.local:50503" // Address of the QueryService endpoint.
+	serverPort          = 50502                                                 // The port for hosting the Match Function.
 )
 
 func main() {

--- a/tutorials/matchmaker102/director/main.go
+++ b/tutorials/matchmaker102/director/main.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	// The endpoint for the Open Match Backend service.
-	omBackendEndpoint = "om-backend.open-match.svc.cluster.local:50505"
+	omBackendEndpoint = "open-match-backend.open-match.svc.cluster.local:50505"
 	// The Host and Port for the Match Function service endpoint.
 	functionHostName       = "mm102-tutorial-matchfunction.mm102-tutorial.svc.cluster.local"
 	functionPort     int32 = 50502

--- a/tutorials/matchmaker102/frontend/main.go
+++ b/tutorials/matchmaker102/frontend/main.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	// The endpoint for the Open Match Frontend service.
-	omFrontendEndpoint = "om-frontend.open-match.svc.cluster.local:50504"
+	omFrontendEndpoint = "open-match-frontend.open-match.svc.cluster.local:50504"
 	// Number of tickets created per iteration
 	ticketsPerIter = 20
 )

--- a/tutorials/matchmaker102/matchfunction/main.go
+++ b/tutorials/matchmaker102/matchfunction/main.go
@@ -28,8 +28,8 @@ import (
 // with which the Match Function communicates to query the Tickets.
 
 const (
-	queryServiceAddress = "om-query.open-match.svc.cluster.local:50503" // Address of the QueryService endpoint.
-	serverPort          = 50502                                         // The port for hosting the Match Function.
+	queryServiceAddress = "open-match-query.open-match.svc.cluster.local:50503" // Address of the QueryService endpoint.
+	serverPort          = 50502                                                 // The port for hosting the Match Function.
 )
 
 func main() {

--- a/tutorials/matchmaker102/solution/director/main.go
+++ b/tutorials/matchmaker102/solution/director/main.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	// The endpoint for the Open Match Backend service.
-	omBackendEndpoint = "om-backend.open-match.svc.cluster.local:50505"
+	omBackendEndpoint = "open-match-backend.open-match.svc.cluster.local:50505"
 	// The Host and Port for the Match Function service endpoint.
 	functionHostName       = "mm102-tutorial-matchfunction.mm102-tutorial.svc.cluster.local"
 	functionPort     int32 = 50502

--- a/tutorials/matchmaker102/solution/frontend/main.go
+++ b/tutorials/matchmaker102/solution/frontend/main.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	// The endpoint for the Open Match Frontend service.
-	omFrontendEndpoint = "om-frontend.open-match.svc.cluster.local:50504"
+	omFrontendEndpoint = "open-match-frontend.open-match.svc.cluster.local:50504"
 	// Number of tickets created per iteration
 	ticketsPerIter = 20
 )

--- a/tutorials/matchmaker102/solution/matchfunction/main.go
+++ b/tutorials/matchmaker102/solution/matchfunction/main.go
@@ -28,8 +28,8 @@ import (
 // with which the Match Function communicates to query the Tickets.
 
 const (
-	queryServiceAddress = "om-query.open-match.svc.cluster.local:50503" // Address of the QueryService endpoint.
-	serverPort          = 50502                                         // The port for hosting the Match Function.
+	queryServiceAddress = "open-match-query.open-match.svc.cluster.local:50503" // Address of the QueryService endpoint.
+	serverPort          = 50502                                                 // The port for hosting the Match Function.
 )
 
 func main() {


### PR DESCRIPTION
This set of changes ensures that every k8s resource created by the Helm chart includes the `fullname` macro which includes the name of the Helm release.

It's a big change, and is probably much easier to read commit-by-commit, due to the distance between different parts for some of the specific changes.

The main observable effect is that all the resources that were hard-coded to `om-XXX` or `open-match-XXX` are now `RELEASE-open-match-XXX`, although if `RELEASE` contains "open-match" then they will be `RELEASE-XXX`.

In a special case (or rather, removing a special case), e01c77b838fdd86fae4ae8983b030fae552973f4 causes the open-match-scale subchart's resources to be `RELEASE-open-match-scale-XXX`, which means a release named "open-match" gets, e.g., Deployments named `open-match-backend` and `open-match-open-match-scale-backend`. It wasn't clear to be if this is desirable, and if not, that commit can be removed, producing `open-match-scale-backend` instead, but cementing that the subcharts are really just part of the main chart.

Similarly, redis no longer has a `fullnameOverride` set, so its resources will generally be of the form `RELEASE-redis-XXX`, e.g., a StatefulSet named `open-match-redis-master`.

*Note*: Redis PVCs names change with this. Since it's a StatefulSet, the old PVCs are left behind. It's still possible to set `redis.fullnameOverride` to "om-redis" to use any existing PVCs in a namespace, when upgrading. If your release is named `om`, this will be the default name anyway.

As noted in the values.yaml, the `hostName` and `serviceAccount` values now default to empty to generate names, and can be overridden where desired.

To regain the short-names, you can use the YAML file (inside the *Details*) with `--values`. The only thing that will differ is the ConfigMap created by open-match-scale for Grafana dashboards, because it was already named `open-match-scale-dashboard`. If you do this, you can only have one such release in a namespace, and you cannot then have a release named 'om' or 'open-match' installed at the same time, as some resources will conflict.

<details>

```yaml
# Reinstate all the resource names as if I hadn't done anything
fullnameOverride: "om"
open-match-scale:
  fullnameOverride: "om"
  configs:
    default:
      configName: "om-configmap-default"
    override:
      configName: "om-configmap-override"
  scaleBackend:
    hostName: "om-scale-backend"
  scaleFrontend:
    hostName: "om-scale-frontend"

open-match-customize:
  fullnameOverride: "om"

redis:
  fullnameOverride: "om-redis"
  serviceAccount:
    name: "open-match-redis-service"
global:
  kubernetes:
    serviceAccount: "open-match-unprivileged-service"

configs:
  default:
    configName: "om-configmap-default"
  override:
    configName: "om-configmap-override"
```

</details>

Tested to support multiple installs using the following commands from _install/helm/open-match_
```
helm dep build
helm install open-match . --values om-install-all.values.yaml --set-string global.image.tag=1.0.0
helm install another-open-match . --values om-install-all.values.yaml --set-string global.image.tag=1.0.0
```

with TLS keys generated per [TLS Encryption](https://open-match.dev/site/docs/guides/tls/)

where _om-install-all-values.yaml_ is set to install as many of the templated resources as possible, as below:

```yaml
open-match-core:
    enabled: true
    swaggerui:
        enabled: true
    redis:
        enabled: true

open-match-customize:
    enabled: true
    function:
        enabled: true
    evaluator:
        enabled: true

open-match-scale:
    enabled: true

open-match-telemetry:
    enabled: true

open-match-override: true

usingHelmTemplate: false

ci: false

global:
    tls:
        enabled: true
    telemetry:
        grafana:
            enabled: true
        jaeger:
            enabled: true
        prometheus:
            enabled: true
```

I repeated the test with `--set ci=true` appended to both, to confirm that the testing resources do not conflict.

Fixes: #1235