### PR TITLE
More consistent helm package versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -320,7 +320,7 @@ HELM_UPGRADE_FLAGS = --cleanup-on-fail -i --no-hooks --debug --timeout=600s --na
 HELM_TEMPLATE_FLAGS = --no-hooks --namespace $(OPEN_MATCH_KUBERNETES_NAMESPACE) --set usingHelmTemplate=true
 HELM_IMAGE_FLAGS = --set global.image.registry=$(REGISTRY) --set global.image.tag=$(TAG)
 
-install-demo: build/toolchain/bin/helm$(EXE_EXTENSION)
+install-demo:
 	cp $(REPOSITORY_ROOT)/install/02-open-match-demo.yaml $(REPOSITORY_ROOT)/install/tmp-demo.yaml
 	$(SED_REPLACE) 's|gcr.io/open-match-public-images|$(REGISTRY)|g' $(REPOSITORY_ROOT)/install/tmp-demo.yaml
 	$(SED_REPLACE) 's|0.0.0-dev|$(TAG)|g' $(REPOSITORY_ROOT)/install/tmp-demo.yaml

--- a/Makefile
+++ b/Makefile
@@ -296,7 +296,7 @@ lint-chart: build/toolchain/bin/helm$(EXE_EXTENSION) build/toolchain/bin/ct$(EXE
 
 build/chart/open-match-$(BASE_VERSION).tgz: build/toolchain/bin/helm$(EXE_EXTENSION) lint-chart
 	mkdir -p $(BUILD_DIR)/chart/
-	$(HELM) package -d $(BUILD_DIR)/chart/ --version $(BASE_VERSION) $(REPOSITORY_ROOT)/install/helm/open-match
+	$(HELM) package -d $(BUILD_DIR)/chart/ --version $(BASE_VERSION) --app-version $(TAG) $(REPOSITORY_ROOT)/install/helm/open-match
 
 build/chart/index.yaml: build/toolchain/bin/helm$(EXE_EXTENSION) gcloud build/chart/open-match-$(BASE_VERSION).tgz
 	mkdir -p $(BUILD_DIR)/chart-index/

--- a/Makefile
+++ b/Makefile
@@ -392,30 +392,30 @@ endif
 install/yaml/: update-chart-deps install/yaml/install.yaml install/yaml/01-open-match-core.yaml install/yaml/02-open-match-demo.yaml install/yaml/03-prometheus-chart.yaml install/yaml/04-grafana-chart.yaml install/yaml/05-jaeger-chart.yaml install/yaml/06-open-match-override-configmap.yaml install/yaml/07-open-match-default-evaluator.yaml
 
 # We have to hard-code the Jaeger endpoints as we are excluding Jaeger, so Helm cannot determine the endpoints from the Jaeger subchart
-install/yaml/01-open-match-core.yaml: build/toolchain/bin/helm$(EXE_EXTENSION)
+install/yaml/01-open-match-core.yaml: build/toolchain/bin/helm$(EXE_EXTENSION) build/chart/open-match-$(BASE_VERSION).tgz
 	mkdir -p install/yaml/
 	$(HELM) template $(OPEN_MATCH_HELM_NAME) $(HELM_TEMPLATE_FLAGS) $(HELM_IMAGE_FLAGS) \
 		--set-string global.telemetry.jaeger.agentEndpoint="$(OPEN_MATCH_HELM_NAME)-jaeger-agent:6831" \
 		--set-string global.telemetry.jaeger.collectorEndpoint="http://$(OPEN_MATCH_HELM_NAME)-jaeger-collector:14268/api/traces" \
-		install/helm/open-match > install/yaml/01-open-match-core.yaml
+		build/chart/open-match-$(BASE_VERSION).tgz > install/yaml/01-open-match-core.yaml
 
-install/yaml/02-open-match-demo.yaml: build/toolchain/bin/helm$(EXE_EXTENSION)
+install/yaml/02-open-match-demo.yaml:
 	mkdir -p install/yaml/
 	cp $(REPOSITORY_ROOT)/install/02-open-match-demo.yaml $(REPOSITORY_ROOT)/install/yaml/02-open-match-demo.yaml
 	$(SED_REPLACE) 's|0.0.0-dev|$(TAG)|g' $(REPOSITORY_ROOT)/install/yaml/02-open-match-demo.yaml
 	$(SED_REPLACE) 's|gcr.io/open-match-public-images|$(REGISTRY)|g' $(REPOSITORY_ROOT)/install/yaml/02-open-match-demo.yaml
 
-install/yaml/03-prometheus-chart.yaml: build/toolchain/bin/helm$(EXE_EXTENSION)
+install/yaml/03-prometheus-chart.yaml: build/toolchain/bin/helm$(EXE_EXTENSION) build/chart/open-match-$(BASE_VERSION).tgz
 	mkdir -p install/yaml/
 	$(HELM) template $(OPEN_MATCH_HELM_NAME) $(HELM_TEMPLATE_FLAGS) $(HELM_IMAGE_FLAGS) \
 		--set open-match-core.enabled=false \
 		--set open-match-core.redis.enabled=false \
 		--set open-match-telemetry.enabled=true \
 		--set global.telemetry.prometheus.enabled=true \
-		install/helm/open-match > install/yaml/03-prometheus-chart.yaml
+		build/chart/open-match-$(BASE_VERSION).tgz > install/yaml/03-prometheus-chart.yaml
 
 # We have to hard-code the Prometheus Server URL as we are excluding Prometheus, so Helm cannot determine the URL from the Prometheus subchart
-install/yaml/04-grafana-chart.yaml: build/toolchain/bin/helm$(EXE_EXTENSION)
+install/yaml/04-grafana-chart.yaml: build/toolchain/bin/helm$(EXE_EXTENSION) build/chart/open-match-$(BASE_VERSION).tgz
 	mkdir -p install/yaml/
 	$(HELM) template $(OPEN_MATCH_HELM_NAME) $(HELM_TEMPLATE_FLAGS) $(HELM_IMAGE_FLAGS) \
 		--set open-match-core.enabled=false \
@@ -423,36 +423,36 @@ install/yaml/04-grafana-chart.yaml: build/toolchain/bin/helm$(EXE_EXTENSION)
 		--set open-match-telemetry.enabled=true \
 		--set global.telemetry.grafana.enabled=true \
 		--set-string global.telemetry.grafana.prometheusServer="http://$(OPEN_MATCH_HELM_NAME)-prometheus-server.$(OPEN_MATCH_KUBERNETES_NAMESPACE).svc.cluster.local:80/" \
-		install/helm/open-match > install/yaml/04-grafana-chart.yaml
+		build/chart/open-match-$(BASE_VERSION).tgz > install/yaml/04-grafana-chart.yaml
 
-install/yaml/05-jaeger-chart.yaml: build/toolchain/bin/helm$(EXE_EXTENSION)
+install/yaml/05-jaeger-chart.yaml: build/toolchain/bin/helm$(EXE_EXTENSION) build/chart/open-match-$(BASE_VERSION).tgz
 	mkdir -p install/yaml/
 	$(HELM) template $(OPEN_MATCH_HELM_NAME) $(HELM_TEMPLATE_FLAGS) $(HELM_IMAGE_FLAGS) \
 		--set open-match-core.enabled=false \
 		--set open-match-core.redis.enabled=false \
 		--set open-match-telemetry.enabled=true \
 		--set global.telemetry.jaeger.enabled=true \
-		install/helm/open-match > install/yaml/05-jaeger-chart.yaml
+		build/chart/open-match-$(BASE_VERSION).tgz > install/yaml/05-jaeger-chart.yaml
 
-install/yaml/06-open-match-override-configmap.yaml: build/toolchain/bin/helm$(EXE_EXTENSION)
+install/yaml/06-open-match-override-configmap.yaml: build/toolchain/bin/helm$(EXE_EXTENSION) build/chart/open-match-$(BASE_VERSION).tgz
 	mkdir -p install/yaml/
 	$(HELM) template $(OPEN_MATCH_HELM_NAME) $(HELM_TEMPLATE_FLAGS) $(HELM_IMAGE_FLAGS) \
 		--set open-match-core.enabled=false \
 		--set open-match-core.redis.enabled=false \
 		--set open-match-override.enabled=true \
 		-s templates/om-configmap-override.yaml \
-		install/helm/open-match > install/yaml/06-open-match-override-configmap.yaml
+		build/chart/open-match-$(BASE_VERSION).tgz > install/yaml/06-open-match-override-configmap.yaml
 
-install/yaml/07-open-match-default-evaluator.yaml: build/toolchain/bin/helm$(EXE_EXTENSION)
+install/yaml/07-open-match-default-evaluator.yaml: build/toolchain/bin/helm$(EXE_EXTENSION) build/chart/open-match-$(BASE_VERSION).tgz
 	mkdir -p install/yaml/
 	$(HELM) template $(OPEN_MATCH_HELM_NAME) $(HELM_TEMPLATE_FLAGS) $(HELM_IMAGE_FLAGS) \
 		--set open-match-core.enabled=false \
 		--set open-match-core.redis.enabled=false \
 		--set open-match-customize.enabled=true \
 		--set open-match-customize.evaluator.enabled=true \
-		install/helm/open-match > install/yaml/07-open-match-default-evaluator.yaml
+		build/chart/open-match-$(BASE_VERSION).tgz > install/yaml/07-open-match-default-evaluator.yaml
 
-install/yaml/install.yaml: build/toolchain/bin/helm$(EXE_EXTENSION)
+install/yaml/install.yaml: build/toolchain/bin/helm$(EXE_EXTENSION) build/chart/open-match-$(BASE_VERSION).tgz
 	mkdir -p install/yaml/
 	$(HELM) template $(OPEN_MATCH_HELM_NAME) $(HELM_TEMPLATE_FLAGS) $(HELM_IMAGE_FLAGS) \
 		--set open-match-customize.enabled=true \
@@ -461,7 +461,7 @@ install/yaml/install.yaml: build/toolchain/bin/helm$(EXE_EXTENSION)
 		--set global.telemetry.jaeger.enabled=true \
 		--set global.telemetry.grafana.enabled=true \
 		--set global.telemetry.prometheus.enabled=true \
-		install/helm/open-match > install/yaml/install.yaml
+		build/chart/open-match-$(BASE_VERSION).tgz > install/yaml/install.yaml
 
 set-redis-password:
 	@stty -echo; \

--- a/Makefile
+++ b/Makefile
@@ -298,7 +298,7 @@ lint-chart: build/toolchain/bin/helm$(EXE_EXTENSION) build/toolchain/bin/ct$(EXE
 patch-chart-image-tag:
 	$(SED_REPLACE) 's|    tag: .*|    tag: $(TAG)|g' $(REPOSITORY_ROOT)/install/helm/open-match/values.yaml
 
-build/chart/open-match-$(BASE_VERSION).tgz: build/toolchain/bin/helm$(EXE_EXTENSION) lint-chart patch-chart-image-tag
+build/chart/open-match-$(BASE_VERSION).tgz: build/toolchain/bin/helm$(EXE_EXTENSION) lint-chart patch-chart-image-tag update-chart-deps
 	mkdir -p $(BUILD_DIR)/chart/
 	$(HELM) package -d $(BUILD_DIR)/chart/ --version $(BASE_VERSION) --app-version $(TAG) $(REPOSITORY_ROOT)/install/helm/open-match
 
@@ -393,7 +393,7 @@ ifneq ($(BASE_VERSION), 0.0.0-dev)
 install/yaml/: REGISTRY = gcr.io/$(OPEN_MATCH_PUBLIC_IMAGES_PROJECT_ID)
 install/yaml/: TAG = $(BASE_VERSION)
 endif
-install/yaml/: update-chart-deps install/yaml/install.yaml install/yaml/01-open-match-core.yaml install/yaml/02-open-match-demo.yaml install/yaml/03-prometheus-chart.yaml install/yaml/04-grafana-chart.yaml install/yaml/05-jaeger-chart.yaml install/yaml/06-open-match-override-configmap.yaml install/yaml/07-open-match-default-evaluator.yaml
+install/yaml/: install/yaml/install.yaml install/yaml/01-open-match-core.yaml install/yaml/02-open-match-demo.yaml install/yaml/03-prometheus-chart.yaml install/yaml/04-grafana-chart.yaml install/yaml/05-jaeger-chart.yaml install/yaml/06-open-match-override-configmap.yaml install/yaml/07-open-match-default-evaluator.yaml
 
 # We have to hard-code the Jaeger endpoints as we are excluding Jaeger, so Helm cannot determine the endpoints from the Jaeger subchart
 install/yaml/01-open-match-core.yaml: build/toolchain/bin/helm$(EXE_EXTENSION) build/chart/open-match-$(BASE_VERSION).tgz

--- a/Makefile
+++ b/Makefile
@@ -285,7 +285,9 @@ $(foreach IMAGE,$(IMAGES),clean-$(IMAGE)-image): clean-%-image:
 
 #####################################################################################################################
 update-chart-deps: build/toolchain/bin/helm$(EXE_EXTENSION)
-	(cd $(REPOSITORY_ROOT)/install/helm/open-match; $(HELM) repo add incubator https://kubernetes-charts-incubator.storage.googleapis.com; $(HELM) dependency update)
+	$(HELM) repo add incubator https://kubernetes-charts-incubator.storage.googleapis.com
+	(cd $(REPOSITORY_ROOT)/install/helm/open-match; $(HELM) dependency update)
+	(cd $(REPOSITORY_ROOT)/install/helm/open-match/subcharts/open-match-telemetry; $(HELM) dependency update)
 
 lint-chart: build/toolchain/bin/helm$(EXE_EXTENSION) build/toolchain/bin/ct$(EXE_EXTENSION)
 	(cd $(REPOSITORY_ROOT)/install/helm; $(HELM) lint $(OPEN_MATCH_HELM_NAME))

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -162,6 +162,8 @@ artifacts:
             - install/yaml/04-grafana-chart.yaml
             - install/yaml/05-jaeger-chart.yaml
             - install/yaml/06-open-match-override-configmap.yaml
+            - install/yaml/07-open-match-default-evaluator.yaml
+            - build/chart/open-match-*.tgz
             
 substitutions:
     _OM_VERSION: "0.0.0-dev"


### PR DESCRIPTION
**What this PR does / Why we need it**:

There's a few fixes here for the generated Helm charts, some low-hanging fruit from #1244 and a fix for some issues noticed while working on #1246.

The major visible fix is that Helm charts packaged from non-release builds will now have a unique AppVersion (the container image tag), so that it's possible to know which version of Open Match you have installed. I haven't changed the (SemVer) Version, as that's not low-hanging fruit per #1244.

This also has the effect that such Helm charts will point to the specific container image tag from which they were built, rather than using a floating image tag. This will avoid surprising issues in an Open Match deployment from a non-release build. It's generally a bad idea to use floating image tags in a Kubernetes Deployment. The manifest YAML generated from the same builds did not use the floating image tags, so this problem was only visible to Helm users.

In order to reduce the risk of similar issues in future, the manifest YAML is generated from the packaged chart, not the chart source. At this point, this probably makes no difference, but as other improvements flow from #1246, it will reduce one point of divergence between the manifest YAML and the Helm package. CI deployments still use the chart source because they need to generate TLS certificates. Fixing this (and hence supporting TLS certificates for the packaged chart) is also not low-hanging fruit.

I also fixed an issue where the open-match-telemetry subchart was not having its dependencies updated, meaning it was specified to use one version of the third-party charts it depends on, but was deploying much older versions in practice.

**Which issue(s) this PR fixes**:

Improvements towards #1244

**Special notes for your reviewer**: