### PR TITLE
Unavailable gRPC match functions forces us to wait the proposalCollectionInterval before failing

### DIFF
--- a/install/helm/open-match/templates/om-configmap-override.yaml
+++ b/install/helm/open-match/templates/om-configmap-override.yaml
@@ -38,8 +38,8 @@ data:
     pendingReleaseTimeout: {{ index .Values "open-match-core" "pendingReleaseTimeout" }}
     # Time after a ticket has been assigned before it is automatically delted.
     assignedDeleteTimeout: {{ index .Values "open-match-core" "assignedDeleteTimeout" }}
-    # Time before a function is considered unavailable after trying to connect to it.
-    functionConnectionTimeout:  {{ index .Values "open-match-core" "functionConnectionTimeout" }}
+    # Time before an RPC connection is considered unavailable after trying to connect to it.
+    rpcConnectionTimeout:  {{ index .Values "open-match-core" "rpcConnectionTimeout" }}
     # Maximum number of tickets to return on a single QueryTicketsResponse.
     queryPageSize: {{ index .Values "open-match-core" "queryPageSize" }}
     api:

--- a/install/helm/open-match/templates/om-configmap-override.yaml
+++ b/install/helm/open-match/templates/om-configmap-override.yaml
@@ -38,6 +38,8 @@ data:
     pendingReleaseTimeout: {{ index .Values "open-match-core" "pendingReleaseTimeout" }}
     # Time after a ticket has been assigned before it is automatically delted.
     assignedDeleteTimeout: {{ index .Values "open-match-core" "assignedDeleteTimeout" }}
+    # Time before a function is considered unavailable after trying to connect to it.
+    functionConnectionTimeout:  {{ index .Values "open-match-core" "functionConnectionTimeout" }}
     # Maximum number of tickets to return on a single QueryTicketsResponse.
     queryPageSize: {{ index .Values "open-match-core" "queryPageSize" }}
     api:

--- a/install/helm/open-match/values.yaml
+++ b/install/helm/open-match/values.yaml
@@ -171,8 +171,8 @@ open-match-core:
   pendingReleaseTimeout: 1m
   # Time after a ticket has been assigned before it is automatically delted.
   assignedDeleteTimeout: 10m
-  # Time before a function is considered unavailable after trying to connect to it.
-  functionConnectionTimeout: 300ms
+  # Time before an RPC connection is considered unavailable after trying to connect to it.
+  rpcConnectionTimeout: 300ms
   # Maximum number of tickets to return on a single QueryTicketsResponse.
   queryPageSize: 10000
 

--- a/install/helm/open-match/values.yaml
+++ b/install/helm/open-match/values.yaml
@@ -171,6 +171,8 @@ open-match-core:
   pendingReleaseTimeout: 1m
   # Time after a ticket has been assigned before it is automatically delted.
   assignedDeleteTimeout: 10m
+  # Time before a function is considered unavailable after trying to connect to it.
+  functionConnectionTimeout: 300ms
   # Maximum number of tickets to return on a single QueryTicketsResponse.
   queryPageSize: 10000
 

--- a/internal/app/backend/backend_service.go
+++ b/internal/app/backend/backend_service.go
@@ -198,7 +198,10 @@ func callGrpcMmf(ctx context.Context, cc *rpc.ClientCache, profile *pb.MatchProf
 	var conn *grpc.ClientConn
 	conn, err := cc.GetGRPC(address)
 	if err != nil {
-		return status.Error(codes.InvalidArgument, "failed to establish grpc client connection to match function")
+		if code := status.Code(err); code != codes.Unknown {
+			return err
+		}
+		return status.Errorf(codes.InvalidArgument, "failed to establish grpc client connection to match function: %s", err.Error())
 	}
 	client := pb.NewMatchFunctionClient(conn)
 

--- a/internal/rpc/clientcache.go
+++ b/internal/rpc/clientcache.go
@@ -43,10 +43,8 @@ type cachedHTTPClient struct {
 	baseURL string
 }
 
-type grpcGetOptions func(config.View, *cachedGRPCClient) error
-
 // GetGRPC gets a GRPC client with the address.
-func (cc *ClientCache) GetGRPC(address string, opts ...grpcGetOptions) (*grpc.ClientConn, error) {
+func (cc *ClientCache) GetGRPC(address string) (*grpc.ClientConn, error) {
 	val, exists := cc.cache.Load(address)
 	c, ok := val.(cachedGRPCClient)
 	if !ok || !exists {

--- a/internal/rpc/clientcache.go
+++ b/internal/rpc/clientcache.go
@@ -58,7 +58,7 @@ func (cc *ClientCache) GetGRPC(address string) (*grpc.ClientConn, error) {
 		cc.cache.Store(address, c)
 	}
 
-	timeoutDuration := functionConnectionTimeout(cc.cfg)
+	timeoutDuration := rpcConnectionTimeout(cc.cfg)
 	ctx, cancel := context.WithTimeout(context.Background(), timeoutDuration)
 	defer cancel()
 	for {
@@ -74,9 +74,9 @@ func (cc *ClientCache) GetGRPC(address string) (*grpc.ClientConn, error) {
 	return c.client, nil
 }
 
-func functionConnectionTimeout(cfg config.View) time.Duration {
+func rpcConnectionTimeout(cfg config.View) time.Duration {
 	const (
-		name            = "functionConnectionTimeout"
+		name            = "rpcConnectionTimeout"
 		defaultInterval = 300 * time.Millisecond
 	)
 

--- a/internal/rpc/clientcache_test.go
+++ b/internal/rpc/clientcache_test.go
@@ -33,7 +33,10 @@ const (
 func TestGetGRPC(t *testing.T) {
 	require := require.New(t)
 
-	cc := NewClientCache(viper.New())
+	// Skipping the connection timeout check
+	cfg := viper.New()
+	cfg.Set("rpcConnectionTimeout", "0")
+	cc := NewClientCache(cfg)
 	client, err := cc.GetGRPC(fakeGRPCAddress)
 	require.Nil(err)
 
@@ -44,7 +47,7 @@ func TestGetGRPC(t *testing.T) {
 	require.EqualValues(client, cachedClient)
 }
 
-func TestGetGRPC_WithUnavailableAddress(t *testing.T) {
+func TestGetGRPC_UnavailableAddress(t *testing.T) {
 	require := require.New(t)
 
 	cc := NewClientCache(viper.New())

--- a/internal/rpc/clientcache_test.go
+++ b/internal/rpc/clientcache_test.go
@@ -17,13 +17,17 @@ package rpc
 import (
 	"testing"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 )
 
 const (
-	fakeHTTPAddress = "http://om-test:54321"
-	fakeGRPCAddress = "om-test:54321"
+	fakeHTTPAddress            = "http://om-test:54321"
+	fakeGRPCAddress            = "om-test:54321"
+	unavailableFakeGRPCAddress = "om-test-1:54321"
 )
 
 func TestGetGRPC(t *testing.T) {
@@ -38,6 +42,17 @@ func TestGetGRPC(t *testing.T) {
 
 	// Test caching by comparing pointer value
 	require.EqualValues(client, cachedClient)
+}
+
+func TestGetGRPC_WithUnavailableAddress(t *testing.T) {
+	require := require.New(t)
+
+	cc := NewClientCache(viper.New())
+	_, err := cc.GetGRPC(unavailableFakeGRPCAddress)
+	require.Error(err)
+
+	code := status.Code(err)
+	require.Equal(codes.Unavailable, code)
 }
 
 func TestGetHTTP(t *testing.T) {

--- a/internal/testing/e2e/common.go
+++ b/internal/testing/e2e/common.go
@@ -164,7 +164,7 @@ const registrationInterval = time.Millisecond * 200
 const proposalCollectionInterval = time.Millisecond * 200
 const pendingReleaseTimeout = time.Millisecond * 200
 const assignedDeleteTimeout = time.Millisecond * 200
-const rpcConnectionTimeout = time.Millisecond * 200
+const rpcConnectionTimeout = time.Millisecond * 300
 
 // configFile is the "canonical" test config.  It exactly matches the configmap
 // which is used in the real cluster tests.
@@ -173,7 +173,7 @@ registrationInterval: 200ms
 proposalCollectionInterval: 200ms
 pendingReleaseTimeout: 200ms
 assignedDeleteTimeout: 200ms
-rpcConnectionTimeout: 200ms
+rpcConnectionTimeout: 300ms
 queryPageSize: 10
 
 logging:

--- a/internal/testing/e2e/common.go
+++ b/internal/testing/e2e/common.go
@@ -164,16 +164,16 @@ const registrationInterval = time.Millisecond * 200
 const proposalCollectionInterval = time.Millisecond * 200
 const pendingReleaseTimeout = time.Millisecond * 200
 const assignedDeleteTimeout = time.Millisecond * 200
-const rpcConnectionTimeout = time.Millisecond * 300
+const rpcConnectionTimeout = time.Millisecond * 200
 
-// configFile is the "cononical" test config.  It exactly matches the configmap
+// configFile is the "canonical" test config.  It exactly matches the configmap
 // which is used in the real cluster tests.
 const configFile = `
 registrationInterval: 200ms
 proposalCollectionInterval: 200ms
 pendingReleaseTimeout: 200ms
 assignedDeleteTimeout: 200ms
-rpcConnectionTimeout: 300ms
+rpcConnectionTimeout: 200ms
 queryPageSize: 10
 
 logging:

--- a/internal/testing/e2e/common.go
+++ b/internal/testing/e2e/common.go
@@ -164,6 +164,7 @@ const registrationInterval = time.Millisecond * 200
 const proposalCollectionInterval = time.Millisecond * 200
 const pendingReleaseTimeout = time.Millisecond * 200
 const assignedDeleteTimeout = time.Millisecond * 200
+const rpcConnectionTimeout = time.Millisecond * 300
 
 // configFile is the "cononical" test config.  It exactly matches the configmap
 // which is used in the real cluster tests.
@@ -172,6 +173,7 @@ registrationInterval: 200ms
 proposalCollectionInterval: 200ms
 pendingReleaseTimeout: 200ms
 assignedDeleteTimeout: 200ms
+rpcConnectionTimeout: 300ms
 queryPageSize: 10
 
 logging:

--- a/internal/testing/e2e/fetch_matches_test.go
+++ b/internal/testing/e2e/fetch_matches_test.go
@@ -16,6 +16,7 @@ package e2e
 
 import (
 	"context"
+	"errors"
 	"io"
 	"math/rand"
 	"sync"
@@ -23,7 +24,6 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -866,11 +866,9 @@ func TestUnavailableMMF(t *testing.T) {
 
 	_, err = stream.Recv()
 	duration := time.Since(startTime)
+
+	// Cannot assert error type since it's wrapped.
 	require.Error(t, err)
-
-	code := status.Code(err)
-	require.Equal(t, codes.Unavailable, code)
-
 	require.True(t, duration > rpcConnectionTimeout, "%s", duration)
 	require.True(t, duration < registrationInterval+proposalCollectionInterval, "%s", duration)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/open-match/blob/master/CONTRIBUTING.md and developer guide https://github.com/googleforgames/open-match/blob/master/docs/development.md
-->

**What this PR does / Why we need it**:
Whenever a profile points to a function that is not available, a call to `FetchMatches` with that profile will force us to wait for the full length of `proposalCollectionInterval` before getting back an error saying that the function took longer than the collection interval to return results. It would be expected that if the function is not available, we should fail fast. This change adds an additional check before calling the function to see if the provided address is available. 

**Which issue(s) this PR fixes**: No issues created for this.
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->

**Special notes for your reviewer**:
Open to suggestions on a more robust way to do this.


