### PR TITLE
Backfill: Skip not found errors on Backend

### DIFF
--- a/internal/testing/e2e/backfill_test.go
+++ b/internal/testing/e2e/backfill_test.go
@@ -588,10 +588,10 @@ func TestCleanUpExpiredBackfills(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	_, err = stream.Recv()
-	e, ok := status.FromError(err)
-	require.True(t, ok)
-	require.Contains(t, e.Message(), "error(s) in FetchMatches call. syncErr=[failed to handle match backfill: 1: rpc error: code = NotFound desc = Backfill id:")
+	// No matches should be returned
+	resp, err := stream.Recv()
+	require.Nil(t, resp)
+	require.Equal(t, io.EOF, err)
 
 	_, err = om.Frontend().GetBackfill(ctx, &pb.GetBackfillRequest{BackfillId: b1.Id})
 	require.Error(t, err)

--- a/internal/testing/e2e/common.go
+++ b/internal/testing/e2e/common.go
@@ -165,7 +165,7 @@ const proposalCollectionInterval = time.Millisecond * 200
 const pendingReleaseTimeout = time.Second * 1
 const assignedDeleteTimeout = time.Millisecond * 200
 
-// configFile is the "cononical" test config.  It exactly matches the configmap
+// configFile is the "canonical" test config.  It exactly matches the configmap
 // which is used in the real cluster tests.
 const configFile = `
 registrationInterval: 200ms


### PR DESCRIPTION
There could be the case when backfill returned by the MMF was deleted
in CleanupBackfills.

**What this PR does / Why we need it**:
We need neither return an error if UpdateBackfill failed due to deleted Backfill , nor return the match.

**Special notes for your reviewer**:
Relates to #1334 