### PR TITLE
Improved app tests

### DIFF
--- a/internal/app/evaluator/defaulteval/evaluator_test.go
+++ b/internal/app/evaluator/defaulteval/evaluator_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"open-match.dev/open-match/pkg/pb"
 )
 
@@ -122,17 +122,17 @@ func TestEvaluate(t *testing.T) {
 			close(in)
 
 			err := evaluate(context.Background(), in, out)
-			assert.Nil(t, err)
+			require.Nil(t, err)
 
 			gotMatchIDs := []string{}
 			close(out)
 			for id := range out {
 				gotMatchIDs = append(gotMatchIDs, id)
 			}
-			assert.Equal(t, len(test.wantMatchIDs), len(gotMatchIDs))
+			require.Equal(t, len(test.wantMatchIDs), len(gotMatchIDs))
 
 			for _, mID := range gotMatchIDs {
-				assert.Contains(t, test.wantMatchIDs, mID)
+				require.Contains(t, test.wantMatchIDs, mID)
 			}
 		})
 	}

--- a/internal/app/frontend/frontend_service_test.go
+++ b/internal/app/frontend/frontend_service_test.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	"github.com/spf13/viper"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"open-match.dev/open-match/internal/statestore"
@@ -77,12 +77,12 @@ func TestDoCreateTickets(t *testing.T) {
 			test.preAction(cancel)
 
 			res, err := doCreateTicket(ctx, &pb.CreateTicketRequest{Ticket: test.ticket}, store)
-			assert.Equal(t, test.wantCode, status.Convert(err).Code())
+			require.Equal(t, test.wantCode.String(), status.Convert(err).Code().String())
 			if err == nil {
 				matched, err := regexp.MatchString(`[0-9a-v]{20}`, res.GetId())
-				assert.True(t, matched)
-				assert.Nil(t, err)
-				assert.Equal(t, test.ticket.SearchFields.DoubleArgs["test-arg"], res.SearchFields.DoubleArgs["test-arg"])
+				require.True(t, matched)
+				require.Nil(t, err)
+				require.Equal(t, test.ticket.SearchFields.DoubleArgs["test-arg"], res.SearchFields.DoubleArgs["test-arg"])
 			}
 		})
 	}
@@ -118,7 +118,7 @@ func TestDoWatchAssignments(t *testing.T) {
 		{
 			description: "expect two assignment reads from preAction writes and fail in grpc aborted code",
 			preAction: func(ctx context.Context, t *testing.T, store statestore.Service, wantAssignments []*pb.Assignment, wg *sync.WaitGroup) {
-				assert.Nil(t, store.CreateTicket(ctx, testTicket))
+				require.Nil(t, store.CreateTicket(ctx, testTicket))
 
 				go func(wg *sync.WaitGroup) {
 					for i := 0; i < len(wantAssignments); i++ {
@@ -131,7 +131,7 @@ func TestDoWatchAssignments(t *testing.T) {
 								},
 							},
 						})
-						assert.Nil(t, err)
+						require.Nil(t, err)
 						wg.Done()
 					}
 				}(wg)
@@ -155,11 +155,11 @@ func TestDoWatchAssignments(t *testing.T) {
 
 			test.preAction(ctx, t, store, test.wantAssignments, &wg)
 			err := doWatchAssignments(ctx, testTicket.GetId(), senderGenerator(gotAssignments, len(test.wantAssignments)), store)
-			assert.Equal(t, test.wantCode, status.Convert(err).Code())
+			require.Equal(t, test.wantCode.String(), status.Convert(err).Code().String())
 
 			wg.Wait()
 			for i := 0; i < len(gotAssignments); i++ {
-				assert.Equal(t, gotAssignments[i], test.wantAssignments[i])
+				require.Equal(t, gotAssignments[i], test.wantAssignments[i])
 			}
 		})
 	}
@@ -211,7 +211,7 @@ func TestDoDeleteTicket(t *testing.T) {
 			test.preAction(ctx, cancel, store)
 
 			err := doDeleteTicket(ctx, fakeTicket.GetId(), store)
-			assert.Equal(t, test.wantCode, status.Convert(err).Code())
+			require.Equal(t, test.wantCode.String(), status.Convert(err).Code().String())
 		})
 	}
 }
@@ -265,11 +265,11 @@ func TestDoGetTicket(t *testing.T) {
 			test.preAction(ctx, cancel, store)
 
 			ticket, err := doGetTickets(ctx, fakeTicket.GetId(), store)
-			assert.Equal(t, test.wantCode, status.Convert(err).Code())
+			require.Equal(t, test.wantCode.String(), status.Convert(err).Code().String())
 
 			if err == nil {
-				assert.Equal(t, test.wantTicket.GetId(), ticket.GetId())
-				assert.Equal(t, test.wantTicket.SearchFields.DoubleArgs, ticket.SearchFields.DoubleArgs)
+				require.Equal(t, test.wantTicket.GetId(), ticket.GetId())
+				require.Equal(t, test.wantTicket.SearchFields.DoubleArgs, ticket.SearchFields.DoubleArgs)
 			}
 		})
 	}

--- a/internal/app/query/query_service_test.go
+++ b/internal/app/query/query_service_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
 	"open-match.dev/open-match/internal/config"
 )
 
@@ -61,9 +62,7 @@ func TestGetPageSize(t *testing.T) {
 			cfg := viper.New()
 			tt.configure(cfg)
 			actual := getPageSize(cfg)
-			if actual != tt.expected {
-				t.Errorf("got %d, want %d", actual, tt.expected)
-			}
+			require.Equal(t, tt.expected, actual)
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / Why we need it**:
Switched from _require_ to _assert_.
Also made output where we compare error codes more readable.

Current output:
```
Error:      	Not equal: 
            	expected: 0xa
            	actual  : 0xe
```

After the fix:
```
Error:      	Not equal: 
            	expected: "Aborted"
            	actual  : "NotFound"
```



