### PR TITLE
add mode to profile name for range of game modes

### DIFF
--- a/tutorials/matchmaker101/solution/director/profile.go
+++ b/tutorials/matchmaker101/solution/director/profile.go
@@ -24,7 +24,7 @@ func generateProfiles() []*pb.MatchProfile {
 	modes := []string{"mode.demo", "mode.ctf", "mode.battleroyale"}
 	for _, mode := range modes {
 		profiles = append(profiles, &pb.MatchProfile{
-			Name: "mode_based_profile",
+			Name: "mode_based_profile_" + mode,
 			Pools: []*pb.Pool{
 				{
 					Name: "pool_mode_" + mode,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/open-match/blob/master/CONTRIBUTING.md and developer guide https://github.com/googleforgames/open-match/blob/master/docs/development.md
-->

**What this PR does / Why we need it**:
The tutorial solution to matchmaker101 director fails to fetch matches:
```shell
2021/04/16 19:14:14 Failed to fetch matches for profile mode_based_profile, got rpc error: code = Unknown desc = error(s) in FetchMatches call. syncErr=[error receiving match from synchronizer: rpc error: code = Unknown desc = error calling evaluator: multiple match functions used same match_id: "profile-mode_based_profile-time-2021-04-16T19:14:14.19-0"], mmfErr=[<nil>]
2021/04/16 19:14:14 Failed to fetch matches for profile mode_based_profile, got rpc error: code = Unknown desc = error(s) in FetchMatches call. syncErr=[error receiving match from synchronizer: rpc error: code = Unknown desc = error calling evaluator: multiple match functions used same match_id: "profile-mode_based_profile-time-2021-04-16T19:14:14.19-0"], mmfErr=[<nil>]
2021/04/16 19:14:14 Failed to fetch matches for profile mode_based_profile, got rpc error: code = Unknown desc = error(s) in FetchMatches call. syncErr=[error receiving match from synchronizer: rpc error: code = Unknown desc = error calling evaluator: multiple match functions used same match_id: "profile-mode_based_profile-time-2021-04-16T19:14:14.19-0"], mmfErr=[<nil>]
```

I believe [this merge](https://github.com/googleforgames/open-match/commit/8c6fbcbe49a933b4fbbfa37c77a5bdf4c30cb664) may have introduced this issue.

Upon updating the profile name, the logs read as such:
```shell
2021/04/16 19:36:14 Generated 18 matches for profile mode_based_profile_mode.ctf
2021/04/16 19:36:14 Generated 19 matches for profile mode_based_profile_mode.demo
2021/04/16 19:36:14 Generated 16 matches for profile mode_based_profile_mode.battleroyale
2021/04/16 19:36:14 Assigned server 129.134.57.172:2222 to match profile-mode_based_profile_mode.demo-time-2021-04-16T19:36:14.20-0
2021/04/16 19:36:14 Assigned server 33.15.199.187:2222 to match profile-mode_based_profile_mode.ctf-time-2021-04-16T19:36:14.20-0
2021/04/16 19:36:14 Assigned server 72.164.198.175:2222 to match profile-mode_based_profile_mode.battleroyale-time-2021-04-16T19:36:14.20-0
```

It looks like the matchmaking102 tutorial also prevents this issue [here](https://github.com/googleforgames/open-match/blob/master/tutorials/matchmaker102/solution/director/profile.go#L48).

**Which issue(s) this PR fixes**:
There are no open issues for this issue. 

**Special notes for your reviewer**:
I'm happy to provide additional information and/or logs. 
Cheers 🍻 

