### PR TITLE
Update WatchAssignment function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -636,7 +636,7 @@ delete-kind-cluster: build/toolchain/bin/kind$(EXE_EXTENSION) build/toolchain/bi
 create-cluster-role-binding:
 	$(KUBECTL) create clusterrolebinding myname-cluster-admin-binding --clusterrole=cluster-admin --user=$(GCLOUD_ACCOUNT_EMAIL)
 
-create-gke-cluster: GKE_VERSION = 1.21.11-gke.900 # gcloud beta container get-server-config --zone us-west1-a
+create-gke-cluster: GKE_VERSION = 1.22.8-gke.202 # gcloud beta container get-server-config --zone us-west1-a
 create-gke-cluster: GKE_CLUSTER_SHAPE_FLAGS = --machine-type n1-standard-8 --enable-autoscaling --min-nodes 1 --num-nodes 6 --max-nodes 10 --disk-size 50
 create-gke-cluster: GKE_FUTURE_COMPAT_FLAGS = --no-enable-basic-auth --no-issue-client-certificate --enable-ip-alias --metadata disable-legacy-endpoints=true --enable-autoupgrade
 create-gke-cluster: build/toolchain/bin/kubectl$(EXE_EXTENSION) gcloud
@@ -645,7 +645,7 @@ create-gke-cluster: build/toolchain/bin/kubectl$(EXE_EXTENSION) gcloud
 		--cluster-version $(GKE_VERSION) \
 		--image-type cos_containerd \
 		--tags open-match \
-		--workload-pool $(PROJECT_ID).svc.id.goog
+		--workload-pool $(GCP_PROJECT_ID).svc.id.goog
 	$(MAKE) create-cluster-role-binding
 	
 

--- a/internal/app/frontend/frontend_service.go
+++ b/internal/app/frontend/frontend_service.go
@@ -227,6 +227,7 @@ func (s *frontendService) DeleteBackfill(ctx context.Context, req *pb.DeleteBack
 // DeleteTicket immediately stops Open Match from using the Ticket for matchmaking and removes the Ticket from state storage.
 // The client must delete the Ticket when finished matchmaking with it.
 //   - If SearchFields exist in a Ticket, DeleteTicket will deindex the fields lazily.
+//
 // Users may still be able to assign/get a ticket after calling DeleteTicket on it.
 func (s *frontendService) DeleteTicket(ctx context.Context, req *pb.DeleteTicketRequest) (*empty.Empty, error) {
 	err := doDeleteTicket(ctx, req.GetTicketId(), s.store)
@@ -277,39 +278,37 @@ func (s *frontendService) GetTicket(ctx context.Context, req *pb.GetTicketReques
 //   - If the Assignment is not updated, GetAssignment will retry using the configured backoff strategy.
 func (s *frontendService) WatchAssignments(req *pb.WatchAssignmentsRequest, stream pb.FrontendService_WatchAssignmentsServer) error {
 	ctx := stream.Context()
-	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-			sender := func(assignment *pb.Assignment) error {
-				return stream.Send(&pb.WatchAssignmentsResponse{Assignment: assignment})
-			}
-			return doWatchAssignments(ctx, req.GetTicketId(), sender, s.store)
-		}
+	sender := func(assignment *pb.Assignment) error {
+		return stream.Send(&pb.WatchAssignmentsResponse{Assignment: assignment})
 	}
+	return doWatchAssignments(ctx, req.GetTicketId(), sender, s.store)
 }
 
 func doWatchAssignments(ctx context.Context, id string, sender func(*pb.Assignment) error, store statestore.Service) error {
 	var currAssignment *pb.Assignment
 	var ok bool
 	callback := func(assignment *pb.Assignment) error {
-		if ctx.Err() != nil {
+		select {
+		case <-ctx.Done():
 			return status.Errorf(codes.Aborted, ctx.Err().Error())
-		}
-
-		if (currAssignment == nil && assignment != nil) || !proto.Equal(currAssignment, assignment) {
-			currAssignment, ok = proto.Clone(assignment).(*pb.Assignment)
-			if !ok {
-				return status.Error(codes.Internal, "failed to cast the assignment object")
+		default:
+			if ctx.Err() != nil {
+				return status.Errorf(codes.Aborted, ctx.Err().Error())
 			}
 
-			err := sender(currAssignment)
-			if err != nil {
-				return status.Errorf(codes.Aborted, err.Error())
+			if (currAssignment == nil && assignment != nil) || !proto.Equal(currAssignment, assignment) {
+				currAssignment, ok = proto.Clone(assignment).(*pb.Assignment)
+				if !ok {
+					return status.Error(codes.Internal, "failed to cast the assignment object")
+				}
+
+				err := sender(currAssignment)
+				if err != nil {
+					return status.Errorf(codes.Aborted, err.Error())
+				}
 			}
+			return nil
 		}
-		return nil
 	}
 
 	return store.GetAssignments(ctx, id, callback)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/open-match/blob/master/CONTRIBUTING.md and developer guide https://github.com/googleforgames/open-match/blob/master/docs/development.md
-->

**What this PR does / Why we need it**: This PR modifies the `FrontendService.WatchAssignment` function and listens to the `ctx.Done` functionality of GRPC stream in callback function so that in every retry of callback function, it is checked whether the user has terminated this API call or not.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #1472 

**Special notes for your reviewer**:
- Updated the GKE version for regular channel support (i.e. 1.22.8-gke.202) [Reference](https://cloud.google.com/kubernetes-engine/docs/release-notes)
