### PR TITLE
Fix minor typos

### DIFF
--- a/examples/demo/bytesub/bytesub.go
+++ b/examples/demo/bytesub/bytesub.go
@@ -37,7 +37,7 @@ func New() *ByteSub {
 	}
 }
 
-// AnnounceLatest writes b to all of the subscribers, with caviets listed in Subscribe.
+// AnnounceLatest writes b to all of the subscribers, with caveats listed in Subscribe.
 func (s *ByteSub) AnnounceLatest(b []byte) {
 	s.r.Lock()
 	defer s.r.Unlock()

--- a/examples/demo/updater/updater.go
+++ b/examples/demo/updater/updater.go
@@ -37,7 +37,7 @@ type Updater struct {
 type SetFunc func(v interface{})
 
 // New creates an Updater.  Set is called when fields update, using the json
-// sererialized value of Updater's tree.  All updates after ctx is canceled are
+// serialized value of Updater's tree.  All updates after ctx is canceled are
 // ignored.
 func New(ctx context.Context, set func([]byte)) *Updater {
 	f := func(v interface{}) {

--- a/examples/functions/golang/backfill/mmf/matchfunction.go
+++ b/examples/functions/golang/backfill/mmf/matchfunction.go
@@ -254,7 +254,7 @@ func newMatch(num int, profile string, tickets []*pb.Ticket, b *pb.Backfill) pb.
 	t := time.Now().Format("2006-01-02T15:04:05.00")
 
 	return pb.Match{
-		MatchId:       fmt.Sprintf("profile-%s-time-%s-num-%d", matchName, t, num),
+		MatchId:       fmt.Sprintf("profile-%s-time-%s-num-%d", profile, t, num),
 		MatchProfile:  profile,
 		MatchFunction: matchName,
 		Tickets:       tickets,

--- a/internal/statestore/public.go
+++ b/internal/statestore/public.go
@@ -80,7 +80,7 @@ type Service interface {
 
 	// GetBackfill gets the Backfill with the specified id from state storage.
 	// This method fails if the Backfill does not exist.
-	// Returns the Backfill and asossiated ticketIDs if they exist.
+	// Returns the Backfill and associated ticketIDs if they exist.
 	GetBackfill(ctx context.Context, id string) (*pb.Backfill, []string, error)
 
 	// GetBackfills returns multiple backfills from storage

--- a/pkg/matchfunction/matchfunction.go
+++ b/pkg/matchfunction/matchfunction.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package matchfunction provides helper methods to simplify authoring a match fuction.
+// Package matchfunction provides helper methods to simplify authoring a match function.
 package matchfunction
 
 import (


### PR DESCRIPTION
There was typos in new Backfill function matchId name.

**What this PR does / Why we need it**:


**Which issue(s) this PR fixes**:
If we are using two profiles with the same Backfill MatchFunction it would produce same matchIds and generates such error in Synchronizer:
```
      "Status": "Encountered error: rpc error: code = Unknown desc = error(s) in FetchMatches call. syncErr=[error receiving match from synchronizer: rpc error: code = Unknown desc = error calling evaluator: multiple match functions used same match_id: \"profile-backfill-matchfunction-time-2021-01-21T17:55:27.65-num-1-c04s\"], mmfErr=[\u003cnil\u003e]",
```

**Special notes for your reviewer**:


