### PR TITLE
Default values of configs

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -58,6 +58,30 @@ func Read() (*viper.Viper, error) {
 		return nil, fmt.Errorf("fatal error reading override config file, desc: %s", err.Error())
 	}
 
+	if !cfg.IsSet("registrationInterval") {
+		log.Printf("config: registrationInterval is not set in matchmaker_config_override.yaml")
+	}
+
+	if !cfg.IsSet("proposalCollectionInterval") {
+		log.Printf("config: proposalCollectionInterval is not set in matchmaker_config_override.yaml")
+	}
+
+	if !cfg.IsSet("pendingReleaseTimeout") {
+		log.Printf("config: pendingReleaseTimeout is not set in matchmaker_config_override.yaml")
+	}
+
+	if !cfg.IsSet("assignedDeleteTimeout") {
+		log.Printf("config: assignedDeleteTimeout is not set in matchmaker_config_override.yaml")
+	}
+
+	if !cfg.IsSet("queryPageSize") {
+		log.Printf("config: queryPageSize is not set in matchmaker_config_override.yaml")
+	}
+
+	if !cfg.IsSet("backfillLockTimeout") {
+		log.Printf("config: backfillLockTimeout is not set in matchmaker_config_override.yaml")
+	}
+
 	// Look for updates to the config; in Kubernetes, this is implemented using
 	// a ConfigMap that is written to the matchmaker_config_override.yaml file, which is
 	// what the Open Match components using Viper monitor for changes.

--- a/internal/statestore/ticket.go
+++ b/internal/statestore/ticket.go
@@ -155,7 +155,7 @@ func (rb *redisBackend) GetIndexedIDSet(ctx context.Context) (map[string]struct{
 	}
 	defer handleConnectionClose(&redisConn)
 
-	ttl := rb.cfg.GetDuration("pendingReleaseTimeout")
+	ttl := getBackfillReleaseTimeout(rb.cfg)
 	curTime := time.Now()
 	endTimeInt := curTime.Add(time.Hour).UnixNano()
 	startTimeInt := curTime.Add(-ttl).UnixNano()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/open-match/blob/master/CONTRIBUTING.md and developer guide https://github.com/googleforgames/open-match/blob/master/docs/development.md
-->

**What this PR does / Why we need it**:  This PR sets the default values of various configs in matchmaker_config_override.yaml file of open-match override configmap to ensure smooth start-up of all deployments in case any config is missing or omitted. Below is the list of default values of respective configs:

- registrationInterval: 1s
- proposalCollectionInterval: 10s
- pendingReleaseTimeout: 1m
- assignedDeleteTimeout: 10m
- queryPageSize: 1000
- backfillLockTimeout: 1m

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #1013 

**Special notes for your reviewer**:


