### PR TITLE
update helm chart repo link

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -292,7 +292,7 @@ $(foreach IMAGE,$(IMAGES),clean-$(IMAGE)-image): clean-%-image:
 
 #####################################################################################################################
 update-chart-deps: build/toolchain/bin/helm$(EXE_EXTENSION)
-	(cd $(REPOSITORY_ROOT)/install/helm/open-match; $(HELM) repo add incubator https://charts.helm.sh/incubator; $(HELM) repo add bitnami https://charts.bitnami.com/bitnami;$(HELM) dependency update)
+	(cd $(REPOSITORY_ROOT)/install/helm/open-match; $(HELM) repo add incubator https://charts.helm.sh/incubator; $(HELM) repo add bitnami-full-index https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami;$(HELM) dependency update)
 
 lint-chart: build/toolchain/bin/helm$(EXE_EXTENSION) build/toolchain/bin/ct$(EXE_EXTENSION)
 	(cd $(REPOSITORY_ROOT)/install/helm; $(HELM) lint $(OPEN_MATCH_HELM_NAME))

--- a/install/helm/open-match/Chart.yaml
+++ b/install/helm/open-match/Chart.yaml
@@ -19,7 +19,7 @@ name: open-match
 dependencies:
   - name: redis
     version: 16.3.1
-    repository: https://charts.bitnami.com/bitnami
+    repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
     condition: open-match-core.redis.enabled
   - name: open-match-telemetry
     version: 0.0.0-dev


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
If this is your first time, please read our contributor guidelines: https://github.com/googleforgames/open-match/blob/master/CONTRIBUTING.md and developer guide https://github.com/googleforgames/open-match/blob/master/docs/development.md
-->

**What this PR does / Why we need it**: This PR contains the changes required for update to repo link of Bitnami's helm chart where the redis's archived chart can be fetched. The updated retention policy for bitnami's helm charts keeps the newly published charts for 6 months before moving to archive.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #1523 

**Special notes for your reviewer**:


