### PR TITLE
Frontend Create Backfill

### DIFF
--- a/internal/app/frontend/frontend.go
+++ b/internal/app/frontend/frontend.go
@@ -25,8 +25,10 @@ import (
 )
 
 var (
-	totalBytesPerTicket   = stats.Int64("open-match.dev/frontend/total_bytes_per_ticket", "Total bytes per ticket", stats.UnitBytes)
-	searchFieldsPerTicket = stats.Int64("open-match.dev/frontend/searchfields_per_ticket", "Searchfields per ticket", stats.UnitDimensionless)
+	totalBytesPerTicket     = stats.Int64("open-match.dev/frontend/total_bytes_per_ticket", "Total bytes per ticket", stats.UnitBytes)
+	searchFieldsPerTicket   = stats.Int64("open-match.dev/frontend/searchfields_per_ticket", "Searchfields per ticket", stats.UnitDimensionless)
+	totalBytesPerBackfill   = stats.Int64("open-match.dev/frontend/total_bytes_per_backfill", "Total bytes per backfill", stats.UnitBytes)
+	searchFieldsPerBackfill = stats.Int64("open-match.dev/frontend/searchfields_per_backfill", "Searchfields per backfill", stats.UnitDimensionless)
 
 	totalBytesPerTicketView = &view.View{
 		Measure:     totalBytesPerTicket,
@@ -38,6 +40,18 @@ var (
 		Measure:     searchFieldsPerTicket,
 		Name:        "open-match.dev/frontend/searchfields_per_ticket",
 		Description: "SearchFields per ticket",
+		Aggregation: telemetry.DefaultCountDistribution,
+	}
+	totalBytesPerBackfillView = &view.View{
+		Measure:     totalBytesPerBackfill,
+		Name:        "open-match.dev/frontend/total_bytes_per_backfill",
+		Description: "Total bytes per backfill",
+		Aggregation: telemetry.DefaultBytesDistribution,
+	}
+	searchFieldsPerBackfillView = &view.View{
+		Measure:     searchFieldsPerBackfill,
+		Name:        "open-match.dev/frontend/searchfields_per_backfill",
+		Description: "SearchFields per backfill",
 		Aggregation: telemetry.DefaultCountDistribution,
 	}
 )
@@ -56,6 +70,8 @@ func BindService(p *appmain.Params, b *appmain.Bindings) error {
 	b.RegisterViews(
 		totalBytesPerTicketView,
 		searchFieldsPerTicketView,
+		totalBytesPerBackfillView,
+		searchFieldsPerBackfillView,
 	)
 	return nil
 }

--- a/internal/app/frontend/frontend_service.go
+++ b/internal/app/frontend/frontend_service.go
@@ -120,6 +120,7 @@ func doCreateBackfill(ctx context.Context, req *pb.CreateBackfillRequest, store 
 	backfill.Id = xid.New().String()
 	backfill.CreateTime = ptypes.TimestampNow()
 
+
 	sfCount := 0
 	sfCount += len(backfill.GetSearchFields().GetDoubleArgs())
 	sfCount += len(backfill.GetSearchFields().GetStringArgs())
@@ -127,17 +128,9 @@ func doCreateBackfill(ctx context.Context, req *pb.CreateBackfillRequest, store 
 	stats.Record(ctx, searchFieldsPerBackfill.M(int64(sfCount)))
 	stats.Record(ctx, totalBytesPerBackfill.M(int64(proto.Size(backfill))))
 
-	err := store.CreateBackfill(ctx, backfill)
+	err := store.CreateBackfill(ctx, backfill, []string{})
 	if err != nil {
 		return nil, err
-	}
-	// TODO: add IndexBackfill functionality
-	/*
-		err = store.IndexBackfill(ctx, ticket)
-		if err != nil {
-			return nil, err
-		}
-	*/
 
 	return backfill, nil
 }

--- a/internal/app/frontend/frontend_service.go
+++ b/internal/app/frontend/frontend_service.go
@@ -120,7 +120,6 @@ func doCreateBackfill(ctx context.Context, req *pb.CreateBackfillRequest, store 
 	backfill.Id = xid.New().String()
 	backfill.CreateTime = ptypes.TimestampNow()
 
-
 	sfCount := 0
 	sfCount += len(backfill.GetSearchFields().GetDoubleArgs())
 	sfCount += len(backfill.GetSearchFields().GetStringArgs())
@@ -131,7 +130,7 @@ func doCreateBackfill(ctx context.Context, req *pb.CreateBackfillRequest, store 
 	err := store.CreateBackfill(ctx, backfill, []string{})
 	if err != nil {
 		return nil, err
-
+	}
 	return backfill, nil
 }
 
@@ -235,7 +234,8 @@ func (s *frontendService) DeleteBackfill(ctx context.Context, req *pb.DeleteBack
 
 // GetBackfill fetches a Backfill object by its ID.
 func (s *frontendService) GetBackfill(ctx context.Context, req *pb.GetBackfillRequest) (*pb.Backfill, error) {
-	return nil, status.Error(codes.Unimplemented, "not implemented")
+	bf, _, err := s.store.GetBackfill(ctx, req.GetBackfillId())
+	return bf, err
 }
 
 // UpdateBackfill updates a Backfill object, if present.

--- a/internal/app/frontend/frontend_service.go
+++ b/internal/app/frontend/frontend_service.go
@@ -94,6 +94,54 @@ func doCreateTicket(ctx context.Context, req *pb.CreateTicketRequest, store stat
 	return ticket, nil
 }
 
+// CreateBackfill creates a new Backfill object.
+// it assigns an unique Id to the input Backfill and record it in state storage.
+// A Backfill is considered as ready for matchmaking once it is created.
+//   - If SearchFields exist in a Backfill, CreateBackfill will also index these fields such that one can query the ticket with query.QueryBackfills function.
+func (s *frontendService) CreateBackfill(ctx context.Context, req *pb.CreateBackfillRequest) (*pb.Backfill, error) {
+	// Perform input validation.
+	if req.Backfill == nil {
+		return nil, status.Errorf(codes.InvalidArgument, ".backfill is required")
+	}
+	if req.Backfill.CreateTime != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "backfills cannot be created with create time set")
+	}
+
+	return doCreateBackfill(ctx, req, s.store)
+}
+
+func doCreateBackfill(ctx context.Context, req *pb.CreateBackfillRequest, store statestore.Service) (*pb.Backfill, error) {
+	// Generate an id and create a Backfill in state storage
+	backfill, ok := proto.Clone(req.Backfill).(*pb.Backfill)
+	if !ok {
+		return nil, status.Error(codes.Internal, "failed to clone input ticket proto")
+	}
+
+	backfill.Id = xid.New().String()
+	backfill.CreateTime = ptypes.TimestampNow()
+
+	sfCount := 0
+	sfCount += len(backfill.GetSearchFields().GetDoubleArgs())
+	sfCount += len(backfill.GetSearchFields().GetStringArgs())
+	sfCount += len(backfill.GetSearchFields().GetTags())
+	stats.Record(ctx, searchFieldsPerBackfill.M(int64(sfCount)))
+	stats.Record(ctx, totalBytesPerBackfill.M(int64(proto.Size(backfill))))
+
+	err := store.CreateBackfill(ctx, backfill)
+	if err != nil {
+		return nil, err
+	}
+	// TODO: add IndexBackfill functionality
+	/*
+		err = store.IndexBackfill(ctx, ticket)
+		if err != nil {
+			return nil, err
+		}
+	*/
+
+	return backfill, nil
+}
+
 // DeleteTicket immediately stops Open Match from using the Ticket for matchmaking and removes the Ticket from state storage.
 // The client must delete the Ticket when finished matchmaking with it.
 //   - If SearchFields exist in a Ticket, DeleteTicket will deindex the fields lazily.
@@ -184,11 +232,6 @@ func doWatchAssignments(ctx context.Context, id string, sender func(*pb.Assignme
 // AcknowledgeBackfill is used to notify OpenMatch about GameServer connection info.
 // This triggers an assignment process.
 func (s *frontendService) AcknowledgeBackfill(ctx context.Context, req *pb.AcknowledgeBackfillRequest) (*pb.Backfill, error) {
-	return nil, status.Error(codes.Unimplemented, "not implemented")
-}
-
-// CreateBackfill creates a new Backfill object.
-func (s *frontendService) CreateBackfill(ctx context.Context, req *pb.CreateBackfillRequest) (*pb.Backfill, error) {
 	return nil, status.Error(codes.Unimplemented, "not implemented")
 }
 

--- a/internal/app/frontend/frontend_service.go
+++ b/internal/app/frontend/frontend_service.go
@@ -100,6 +100,9 @@ func doCreateTicket(ctx context.Context, req *pb.CreateTicketRequest, store stat
 //   - If SearchFields exist in a Backfill, CreateBackfill will also index these fields such that one can query the ticket with query.QueryBackfills function.
 func (s *frontendService) CreateBackfill(ctx context.Context, req *pb.CreateBackfillRequest) (*pb.Backfill, error) {
 	// Perform input validation.
+	if req == nil {
+		return nil, status.Errorf(codes.InvalidArgument, "request is nil")
+	}
 	if req.Backfill == nil {
 		return nil, status.Errorf(codes.InvalidArgument, ".backfill is required")
 	}

--- a/internal/app/frontend/frontend_service_test.go
+++ b/internal/app/frontend/frontend_service_test.go
@@ -93,7 +93,7 @@ func TestCreateBackfill(t *testing.T) {
 	cfg := viper.New()
 	store, closer := statestoreTesting.NewStoreServiceForTesting(t, cfg)
 	defer closer()
-	ctx, _ := context.WithCancel(utilTesting.NewContext(t))
+	ctx := context.Background()
 	fs := frontendService{cfg, store}
 
 	var testCases = []struct {
@@ -160,21 +160,6 @@ func TestCreateBackfill(t *testing.T) {
 			}
 		})
 	}
-
-	//expect error with canceled context
-
-	ctx, cancel := context.WithCancel(utilTesting.NewContext(t))
-	cancel()
-
-	res, err := doCreateBackfill(ctx, &pb.CreateBackfillRequest{Backfill: &pb.Backfill{
-		SearchFields: &pb.SearchFields{
-			DoubleArgs: map[string]float64{
-				"test-arg": 1,
-			},
-		},
-	}}, store)
-	require.Equal(t, codes.Unavailable.String(), status.Convert(err).Code().String())
-	require.Nil(t, res)
 }
 
 func TestDoWatchAssignments(t *testing.T) {

--- a/internal/testing/e2e/backfill_test.go
+++ b/internal/testing/e2e/backfill_test.go
@@ -1,0 +1,50 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"open-match.dev/open-match/pkg/pb"
+)
+
+// TestCreateGetBackfill Create and Get Backfill test
+func TestCreateGetBackfill(t *testing.T) {
+	om := newOM(t)
+	ctx := context.Background()
+
+	bf := &pb.CreateBackfillRequest{Backfill: &pb.Backfill{SearchFields: &pb.SearchFields{
+		StringArgs: map[string]string{
+			"search": "me",
+		},
+	}}}
+	b1, err := om.Frontend().CreateBackfill(ctx, bf)
+	require.Nil(t, err)
+
+	b2, err := om.Frontend().CreateBackfill(ctx, bf)
+
+	// Different Ids should be generated
+	assert.NotEqual(t, b1.Id, b2.Id)
+	b1.Id = b2.Id
+	b1.CreateTime = b2.CreateTime
+	// Other than that they should be equal
+	assert.Equal(t, b1, b2)
+	require.Nil(t, err)
+	get, err := om.Frontend().GetBackfill(ctx, &pb.GetBackfillRequest{BackfillId: b1.Id})
+	require.Equal(t, b1, get)
+}

--- a/internal/testing/e2e/backfill_test.go
+++ b/internal/testing/e2e/backfill_test.go
@@ -37,14 +37,16 @@ func TestCreateGetBackfill(t *testing.T) {
 	require.Nil(t, err)
 
 	b2, err := om.Frontend().CreateBackfill(ctx, bf)
+	require.Nil(t, err)
 
 	// Different Ids should be generated
 	assert.NotEqual(t, b1.Id, b2.Id)
 	b1.Id = b2.Id
 	b1.CreateTime = b2.CreateTime
-	// Other than that they should be equal
+	// Other than CreateTune abd Id fields, they should be equal
 	assert.Equal(t, b1, b2)
 	require.Nil(t, err)
 	get, err := om.Frontend().GetBackfill(ctx, &pb.GetBackfillRequest{BackfillId: b1.Id})
+	require.Nil(t, err)
 	require.Equal(t, b1, get)
 }


### PR DESCRIPTION
Initial version of CreateBackfill. It stores an empty regular TicketIds list.

**What this PR does / Why we need it**:

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
Wait on StateStare changes.


