### PR TITLE
Return 404 when deleting ticket/backfill ticket that does not exist

### DIFF
--- a/internal/statestore/backfill.go
+++ b/internal/statestore/backfill.go
@@ -164,7 +164,7 @@ func (rb *redisBackend) GetBackfills(ctx context.Context, ids []string) ([]*pb.B
 	return result, nil
 }
 
-// DeleteBackfill removes the Backfill with the specified id from state storage. This method succeeds if the Backfill does not exist.
+// DeleteBackfill removes the Backfill with the specified id from state storage.
 func (rb *redisBackend) DeleteBackfill(ctx context.Context, id string) error {
 	redisConn, err := rb.redisPool.GetContext(ctx)
 	if err != nil {
@@ -172,10 +172,14 @@ func (rb *redisBackend) DeleteBackfill(ctx context.Context, id string) error {
 	}
 	defer handleConnectionClose(&redisConn)
 
-	_, err = redisConn.Do("DEL", id)
+	value, err := redis.Int(redisConn.Do("DEL", id))
 	if err != nil {
 		err = errors.Wrapf(err, "failed to delete the backfill from state storage, id: %s", id)
 		return status.Errorf(codes.Internal, "%v", err)
+	}
+
+	if value == 0 {
+		return status.Errorf(codes.NotFound, "Backfill id: %s not found", id)
 	}
 
 	return rb.deleteExpiredBackfillID(redisConn, id)

--- a/internal/statestore/ticket.go
+++ b/internal/statestore/ticket.go
@@ -99,10 +99,14 @@ func (rb *redisBackend) DeleteTicket(ctx context.Context, id string) error {
 	}
 	defer handleConnectionClose(&redisConn)
 
-	_, err = redisConn.Do("DEL", id)
+	value, err := redis.Int(redisConn.Do("DEL", id))
 	if err != nil {
 		err = errors.Wrapf(err, "failed to delete the ticket from state storage, id: %s", id)
 		return status.Errorf(codes.Internal, "%v", err)
+	}
+
+	if value == 0 {
+		return status.Errorf(codes.NotFound, "Ticket id: %s not found", id)
 	}
 
 	return nil

--- a/internal/statestore/ticket_test.go
+++ b/internal/statestore/ticket_test.go
@@ -75,7 +75,8 @@ func TestTicketLifecycle(t *testing.T) {
 
 	// Validate nonexisting Ticket deletion
 	err = service.DeleteTicket(ctx, id)
-	require.Nil(t, err)
+	require.NotNil(t, err)
+	require.Equal(t, status.Code(err), codes.NotFound)
 
 	// Validate nonexisting Ticket deindexing
 	err = service.DeindexTicket(ctx, id)
@@ -540,10 +541,16 @@ func TestDeleteTicket(t *testing.T) {
 			expectedMessage: "",
 		},
 		{
-			description:     "empty id passed, no err expected",
+			description:     "empty id passed, err expected",
 			ticketID:        "",
-			expectedCode:    codes.OK,
-			expectedMessage: "",
+			expectedCode:    codes.NotFound,
+			expectedMessage: "Ticket id:  not found",
+		},
+		{
+			description:     "wrong id passed, err expected",
+			ticketID:        "123456",
+			expectedCode:    codes.NotFound,
+			expectedMessage: "Ticket id: 123456 not found",
 		},
 	}
 
@@ -554,11 +561,9 @@ func TestDeleteTicket(t *testing.T) {
 			if tc.expectedCode == codes.OK {
 				require.NoError(t, errActual)
 
-				if tc.ticketID != "" {
-					_, errGetTicket := service.GetTicket(ctx, tc.ticketID)
-					require.Error(t, errGetTicket)
-					require.Equal(t, codes.NotFound.String(), status.Convert(errGetTicket).Code().String())
-				}
+				_, errGetTicket := service.GetTicket(ctx, tc.ticketID)
+				require.Error(t, errGetTicket)
+				require.Equal(t, codes.NotFound.String(), status.Convert(errGetTicket).Code().String())
 			} else {
 				require.Error(t, errActual)
 				require.Equal(t, tc.expectedCode.String(), status.Convert(errActual).Code().String())


### PR DESCRIPTION
**What this PR does / Why we need it**:

Delete requests will return 404 instead of 200 when the resource (ticket) is not found. This does not break the concept of idempotency and will align with get requests as well as the frontend swagger configuration.