### PR TITLE
AssignTickets empty check and test cases added

### DIFF
--- a/internal/statestore/ticket.go
+++ b/internal/statestore/ticket.go
@@ -255,6 +255,10 @@ func (rb *redisBackend) UpdateAssignments(ctx context.Context, req *pb.AssignTic
 		}
 	}
 
+	if len(idsI) == 0 {
+		return nil, nil, status.Error(codes.InvalidArgument, "AssignmentGroupTicketIds is empty")
+	}
+
 	ticketBytes, err := redis.ByteSlices(redisConn.Do("MGET", idsI...))
 	if err != nil {
 		return nil, nil, err

--- a/internal/statestore/ticket_test.go
+++ b/internal/statestore/ticket_test.go
@@ -229,6 +229,23 @@ func TestUpdateAssignments(t *testing.T) {
 			},
 		},
 		{
+			description: "empty ticketIds, error expected",
+			request: &pb.AssignTicketsRequest{
+				Assignments: []*pb.AssignmentGroup{
+					{
+						TicketIds:  []string{},
+						Assignment: &pb.Assignment{Connection: "2"},
+					},
+				},
+			},
+			expected: expected{
+				resp:               nil,
+				errCode:            codes.InvalidArgument,
+				errMessage:         "AssignmentGroupTicketIds is empty",
+				assignedTicketsIDs: nil,
+			},
+		},
+		{
 			description: "nil assignment, error expected",
 			request: &pb.AssignTicketsRequest{
 				Assignments: []*pb.AssignmentGroup{

--- a/internal/testing/e2e/ticket_test.go
+++ b/internal/testing/e2e/ticket_test.go
@@ -74,6 +74,27 @@ func TestAssignTickets(t *testing.T) {
 	require.Equal(t, "b", get.Assignment.Connection)
 }
 
+// TestAssignTicketsEmpty covers calls to assign when empty TicketIds
+func TestAssignTicketsEmpty(t *testing.T) {
+	om := newOM(t)
+	ctx := context.Background()
+
+	req := &pb.AssignTicketsRequest{
+		Assignments: []*pb.AssignmentGroup{
+			{
+				TicketIds:  []string{},
+				Assignment: &pb.Assignment{Connection: "a"},
+			},
+		},
+	}
+
+	resp, err := om.Backend().AssignTickets(ctx, req)
+	require.Nil(t, resp)
+	require.Equal(t, codes.InvalidArgument.String(), status.Convert(err).Code().String())
+	require.Equal(t, "AssignmentGroupTicketIds is empty", status.Convert(err).Message())
+
+}
+
 // TestAssignTicketsInvalidArgument covers various invalid calls to assign
 // tickets.
 func TestAssignTicketsInvalidArgument(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/open-match/blob/master/CONTRIBUTING.md and developer guide https://github.com/googleforgames/open-match/blob/master/docs/development.md
-->

**What this PR does / Why we need it**: When making a call to `AssignTicketsRequest`, To check at least one of the `AssignmentGroup` have at least one `ticket_ids` present such that redis command doesn't throw error.
```
time="2020-10-09T12:38:09Z" level=error msg="failed to update assignments" app=openmatch component=app.backend error="ERR wrong number of arguments for 'mget' command"
time="2020-10-09T12:38:09Z" level=error msg="failed to update assignments for requested tickets" app=openmatch component=app.backend error="ERR wrong number of arguments for 'mget' command"
```

To prevent the code execution from going into this situation, we can check the length of the array containing all `ticket_ids`, so that in case `AssignmentGroup` doesn't contain any value in `ticket_ids` will return error `codes.InvalidArgument`
 
**Which issue(s) this PR fixes**: #1266 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #

**Special notes for your reviewer**:
unit test case condition added: `TestUpdateAssignments`

> description: "empty ticketIds, error expected"
> errMessage:         "AssignmentGroupTicketIds is empty"
> 

e2e test case added: `TestAssignTicketsEmpty`

