### PR TITLE
Use require in tests to avoid nil pointer exceptions

### DIFF
--- a/internal/statestore/redis_test.go
+++ b/internal/statestore/redis_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/rs/xid"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"open-match.dev/open-match/internal/config"
@@ -90,11 +91,13 @@ func TestTicketLifecycle(t *testing.T) {
 
 	// Validate Ticket retrival
 	result, err := service.GetTicket(ctx, ticket.Id)
-	assert.Nil(err)
-	assert.NotNil(result)
+	require.NoError(t, err)
+	require.NotNil(t, result)
 	assert.Equal(ticket.Id, result.Id)
 	assert.Equal(ticket.SearchFields.DoubleArgs["testindex1"], result.SearchFields.DoubleArgs["testindex1"])
-	assert.Equal(ticket.Assignment.Connection, result.Assignment.Connection)
+	if assert.NotNil(result.Assignment) {
+		assert.Equal(ticket.Assignment.Connection, result.Assignment.Connection)
+	}
 
 	// Validate Ticket deletion
 	err = service.DeleteTicket(ctx, id)
@@ -266,8 +269,8 @@ func testConnect(t *testing.T, withSentinel bool, withPassword string) {
 	assert.True(ok)
 
 	conn, err := rb.connect(ctx)
-	assert.NotNil(conn)
-	assert.Nil(err)
+	require.NoError(t, err)
+	require.NotNil(t, conn)
 
 	rply, err := redis.String(conn.Do("PING"))
 	assert.Nil(err)

--- a/internal/statestore/testing/fake_redis_test.go
+++ b/internal/statestore/testing/fake_redis_test.go
@@ -18,14 +18,13 @@ import (
 	"testing"
 
 	"github.com/spf13/viper"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"open-match.dev/open-match/internal/statestore"
 	utilTesting "open-match.dev/open-match/internal/util/testing"
 	"open-match.dev/open-match/pkg/pb"
 )
 
 func TestFakeStatestore(t *testing.T) {
-	assert := assert.New(t)
 	cfg := viper.New()
 	closer := New(t, cfg)
 	defer closer()
@@ -35,8 +34,8 @@ func TestFakeStatestore(t *testing.T) {
 	ticket := &pb.Ticket{
 		Id: "abc",
 	}
-	assert.Nil(s.CreateTicket(ctx, ticket))
+	require.Nil(t, s.CreateTicket(ctx, ticket))
 	retrievedTicket, err := s.GetTicket(ctx, "abc")
-	assert.Nil(err)
-	assert.Equal(ticket.Id, retrievedTicket.Id)
+	require.Nil(t, err)
+	require.Equal(t, ticket.Id, retrievedTicket.Id)
 }


### PR DESCRIPTION
Several fixes in order to avoid nil pointer exceptions in cases if tests fail.