### PR TITLE
Replaced GS bucket links with substitution variables

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -153,7 +153,7 @@ steps:
 
 artifacts:
     objects:
-        location: gs://open-match-build-artifacts/output/
+        location: '${_ARTIFACTS_BUCKET}'
         paths:
             - install/yaml/install.yaml
             - install/yaml/01-open-match-core.yaml
@@ -167,7 +167,9 @@ substitutions:
     _OM_VERSION: "0.0.0-dev"
     _GCB_POST_SUBMIT: "0"
     _GCB_LATEST_VERSION: "undefined"
-logsBucket: 'gs://open-match-build-logs/'
+    _ARTIFACTS_BUCKET: "gs://open-match-build-artifacts/output/"
+    _LOGS_BUCKET: "gs://open-match-build-logs/"
+logsBucket: '${_LOGS_BUCKET}'
 options:
   sourceProvenanceHash: ['SHA256']
   machineType: 'N1_HIGHCPU_32'


### PR DESCRIPTION
**What this PR does / Why we need it**:

In order to use the cloud build file on a separate GCP project different infrastructures need to be deployed, including a couple of GS Buckets. Unfortunately, the cloud build file has the open-match build pipeline buckets for artifacts and logs hardcoded and not exposed as substitution variables.

This PR creates two substitution variables for the buckets (`_ARTIFACTS_BUCKET`, and `_LOGS_BUCKET`), allowing a google cloud build to succeed by using a different value for these variables.
