### PR TITLE
Move Cleanup Backfills after main SynchronizerCycle & add workers pool

### DIFF
--- a/internal/app/synchronizer/synchronizer_service.go
+++ b/internal/app/synchronizer/synchronizer_service.go
@@ -212,11 +212,6 @@ func (s *synchronizerService) runCycle() {
 	/////////////////////////////////////// Initialize cycle
 	ctx, cancel := contextcause.WithCancelCause(context.Background())
 
-	err := s.store.CleanupBackfills(ctx)
-	if err != nil {
-		logger.Errorf("Failed to clean up backfills, %s", err.Error())
-	}
-
 	m2c := make(chan mAndM6c)
 	m3c := make(chan *pb.Match)
 	m4c := make(chan *pb.Match)
@@ -296,6 +291,11 @@ Registration:
 	})
 
 	<-closedOnCycleEnd
+	err := s.store.CleanupBackfills(ctx)
+	if err != nil {
+		logger.Errorf("Failed to clean up backfills, %s", err.Error())
+	}
+
 	stats.Record(ctx, iterationLatency.M(float64(time.Since(cst)/time.Millisecond)))
 
 	// Clean up in case it was never needed.

--- a/internal/app/synchronizer/synchronizer_service.go
+++ b/internal/app/synchronizer/synchronizer_service.go
@@ -291,15 +291,16 @@ Registration:
 	})
 
 	<-closedOnCycleEnd
-	err := s.store.CleanupBackfills(ctx)
-	if err != nil {
-		logger.Errorf("Failed to clean up backfills, %s", err.Error())
-	}
 
 	stats.Record(ctx, iterationLatency.M(float64(time.Since(cst)/time.Millisecond)))
 
 	// Clean up in case it was never needed.
 	cancelProposalCollection.Stop()
+
+	err := s.store.CleanupBackfills(ctx)
+	if err != nil {
+		logger.Errorf("Failed to clean up backfills, %s", err.Error())
+	}
 }
 
 ///////////////////////////////////////

--- a/internal/statestore/backfill.go
+++ b/internal/statestore/backfill.go
@@ -306,7 +306,6 @@ func (rb *redisBackend) CleanupBackfills(ctx context.Context) error {
 	wg.Add(len(expiredBfIDs))
 	backfillIDsCh := make(chan string, len(expiredBfIDs))
 
-	// TODO: move workers amount to a config parameter
 	for w := 1; w <= 3; w++ {
 		go rb.cleanupWorker(ctx, backfillIDsCh, &wg)
 	}

--- a/internal/statestore/backfill_test.go
+++ b/internal/statestore/backfill_test.go
@@ -732,7 +732,6 @@ func BenchmarkCleanupBackfills(b *testing.B) {
 		err = service.CleanupBackfills(ctx)
 		require.NoError(t, err)
 	}
-
 }
 
 func TestCleanupBackfills(t *testing.T) {

--- a/internal/statestore/backfill_test.go
+++ b/internal/statestore/backfill_test.go
@@ -695,6 +695,46 @@ func generateBackfills(ctx context.Context, t *testing.T, service Service, amoun
 	return backfills
 }
 
+func BenchmarkCleanupBackfills(b *testing.B) {
+	t := &testing.T{}
+	cfg, closer := createRedis(t, false, "")
+	defer closer()
+	service := New(cfg)
+	require.NotNil(t, service)
+	defer service.Close()
+	ctx := utilTesting.NewContext(t)
+
+	rc, err := redis.Dial("tcp", fmt.Sprintf("%s:%s", cfg.GetString("redis.hostname"), cfg.GetString("redis.port")))
+	require.NoError(t, err)
+
+	createStaleBF := func(bfID string, ticketIDs ...string) {
+		bf := &pb.Backfill{
+			Id:         bfID,
+			Generation: 1,
+		}
+		err = service.CreateBackfill(ctx, bf, ticketIDs)
+		require.NoError(t, err)
+
+		_, err = rc.Do("ZADD", "backfill_last_ack_time", 123, bfID)
+		require.NoError(t, err)
+
+		err = service.AddTicketsToPendingRelease(ctx, ticketIDs)
+		require.NoError(t, err)
+
+		err = service.IndexBackfill(ctx, bf)
+		require.NoError(t, err)
+	}
+
+	for n := 0; n < b.N; n++ {
+		for i := 0; i < 50; i++ {
+			createStaleBF(fmt.Sprintf("b-%d", i), fmt.Sprintf("t1-%d", i), fmt.Sprintf("t1-%d", i+1))
+		}
+		err = service.CleanupBackfills(ctx)
+		require.NoError(t, err)
+	}
+
+}
+
 func TestCleanupBackfills(t *testing.T) {
 	cfg, closer := createRedis(t, false, "")
 	defer closer()

--- a/internal/testing/e2e/backfill_test.go
+++ b/internal/testing/e2e/backfill_test.go
@@ -581,7 +581,7 @@ func TestCleanUpExpiredBackfills(t *testing.T) {
 	// wait until backfill is expired, then try to get it
 	time.Sleep(pendingReleaseTimeout * 2)
 
-	// statestore.CleanupBackfills is called at the beginning of each syncronizer cycle after fetch matches call, so expired backfill will be removed
+	// statestore.CleanupBackfills is called at the end of each syncronizer cycle after fetch matches call, so expired backfill will be removed
 	stream, err := om.Backend().FetchMatches(ctx, &pb.FetchMatchesRequest{
 		Config:  om.MMFConfigGRPC(),
 		Profile: &pb.MatchProfile{},

--- a/internal/testing/e2e/backfill_test.go
+++ b/internal/testing/e2e/backfill_test.go
@@ -556,43 +556,37 @@ func TestCleanUpExpiredBackfills(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, b1)
 
-	m := &pb.Match{
-		MatchId:  "1",
-		Tickets:  []*pb.Ticket{t1},
-		Backfill: b1,
-	}
-
 	om.SetMMF(func(ctx context.Context, profile *pb.MatchProfile, out chan<- *pb.Match) error {
-		out <- m
 		return nil
 	})
 
 	om.SetEvaluator(func(ctx context.Context, in <-chan *pb.Match, out chan<- string) error {
-		p, ok := <-in
-		require.True(t, ok)
-		require.True(t, proto.Equal(p, m))
-		_, ok = <-in
-		require.False(t, ok)
-
-		out <- m.MatchId
 		return nil
 	})
 
 	// wait until backfill is expired, then try to get it
 	time.Sleep(pendingReleaseTimeout * 2)
 
-	// statestore.CleanupBackfills is called at the end of each syncronizer cycle after fetch matches call, so expired backfill will be removed
+	// statestore.CleanupBackfills is called at the end of each synchronizer cycle after fetch matches call, so expired backfill will be removed
 	stream, err := om.Backend().FetchMatches(ctx, &pb.FetchMatchesRequest{
 		Config:  om.MMFConfigGRPC(),
 		Profile: &pb.MatchProfile{},
 	})
 	require.NoError(t, err)
+	resp, err := stream.Recv()
+	require.Nil(t, resp)
+	require.Equal(t, io.EOF, err)
 
-	_, err = stream.Recv()
-	require.Error(t, err)
-	e, ok := status.FromError(err)
-	require.True(t, ok)
-	require.Contains(t, e.Message(), "error(s) in FetchMatches call. syncErr=[failed to handle match backfill: 1: rpc error: code = NotFound desc = Backfill id:")
+	// call FetchMatches twice in order to give backfills time to be completely cleaned up
+	stream, err = om.Backend().FetchMatches(ctx, &pb.FetchMatchesRequest{
+		Config:  om.MMFConfigGRPC(),
+		Profile: &pb.MatchProfile{},
+	})
+	require.NoError(t, err)
+
+	resp, err = stream.Recv()
+	require.Nil(t, resp)
+	require.Equal(t, io.EOF, err)
 
 	_, err = om.Frontend().GetBackfill(ctx, &pb.GetBackfillRequest{BackfillId: b1.Id})
 	require.Error(t, err)

--- a/internal/testing/e2e/backfill_test.go
+++ b/internal/testing/e2e/backfill_test.go
@@ -589,6 +589,7 @@ func TestCleanUpExpiredBackfills(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = stream.Recv()
+	require.Error(t, err)
 	e, ok := status.FromError(err)
 	require.True(t, ok)
 	require.Contains(t, e.Message(), "error(s) in FetchMatches call. syncErr=[failed to handle match backfill: 1: rpc error: code = NotFound desc = Backfill id:")


### PR DESCRIPTION
**What this PR does / Why we need it**:
During the contributor's meeting, we agreed with @Laremere to follow this pattern in the cleanup backfills process.
Move CleanupBackfills after main SynchronizerCycle. 

**Special notes for your reviewer**:
There are some benchmarks:

**Using workers pool**
workers=5; expired backfills=50
```BenchmarkCleanupBackfills-12    	      40	  28685354 ns/op	15493765 B/op	   90618 allocs/op```

workers=3; expired backfills=50
```BenchmarkCleanupBackfills-12    	      34	  29910474 ns/op	15493394 B/op	   90614 allocs/op```

workers=1; expired backfills=50
```BenchmarkCleanupBackfills-12    	      26	  40829001 ns/op	15492384 B/op	   90604 allocs/op```

workers=5; expired backfills=200
```BenchmarkCleanupBackfills-12    	       9	 114774808 ns/op	61991684 B/op	  362357 allocs/op```

workers=3; expired backfills=200
```BenchmarkCleanupBackfills-12    	       8	 130279702 ns/op	61985000 B/op	  362315 allocs/op```

workers=1; expired backfills=200
```BenchmarkCleanupBackfills-12    	       7	 200287135 ns/op	61978501 B/op	  362230 allocs/op```

**Previous straightforward implementation**
expired backfills=50
```BenchmarkCleanupBackfills-12    	      25	  41920697 ns/op	15491571 B/op	   90599 allocs/op```

expired backfills=200
```BenchmarkCleanupBackfills-12    	       6	 186510753 ns/op	61971938 B/op	  362200 allocs/op```

As you can see, results with worker=1 are pretty close to not using the worker at all.
Also, there is no big difference between 5 and 3 workers, taking into account that all benchmarks have a margin of error. 

Closes #1324 .
