### PR TITLE
Fix: add Content-Type and Transfer-Encoding to matchfunction:run POST request

### DIFF
--- a/internal/app/backend/backend_service.go
+++ b/internal/app/backend/backend_service.go
@@ -279,6 +279,8 @@ func callHTTPMmf(ctx context.Context, cc *rpc.ClientCache, profile *pb.MatchProf
 	if err != nil {
 		return status.Errorf(codes.FailedPrecondition, "failed to create mmf http request for profile %s: %s", profile.GetName(), err.Error())
 	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Transfer-Encoding", "chunked")
 
 	resp, err := client.Do(req.WithContext(ctx))
 	if err != nil {


### PR DESCRIPTION
**What this PR does / Why we need it**:

The HTTP POST request to run the Match Function (`/v1/matchfunction:run`) currently has no `Content-Type` header on it. This prevents parsing utils (such as https://www.npmjs.com/package/body-parser) from automatically being able to parse the JSON body. This PR adds the missing `Content-Type` header as well as the `Transfer-Encoding` header.

**Which issue(s) this PR fixes**:
There is no associated issue for this.

**Special notes for your reviewer**:
Here is the Slack conversation about this issue: https://open-match.slack.com/archives/CCD3H0L2D/p1673486707254609

