### PR TITLE
Fix integration tests failing because of an Idle connection

### DIFF
--- a/internal/rpc/clientcache.go
+++ b/internal/rpc/clientcache.go
@@ -64,7 +64,7 @@ func (cc *ClientCache) GetGRPC(address string) (*grpc.ClientConn, error) {
 		defer cancel()
 		for {
 			s := c.client.GetState()
-			if s == connectivity.Ready {
+			if s == connectivity.Ready || s == connectivity.Idle {
 				break
 			}
 			if !c.client.WaitForStateChange(ctx, s) {


### PR DESCRIPTION
Example test failure:
`
time="2020-10-28T18:52:51Z" level=error msg="error(s) in FetchMatches call. syncErr=[<nil>], mmfErr=[rpc error: code = Unavailable desc = timeout waiting for connection ready after 300ms, stuck in state IDLE]" app=openmatch component=api.test
--- FAIL: TestUnavailableMMF (0.45s)
    fetch_matches_test.go:873: 
        	Error Trace:	fetch_matches_test.go:873
        	Error:      	Should be true
        	Test:       	TestUnavailableMMF
        	Messages:   	406.163034ms
`

Including Idle as a valid "go ahead" state.  It's not perfect, but it should mostly work, as idle only happens when the connection hasn't been used.

https://github.com/grpc/grpc/blob/master/doc/connectivity-semantics-and-api.md

At wrost, any attempted connections may wait awhile the first time, but then will be kicked out of idle for future iterations.