### PR TITLE
Backfill: Autoincrement generation on every Backfill update

### DIFF
--- a/internal/app/backend/backend_service.go
+++ b/internal/app/backend/backend_service.go
@@ -386,6 +386,7 @@ func createOrUpdateBackfill(ctx context.Context, match *pb.Match, store statesto
 
 	bf.SearchFields = backfill.SearchFields
 	bf.Extensions = backfill.Extensions
+	bf.Generation++
 
 	return store.UpdateBackfill(ctx, bf, append(ids, ticketIds...))
 }

--- a/internal/app/backend/backend_service.go
+++ b/internal/app/backend/backend_service.go
@@ -356,6 +356,7 @@ func createOrUpdateBackfill(ctx context.Context, match *pb.Match, store statesto
 	if backfill.Id == "" {
 		backfill.Id = xid.New().String()
 		backfill.CreateTime = ptypes.TimestampNow()
+		backfill.Generation = 1
 		return store.CreateBackfill(ctx, backfill, ticketIds)
 	}
 

--- a/internal/app/frontend/frontend_service.go
+++ b/internal/app/frontend/frontend_service.go
@@ -183,6 +183,9 @@ func (s *frontendService) UpdateBackfill(ctx context.Context, req *pb.UpdateBack
 	// Update generation here, because Frontend is used by GameServer only
 	bfStored.SearchFields = backfill.SearchFields
 	bfStored.Extensions = backfill.Extensions
+	// Autoincrement generation, input backfill generation validation is performed
+	// on Backend only (after MMF round)
+	bfStored.Generation++
 	err = s.store.UpdateBackfill(ctx, bfStored, []string{})
 	if err != nil {
 		return nil, err

--- a/internal/app/frontend/frontend_service.go
+++ b/internal/app/frontend/frontend_service.go
@@ -181,7 +181,6 @@ func (s *frontendService) UpdateBackfill(ctx context.Context, req *pb.UpdateBack
 	}
 
 	// Update generation here, because Frontend is used by GameServer only
-	bfStored.Generation++
 	bfStored.SearchFields = backfill.SearchFields
 	bfStored.Extensions = backfill.Extensions
 	err = s.store.UpdateBackfill(ctx, bfStored, []string{})

--- a/internal/statestore/backfill.go
+++ b/internal/statestore/backfill.go
@@ -116,12 +116,15 @@ func (rb *redisBackend) DeleteBackfill(ctx context.Context, id string) error {
 }
 
 // UpdateBackfill updates an existing Backfill with a new data. ticketIDs can be nil.
+// Autoincrement generation, input backfill generation validation is performed on Backend only after MMF round
 func (rb *redisBackend) UpdateBackfill(ctx context.Context, backfill *pb.Backfill, ticketIDs []string) error {
 	redisConn, err := rb.redisPool.GetContext(ctx)
 	if err != nil {
 		return status.Errorf(codes.Unavailable, "UpdateBackfill, id: %s, failed to connect to redis: %v", backfill.GetId(), err)
 	}
 	defer handleConnectionClose(&redisConn)
+
+	backfill.Generation++
 
 	bf := ipb.BackfillInternal{
 		Backfill:  backfill,

--- a/internal/statestore/backfill.go
+++ b/internal/statestore/backfill.go
@@ -116,15 +116,12 @@ func (rb *redisBackend) DeleteBackfill(ctx context.Context, id string) error {
 }
 
 // UpdateBackfill updates an existing Backfill with a new data. ticketIDs can be nil.
-// Autoincrement generation, input backfill generation validation is performed on Backend only after MMF round
 func (rb *redisBackend) UpdateBackfill(ctx context.Context, backfill *pb.Backfill, ticketIDs []string) error {
 	redisConn, err := rb.redisPool.GetContext(ctx)
 	if err != nil {
 		return status.Errorf(codes.Unavailable, "UpdateBackfill, id: %s, failed to connect to redis: %v", backfill.GetId(), err)
 	}
 	defer handleConnectionClose(&redisConn)
-
-	backfill.Generation++
 
 	bf := ipb.BackfillInternal{
 		Backfill:  backfill,

--- a/internal/testing/e2e/backfill_test.go
+++ b/internal/testing/e2e/backfill_test.go
@@ -192,6 +192,7 @@ func TestProposedBackfillCreate(t *testing.T) {
 	require.NotNil(t, actual)
 
 	b.Id = actual.Id
+	b.Generation = 1
 	b.CreateTime = actual.CreateTime
 	require.True(t, proto.Equal(b, actual))
 

--- a/internal/testing/e2e/backfill_test.go
+++ b/internal/testing/e2e/backfill_test.go
@@ -274,6 +274,9 @@ func TestProposedBackfillUpdate(t *testing.T) {
 	actual, err := om.Frontend().GetBackfill(ctx, &pb.GetBackfillRequest{BackfillId: b.Id})
 	require.Nil(t, err)
 	require.NotNil(t, actual)
+
+	// Backfill Generation should be autoincremented
+	b.Generation++
 	require.True(t, proto.Equal(b, actual))
 
 	client, err := om.Query().QueryTickets(ctx, &pb.QueryTicketsRequest{Pool: &pb.Pool{

--- a/internal/testing/e2e/query_backfills_test.go
+++ b/internal/testing/e2e/query_backfills_test.go
@@ -141,7 +141,8 @@ func TestBackfillQueryAfterMMFUpdate(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		require.Len(t, resp.Backfills, 1)
-		require.Equal(t, int64(firstBackfillGeneration), resp.Backfills[0].Generation)
+		// FetchMatches results in a one Backfill update, so Generation is autoincremented
+		require.Equal(t, int64(firstBackfillGeneration)+1, resp.Backfills[0].Generation)
 
 		resp, err = stream.Recv()
 		require.Equal(t, io.EOF, err)

--- a/internal/testing/e2e/query_backfills_test.go
+++ b/internal/testing/e2e/query_backfills_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package e2e
 
 import (


### PR DESCRIPTION
Autoincrement Backfill Generation for QueryBackfills and BackfillCache to work as expected.

**What this PR does / Why we need it**:
In order Backfill Cache to work in QueryBackfill, every update should
store a backfill as a new Generation Backfill.

**Which issue(s) this PR fixes**:
Work on #1294 .

**Special notes for your reviewer**:

In the future Generation could be renamed to Version field in Backfill,
one change at a time.


