### PR TITLE
Add seed to Ticket and Backfill ID generation

### DIFF
--- a/internal/app/backend/backend_service.go
+++ b/internal/app/backend/backend_service.go
@@ -368,7 +368,7 @@ func (s *backendService) AssignTickets(ctx context.Context, req *pb.AssignTicket
 
 func createOrUpdateBackfill(ctx context.Context, backfill *pb.Backfill, ticketIds []string, store statestore.Service) error {
 	if backfill.Id == "" {
-		backfill.Id = xid.New().String()
+		backfill.Id = xid.NewWithTime(time.Now()).String()
 		backfill.CreateTime = ptypes.TimestampNow()
 		backfill.Generation = 1
 		err := store.CreateBackfill(ctx, backfill, ticketIds)

--- a/internal/app/frontend/frontend_service.go
+++ b/internal/app/frontend/frontend_service.go
@@ -16,6 +16,7 @@ package frontend
 
 import (
 	"context"
+	"time"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
@@ -71,7 +72,7 @@ func doCreateTicket(ctx context.Context, req *pb.CreateTicketRequest, store stat
 		return nil, status.Error(codes.Internal, "failed to clone input ticket proto")
 	}
 
-	ticket.Id = xid.New().String()
+	ticket.Id = xid.NewWithTime(time.Now()).String()
 	ticket.CreateTime = ptypes.TimestampNow()
 
 	sfCount := 0
@@ -121,7 +122,7 @@ func doCreateBackfill(ctx context.Context, req *pb.CreateBackfillRequest, store 
 		return nil, status.Error(codes.Internal, "failed to clone input ticket proto")
 	}
 
-	backfill.Id = xid.New().String()
+	backfill.Id = xid.NewWithTime(time.Now()).String()
 	backfill.CreateTime = ptypes.TimestampNow()
 	backfill.Generation = 1
 

--- a/internal/statestore/ticket_test.go
+++ b/internal/statestore/ticket_test.go
@@ -55,7 +55,7 @@ func TestTicketLifecycle(t *testing.T) {
 	ctx := utilTesting.NewContext(t)
 
 	// Initialize test data
-	id := xid.New().String()
+	id := xid.NewWithTime(time.Now()).String()
 	ticket := &pb.Ticket{
 		Id: id,
 		SearchFields: &pb.SearchFields{


### PR DESCRIPTION
Add time as seed to xid algorithm.

**What this PR does / Why we need it**:
There could be some errors with tickets always have the same IDs after redeploying OM.

**Special notes for your reviewer**:


