### PR TITLE
Fix tutorial images not building due to locally specified open-match version

### DIFF
--- a/tutorials/matchmaker101/director/Dockerfile
+++ b/tutorials/matchmaker101/director/Dockerfile
@@ -15,8 +15,10 @@
 FROM golang:alpine as go
 WORKDIR /app
 ENV GO111MODULE=on
-
+RUN apk add --no-cache git
 COPY . .
+RUN go mod edit -replace open-match.dev/open-match@v0.0.0-dev=open-match.dev/open-match@latest
+RUN go mod tidy
 RUN go build -o director .
 
 CMD ["/app/director"]

--- a/tutorials/matchmaker101/frontend/Dockerfile
+++ b/tutorials/matchmaker101/frontend/Dockerfile
@@ -15,8 +15,10 @@
 FROM golang:alpine as go
 WORKDIR /app
 ENV GO111MODULE=on
-
+RUN apk add --no-cache git
 COPY . .
+RUN go mod edit -replace open-match.dev/open-match@v0.0.0-dev=open-match.dev/open-match@latest
+RUN go mod tidy
 RUN go build -o frontend .
 
 CMD ["/app/frontend"]

--- a/tutorials/matchmaker101/matchfunction/Dockerfile
+++ b/tutorials/matchmaker101/matchfunction/Dockerfile
@@ -15,8 +15,10 @@
 FROM golang:alpine as go
 WORKDIR /app
 ENV GO111MODULE=on
-
+RUN apk add --no-cache git
 COPY . .
+RUN go mod edit -replace open-match.dev/open-match@v0.0.0-dev=open-match.dev/open-match@latest
+RUN go mod tidy
 RUN go build -o matchfunction .
 
 CMD ["/app/matchfunction"]


### PR DESCRIPTION
**What this PR does / Why we need it**:
Specifies the tutorial project images to use the remote open-match versions instead of the local project one
Fixes the issue I had described here: https://github.com/googleforgames/open-match-docs/issues/252
Similar to https://github.com/googleforgames/open-match/pull/1220
**Which issue(s) this PR fixes**:
Closes https://github.com/googleforgames/open-match-docs/issues/252.

