### PR TITLE
Revert "Unavailable gRPC match functions forces us to wait the proposalCollectionInterval before failing"

### DIFF
--- a/install/helm/open-match/templates/om-configmap-override.yaml
+++ b/install/helm/open-match/templates/om-configmap-override.yaml
@@ -38,8 +38,6 @@ data:
     pendingReleaseTimeout: {{ index .Values "open-match-core" "pendingReleaseTimeout" }}
     # Time after a ticket has been assigned before it is automatically delted.
     assignedDeleteTimeout: {{ index .Values "open-match-core" "assignedDeleteTimeout" }}
-    # Time before an RPC connection is considered unavailable after trying to connect to it.
-    rpcConnectionTimeout:  {{ index .Values "open-match-core" "rpcConnectionTimeout" }}
     # Maximum number of tickets to return on a single QueryTicketsResponse.
     queryPageSize: {{ index .Values "open-match-core" "queryPageSize" }}
     api:

--- a/install/helm/open-match/values.yaml
+++ b/install/helm/open-match/values.yaml
@@ -171,8 +171,6 @@ open-match-core:
   pendingReleaseTimeout: 1m
   # Time after a ticket has been assigned before it is automatically delted.
   assignedDeleteTimeout: 10m
-  # Time before an RPC connection is considered unavailable after trying to connect to it.
-  rpcConnectionTimeout: 300ms
   # Maximum number of tickets to return on a single QueryTicketsResponse.
   queryPageSize: 10000
 

--- a/internal/app/backend/backend_service.go
+++ b/internal/app/backend/backend_service.go
@@ -198,10 +198,7 @@ func callGrpcMmf(ctx context.Context, cc *rpc.ClientCache, profile *pb.MatchProf
 	var conn *grpc.ClientConn
 	conn, err := cc.GetGRPC(address)
 	if err != nil {
-		if code := status.Code(err); code != codes.Unknown {
-			return err
-		}
-		return status.Errorf(codes.InvalidArgument, "failed to establish grpc client connection to match function: %s", err.Error())
+		return status.Error(codes.InvalidArgument, "failed to establish grpc client connection to match function")
 	}
 	client := pb.NewMatchFunctionClient(conn)
 

--- a/internal/rpc/clientcache.go
+++ b/internal/rpc/clientcache.go
@@ -15,14 +15,8 @@
 package rpc
 
 import (
-	"context"
 	"net/http"
 	"sync"
-	"time"
-
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/connectivity"
-	"google.golang.org/grpc/status"
 
 	"google.golang.org/grpc"
 	"open-match.dev/open-match/internal/config"
@@ -58,35 +52,7 @@ func (cc *ClientCache) GetGRPC(address string) (*grpc.ClientConn, error) {
 		cc.cache.Store(address, c)
 	}
 
-	timeoutDuration := rpcConnectionTimeout(cc.cfg)
-	if timeoutDuration.Milliseconds() > 0 {
-		ctx, cancel := context.WithTimeout(context.Background(), timeoutDuration)
-		defer cancel()
-		for {
-			s := c.client.GetState()
-			if s == connectivity.Ready {
-				break
-			}
-			if !c.client.WaitForStateChange(ctx, s) {
-				return nil, status.Errorf(codes.Unavailable, "timeout waiting for connection ready after %s, stuck in state %s", timeoutDuration, s)
-			}
-		}
-	}
-
 	return c.client, nil
-}
-
-func rpcConnectionTimeout(cfg config.View) time.Duration {
-	const (
-		name            = "rpcConnectionTimeout"
-		defaultInterval = 300 * time.Millisecond
-	)
-
-	if !cfg.IsSet(name) {
-		return defaultInterval
-	}
-
-	return cfg.GetDuration(name)
 }
 
 // GetHTTP gets a HTTP client with the address.

--- a/internal/rpc/clientcache_test.go
+++ b/internal/rpc/clientcache_test.go
@@ -17,26 +17,19 @@ package rpc
 import (
 	"testing"
 
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 )
 
 const (
-	fakeHTTPAddress            = "http://om-test:54321"
-	fakeGRPCAddress            = "om-test:54321"
-	unavailableFakeGRPCAddress = "om-test-1:54321"
+	fakeHTTPAddress = "http://om-test:54321"
+	fakeGRPCAddress = "om-test:54321"
 )
 
 func TestGetGRPC(t *testing.T) {
 	require := require.New(t)
 
-	// Skipping the connection timeout check
-	cfg := viper.New()
-	cfg.Set("rpcConnectionTimeout", "0")
-	cc := NewClientCache(cfg)
+	cc := NewClientCache(viper.New())
 	client, err := cc.GetGRPC(fakeGRPCAddress)
 	require.Nil(err)
 
@@ -45,17 +38,6 @@ func TestGetGRPC(t *testing.T) {
 
 	// Test caching by comparing pointer value
 	require.EqualValues(client, cachedClient)
-}
-
-func TestGetGRPC_UnavailableAddress(t *testing.T) {
-	require := require.New(t)
-
-	cc := NewClientCache(viper.New())
-	_, err := cc.GetGRPC(unavailableFakeGRPCAddress)
-	require.Error(err)
-
-	code := status.Code(err)
-	require.Equal(codes.Unavailable, code)
 }
 
 func TestGetHTTP(t *testing.T) {

--- a/internal/testing/e2e/common.go
+++ b/internal/testing/e2e/common.go
@@ -164,16 +164,14 @@ const registrationInterval = time.Millisecond * 200
 const proposalCollectionInterval = time.Millisecond * 200
 const pendingReleaseTimeout = time.Millisecond * 200
 const assignedDeleteTimeout = time.Millisecond * 200
-const rpcConnectionTimeout = time.Millisecond * 300
 
-// configFile is the "canonical" test config.  It exactly matches the configmap
+// configFile is the "cononical" test config.  It exactly matches the configmap
 // which is used in the real cluster tests.
 const configFile = `
 registrationInterval: 200ms
 proposalCollectionInterval: 200ms
 pendingReleaseTimeout: 200ms
 assignedDeleteTimeout: 200ms
-rpcConnectionTimeout: 300ms
 queryPageSize: 10
 
 logging:


### PR DESCRIPTION
Reverts googleforgames/open-match#1271 while we figure out how to fix the test, so other PRs aren't blocked.