### PR TITLE
Added a new exception to golangci config

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -186,6 +186,7 @@ issues:
   # excluded by default patterns execute `golangci-lint run --help`
   exclude:
     - abcdef
+    - Using the variable on range scope .* in function literal
 
   # Excluding configuration per-path, per-linter, per-text and per-source
   exclude-rules:

--- a/internal/app/evaluator/defaulteval/evaluator_test.go
+++ b/internal/app/evaluator/defaulteval/evaluator_test.go
@@ -111,7 +111,6 @@ func TestEvaluate(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.description, func(t *testing.T) {
 			t.Parallel()
 			in := make(chan *pb.Match, 10)

--- a/internal/app/frontend/frontend_service_test.go
+++ b/internal/app/frontend/frontend_service_test.go
@@ -68,7 +68,6 @@ func TestDoCreateTickets(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.description, func(t *testing.T) {
 			store, closer := statestoreTesting.NewStoreServiceForTesting(t, cfg)
 			defer closer()
@@ -142,7 +141,6 @@ func TestDoWatchAssignments(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.description, func(t *testing.T) {
 			var wg sync.WaitGroup
 			wg.Add(len(test.wantAssignments))
@@ -202,7 +200,6 @@ func TestDoDeleteTicket(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.description, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(utilTesting.NewContext(t))
 			store, closer := statestoreTesting.NewStoreServiceForTesting(t, viper.New())
@@ -256,7 +253,6 @@ func TestDoGetTicket(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.description, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(utilTesting.NewContext(t))
 			store, closer := statestoreTesting.NewStoreServiceForTesting(t, viper.New())

--- a/internal/app/query/query_service_test.go
+++ b/internal/app/query/query_service_test.go
@@ -57,7 +57,6 @@ func TestGetPageSize(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := viper.New()
 			tt.configure(cfg)

--- a/internal/config/cacher_test.go
+++ b/internal/config/cacher_test.go
@@ -136,7 +136,6 @@ var getTests = []struct {
 //nolint: gocritic, staticcheck
 func Test_Get(t *testing.T) {
 	for _, tt := range getTests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.verifySame == nil {
 				tt.verifySame = func(a, b interface{}) bool {

--- a/internal/filter/filter_test.go
+++ b/internal/filter/filter_test.go
@@ -28,7 +28,6 @@ import (
 
 func TestMeetsCriteria(t *testing.T) {
 	for _, tc := range testcases.IncludedTestCases() {
-		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
 			pf, err := NewPoolFilter(tc.Pool)
 			if err != nil {
@@ -42,7 +41,6 @@ func TestMeetsCriteria(t *testing.T) {
 	}
 
 	for _, tc := range testcases.ExcludedTestCases() {
-		tc := tc
 		t.Run(tc.Name, func(t *testing.T) {
 			pf, err := NewPoolFilter(tc.Pool)
 			if err != nil {
@@ -80,7 +78,6 @@ func TestValidPoolFilter(t *testing.T) {
 			".invalid created_after value",
 		},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			pf, err := NewPoolFilter(tc.pool)
 			assert.Nil(t, pf)

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -35,7 +35,6 @@ func TestNewFormatter(t *testing.T) {
 		{"text", &logrus.TextFormatter{}},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(fmt.Sprintf("newFormatter(%s) => %s", tc.in, tc.expected), func(t *testing.T) {
 			assert := assert.New(t)
 			actual := newFormatter(tc.in)
@@ -58,7 +57,6 @@ func TestIsDebugLevel(t *testing.T) {
 		{logrus.PanicLevel, false},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(fmt.Sprintf("isDebugLevel(%s) => %t", tc.in, tc.expected), func(t *testing.T) {
 			assert := assert.New(t)
 			actual := isDebugLevel(tc.in)
@@ -85,7 +83,6 @@ func TestToLevel(t *testing.T) {
 		{"nothing", logrus.InfoLevel},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(fmt.Sprintf("toLevel(%s) => %s", tc.in, tc.expected), func(t *testing.T) {
 			assert := assert.New(t)
 			actual := toLevel(tc.in)

--- a/internal/rpc/clients_test.go
+++ b/internal/rpc/clients_test.go
@@ -84,8 +84,7 @@ func TestSanitizeHTTPAddress(t *testing.T) {
 		{"https://om-test:54321", true, "https://om-test:54321", nil},
 	}
 
-	for _, testCase := range tests {
-		tc := testCase
+	for _, tc := range tests {
 		description := fmt.Sprintf("sanitizeHTTPAddress(%s, %t) => (%s, %v)", tc.address, tc.preferHTTPS, tc.expected, tc.err)
 		t.Run(description, func(t *testing.T) {
 			assert := assert.New(t)

--- a/internal/telemetry/probe_test.go
+++ b/internal/telemetry/probe_test.go
@@ -48,7 +48,6 @@ func TestHealthCheck(t *testing.T) {
 		{"angryHealthCheck", []func(context.Context) error{angryHealthCheck}, "I'm angry"},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			assertHealthCheck(t, NewHealthCheck(tc.healthChecks), tc.errorString)
 		})

--- a/internal/testing/e2e/query_tickets_test.go
+++ b/internal/testing/e2e/query_tickets_test.go
@@ -119,7 +119,6 @@ func TestPaging(t *testing.T) {
 
 func TestTicketFound(t *testing.T) {
 	for _, tc := range testcases.IncludedTestCases() {
-		tc := tc
 		t.Run("QueryTickets_"+tc.Name, func(t *testing.T) {
 			if !returnedByQuery(t, tc) {
 				require.Fail(t, "Expected to find ticket in pool but didn't.")
@@ -135,7 +134,6 @@ func TestTicketFound(t *testing.T) {
 
 func TestTicketNotFound(t *testing.T) {
 	for _, tc := range testcases.ExcludedTestCases() {
-		tc := tc
 		t.Run("QueryTickets_"+tc.Name, func(t *testing.T) {
 			if returnedByQuery(t, tc) {
 				require.Fail(t, "Expected to not find ticket in pool but did.")

--- a/internal/testing/e2e/ticket_test.go
+++ b/internal/testing/e2e/ticket_test.go
@@ -122,7 +122,6 @@ func TestAssignTicketsInvalidArgument(t *testing.T) {
 			"Ticket id " + ctResp.Id + " is assigned multiple times in one assign tickets call.",
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := om.Backend().AssignTickets(ctx, tt.req)
 			require.Equal(t, codes.InvalidArgument, status.Convert(err).Code())
@@ -516,7 +515,6 @@ func TestCreateTicketErrors(t *testing.T) {
 			"tickets cannot be created with create time set",
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			om := newOM(t)
 			ctx := context.Background()

--- a/tools/certgen/internal/internal_test.go
+++ b/tools/certgen/internal/internal_test.go
@@ -96,7 +96,6 @@ func TestBadValues(t *testing.T) {
 		{"validity duration is required, otherwise the certificate would immediately expire", "pub.cert", "priv.key", &Params{Hostnames: []string{"127.0.0.1"}, RSAKeyLength: 2048}},
 	}
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.errorString, func(t *testing.T) {
 			err := CreateCertificateAndPrivateKeyFiles(
 				testCase.pub,
@@ -130,7 +129,6 @@ func TestExpandHostnames(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(fmt.Sprintf("expandHostnames(%s) => %s", testCase.input, testCase.expected), func(t *testing.T) {
 			assert := assert.New(t)
 			actual := expandHostnames(testCase.input)

--- a/tools/reaper/internal/internal_test.go
+++ b/tools/reaper/internal/internal_test.go
@@ -113,7 +113,6 @@ func TestIsOrphaned(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(fmt.Sprintf("%s deleted= %t", tc.namespace.ObjectMeta.Name, tc.expected), func(t *testing.T) {
 			actual := isOrphaned(&tc.namespace, &Params{
 				Age: tc.age,


### PR DESCRIPTION
**What this PR does / Why we need it**:
I've noticed that in tests we use a workaround like `tt:=tt` in order to avoid linter fails.
In my opinion, this is not an elegant solution, and I've spent some time researching if there is a way to fix it, and found several issues:
https://github.com/golangci/golangci-lint/issues/281
https://github.com/kyoh86/scopelint/issues/4

I think adding this warning to the exception list makes our code a bit cleaner and easy to understand. Personally, when I've encountered this line in tests for the first time I thought that this was probably a mistake and removed that code and noticed a linter warning much later. 

What do you think?


