### PR TITLE
Reduce logging in statestore - redis

### DIFF
--- a/internal/rpc/server.go
+++ b/internal/rpc/server.go
@@ -283,6 +283,9 @@ func newGRPCServerOptions(params *ServerParams) []grpc.ServerOption {
 		}
 	}
 
+	// TODO: add unary interceptor once all redundant logs are removed
+	si = append(si, serverStreamInterceptor)
+
 	if params.enableMetrics {
 		opts = append(opts, grpc.StatsHandler(&ocgrpc.ServerHandler{}))
 	}
@@ -296,4 +299,15 @@ func newGRPCServerOptions(params *ServerParams) []grpc.ServerOption {
 				PermitWithoutStream: true,
 			},
 		))
+}
+
+func serverStreamInterceptor(srv interface{},
+	stream grpc.ServerStream,
+	info *grpc.StreamServerInfo,
+	handler grpc.StreamHandler) error {
+	err := handler(srv, stream)
+	if err != nil {
+		serverLogger.Error(err)
+	}
+	return err
 }

--- a/internal/statestore/redis_test.go
+++ b/internal/statestore/redis_test.go
@@ -259,7 +259,7 @@ func testConnect(t *testing.T, withSentinel bool, withPassword string) {
 	rb, ok := is.s.(*redisBackend)
 	require.True(t, ok)
 
-	conn, err := rb.connect(ctx)
+	conn, err := rb.redisPool.GetContext(ctx)
 	require.NoError(t, err)
 	require.NotNil(t, conn)
 


### PR DESCRIPTION
Closes #1228 

Previously _context canceled_ message was mentioned twice: 
1) connect method
2) GetAssignments method, after GetTicket returns an error.
Logs before the fix:
![image](https://user-images.githubusercontent.com/16540942/90985584-a9c6a380-e585-11ea-9cc7-ed25996aab0f.png)

I suggest to log everything on a very top level of API and just wrap everything which comes from lower levels.
Also, I've made logs more informative adding an ID to each record.

Logs after the fix:
![image](https://user-images.githubusercontent.com/16540942/90985625-d084da00-e585-11ea-980b-bb44e3ded197.png)
