### PR TITLE
fix outdated apiVersion in frontend scale testing helm template

### DIFF
--- a/install/helm/open-match/subcharts/open-match-scale/templates/scale-frontend.yaml
+++ b/install/helm/open-match/subcharts/open-match-scale/templates/scale-frontend.yaml
@@ -31,7 +31,7 @@ spec:
     protocol: TCP
     port: {{ .Values.scaleFrontend.httpPort }}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "openmatchscale.scaleFrontend.hostName" . }}


### PR DESCRIPTION



**What this PR does / Why we need it**:
Recent k8s APIs remove `Deployment` from `extensions/v1beta1`, it's now in `apps/v1`.

**Which issue(s) this PR fixes**:
Without this update, yaml generated by this template fails with
`no matches for kind "Deployment" in version "extensions/v1beta1"`

