### PR TITLE
Using uuid instead time value to make unique matchId.

### DIFF
--- a/tutorials/matchmaker101/frontend/main.go
+++ b/tutorials/matchmaker101/frontend/main.go
@@ -63,9 +63,12 @@ func main() {
 // once it has an assignment.
 func deleteOnAssign(fe pb.FrontendServiceClient, t *pb.Ticket) {
 	for {
+		time.Sleep(time.Second * 1)
+
 		got, err := fe.GetTicket(context.Background(), &pb.GetTicketRequest{TicketId: t.GetId()})
 		if err != nil {
-			log.Fatalf("Failed to Get Ticket %v, got %s", t.GetId(), err.Error())
+			log.Printf("Failed to Get Ticket %v, got %s", t.GetId(), err.Error())
+			continue
 		}
 
 		if got.GetAssignment() != nil {
@@ -73,7 +76,6 @@ func deleteOnAssign(fe pb.FrontendServiceClient, t *pb.Ticket) {
 			break
 		}
 
-		time.Sleep(time.Second * 1)
 	}
 
 	_, err := fe.DeleteTicket(context.Background(), &pb.DeleteTicketRequest{TicketId: t.GetId()})

--- a/tutorials/matchmaker101/matchfunction/mmf/matchfunction.go
+++ b/tutorials/matchmaker101/matchfunction/mmf/matchfunction.go
@@ -15,21 +15,21 @@
 package mmf
 
 import (
+	"fmt"
 	"log"
-
-	// Uncomment if following the tutorial
-	// "fmt"
-	// "time"
+	"github.com/google/uuid"
 
 	"open-match.dev/open-match/pkg/matchfunction"
 	"open-match.dev/open-match/pkg/pb"
 )
 
+// This match function fetches all the Tickets for all the pools specified in
+// the profile. It uses a configured number of tickets from each pool to generate
+// a Match Proposal. It continues to generate proposals till one of the pools
+// runs out of Tickets.
 const (
-	matchName = "basic-matchfunction"
-
-	// Uncomment if following the tutorial
-	// ticketsPerPoolPerMatch = 4
+	matchName              = "basic-matchfunction"
+	ticketsPerPoolPerMatch = 4
 )
 
 // Run is this match function's implementation of the gRPC call defined in api/matchfunction.proto.
@@ -63,6 +63,33 @@ func (s *MatchFunctionService) Run(req *pb.RunRequest, stream pb.MatchFunction_R
 }
 
 func makeMatches(p *pb.MatchProfile, poolTickets map[string][]*pb.Ticket) ([]*pb.Match, error) {
-	// Add logic to parse the pool tickets and generate matches here.
-	return nil, nil
+	var matches []*pb.Match
+	for {
+		insufficientTickets := false
+		matchTickets := []*pb.Ticket{}
+		for pool, tickets := range poolTickets {
+			if len(tickets) < ticketsPerPoolPerMatch {
+				// This pool is completely drained out. Stop creating matches.
+				insufficientTickets = true
+				break
+			}
+
+			// Remove the Tickets from this pool and add to the match proposal.
+			matchTickets = append(matchTickets, tickets[0:ticketsPerPoolPerMatch]...)
+			poolTickets[pool] = tickets[ticketsPerPoolPerMatch:]
+		}
+
+		if insufficientTickets {
+			break
+		}
+
+		matches = append(matches, &pb.Match{
+			MatchId:       fmt.Sprintf("profile-%v-%s", p.GetName(), uuid.New().String()),
+			MatchProfile:  p.GetName(),
+			MatchFunction: matchName,
+			Tickets:       matchTickets,
+		})
+	}
+
+	return matches, nil
 }

--- a/tutorials/matchmaker101/matchfunction/mmf/matchfunction.go
+++ b/tutorials/matchmaker101/matchfunction/mmf/matchfunction.go
@@ -15,21 +15,21 @@
 package mmf
 
 import (
-	"fmt"
 	"log"
-	"github.com/google/uuid"
+
+	// Uncomment if following the tutorial
+	// "fmt"
+	// "time"
 
 	"open-match.dev/open-match/pkg/matchfunction"
 	"open-match.dev/open-match/pkg/pb"
 )
 
-// This match function fetches all the Tickets for all the pools specified in
-// the profile. It uses a configured number of tickets from each pool to generate
-// a Match Proposal. It continues to generate proposals till one of the pools
-// runs out of Tickets.
 const (
-	matchName              = "basic-matchfunction"
-	ticketsPerPoolPerMatch = 4
+	matchName = "basic-matchfunction"
+
+	// Uncomment if following the tutorial
+	// ticketsPerPoolPerMatch = 4
 )
 
 // Run is this match function's implementation of the gRPC call defined in api/matchfunction.proto.
@@ -63,33 +63,6 @@ func (s *MatchFunctionService) Run(req *pb.RunRequest, stream pb.MatchFunction_R
 }
 
 func makeMatches(p *pb.MatchProfile, poolTickets map[string][]*pb.Ticket) ([]*pb.Match, error) {
-	var matches []*pb.Match
-	for {
-		insufficientTickets := false
-		matchTickets := []*pb.Ticket{}
-		for pool, tickets := range poolTickets {
-			if len(tickets) < ticketsPerPoolPerMatch {
-				// This pool is completely drained out. Stop creating matches.
-				insufficientTickets = true
-				break
-			}
-
-			// Remove the Tickets from this pool and add to the match proposal.
-			matchTickets = append(matchTickets, tickets[0:ticketsPerPoolPerMatch]...)
-			poolTickets[pool] = tickets[ticketsPerPoolPerMatch:]
-		}
-
-		if insufficientTickets {
-			break
-		}
-
-		matches = append(matches, &pb.Match{
-			MatchId:       fmt.Sprintf("profile-%v-%s", p.GetName(), uuid.New().String()),
-			MatchProfile:  p.GetName(),
-			MatchFunction: matchName,
-			Tickets:       matchTickets,
-		})
-	}
-
-	return matches, nil
+	// Add logic to parse the pool tickets and generate matches here.
+	return nil, nil
 }

--- a/tutorials/matchmaker101/solution/matchfunction/mmf/matchfunction.go
+++ b/tutorials/matchmaker101/solution/matchfunction/mmf/matchfunction.go
@@ -17,7 +17,7 @@ package mmf
 import (
 	"fmt"
 	"log"
-	"time"
+	"github.com/google/uuid"
 
 	"open-match.dev/open-match/pkg/matchfunction"
 	"open-match.dev/open-match/pkg/pb"
@@ -64,7 +64,6 @@ func (s *MatchFunctionService) Run(req *pb.RunRequest, stream pb.MatchFunction_R
 
 func makeMatches(p *pb.MatchProfile, poolTickets map[string][]*pb.Ticket) ([]*pb.Match, error) {
 	var matches []*pb.Match
-	count := 0
 	for {
 		insufficientTickets := false
 		matchTickets := []*pb.Ticket{}
@@ -85,13 +84,11 @@ func makeMatches(p *pb.MatchProfile, poolTickets map[string][]*pb.Ticket) ([]*pb
 		}
 
 		matches = append(matches, &pb.Match{
-			MatchId:       fmt.Sprintf("profile-%v-time-%v-%v", p.GetName(), time.Now().Format("2006-01-02T15:04:05.00"), count),
+			MatchId:       fmt.Sprintf("profile-%v-%s", p.GetName(), uuid.New().String()),
 			MatchProfile:  p.GetName(),
 			MatchFunction: matchName,
 			Tickets:       matchTickets,
 		})
-
-		count++
 	}
 
 	return matches, nil

--- a/tutorials/matchmaker101/solution/matchfunction/mmf/matchfunction.go
+++ b/tutorials/matchmaker101/solution/matchfunction/mmf/matchfunction.go
@@ -17,7 +17,8 @@ package mmf
 import (
 	"fmt"
 	"log"
-	"github.com/google/uuid"
+
+	"github.com/rs/xid"
 
 	"open-match.dev/open-match/pkg/matchfunction"
 	"open-match.dev/open-match/pkg/pb"
@@ -84,7 +85,7 @@ func makeMatches(p *pb.MatchProfile, poolTickets map[string][]*pb.Ticket) ([]*pb
 		}
 
 		matches = append(matches, &pb.Match{
-			MatchId:       fmt.Sprintf("profile-%v-%s", p.GetName(), uuid.New().String()),
+			MatchId:       fmt.Sprintf("profile-%v-%s", p.GetName(), xid.New().String()),
 			MatchProfile:  p.GetName(),
 			MatchFunction: matchName,
 			Tickets:       matchTickets,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/open-match/blob/master/CONTRIBUTING.md and developer guide https://github.com/googleforgames/open-match/blob/master/docs/development.md
-->

**What this PR does / Why we need it**:
I did try tutorial matchmaker101 in open-match 1.2.0 and
I got many errors of "multiple match functions used same match_id".
```2021/09/12 03:52:37 Failed to fetch matches for profile mode_based_profile, got rpc error: code = Unknown desc = error(s) in FetchMatches call. syncErr=[error receiving match from synchronizer: rpc error: code = Unknown desc = error calling evaluator: multiple match functions used same match_id: "profile-mode_based_profile-time-2021-09-12T03:52:37.39-0"], mmfErr=[<nil>]```

I guess matchfunction is called concurrently.
matchId should be unique so I used uuid for that instead time.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #

**Special notes for your reviewer**:


