### PR TITLE
Redis helm chart

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian
+FROM debian:bullseye
 
 RUN apt-get update
 RUN apt-get install -y -qq git make python3 virtualenv curl sudo unzip apt-transport-https ca-certificates curl software-properties-common gnupg2
@@ -31,9 +31,7 @@ RUN sudo apt-get install -y -qq docker-ce docker-ce-cli containerd.io
 RUN export CLOUD_SDK_REPO="cloud-sdk-stretch" && \
     echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
-    apt-get update -y && apt-get install google-cloud-sdk google-cloud-sdk-app-engine-go -y -qq && \
-    sudo apt-get update -y && \
-    sudo apt-get install -y google-cloud-sdk-gke-gcloud-auth-plugin
+    apt-get update -y && apt-get install -y qq google-cloud-sdk google-cloud-sdk-app-engine-go google-cloud-sdk-gke-gcloud-auth-plugin
 
 # Install Golang
 # https://github.com/docker-library/golang/blob/master/1.14/stretch/Dockerfile

--- a/Makefile
+++ b/Makefile
@@ -758,7 +758,8 @@ endef
 ## # Run go tests
 ## make test
 ##
-test: $(ALL_PROTOS) tls-certs third_party/
+test: $(GO) mod tidy \
+    $(ALL_PROTOS) tls-certs third_party/
 	$(call test_folder,.)
 
 ## # Run go tests more quickly, but with worse flake and race detection

--- a/Makefile
+++ b/Makefile
@@ -77,9 +77,7 @@ CHART_TESTING_VERSION = 2.4.0
 REDIS_DEV_PASSWORD = helloworld
 
 ENABLE_SECURITY_HARDENING = 0
-# GO = GO111MODULE=on go
-export GO111MODULE=on
-GO=go
+GO = GO111MODULE=on go
 # Defines the absolute local directory of the open-match project
 REPOSITORY_ROOT := $(patsubst %/,%,$(dir $(abspath $(MAKEFILE_LIST))))
 BUILD_DIR = $(REPOSITORY_ROOT)/build

--- a/Makefile
+++ b/Makefile
@@ -293,7 +293,7 @@ $(foreach IMAGE,$(IMAGES),clean-$(IMAGE)-image): clean-%-image:
 
 #####################################################################################################################
 update-chart-deps: build/toolchain/bin/helm$(EXE_EXTENSION)
-	(cd $(REPOSITORY_ROOT)/install/helm/open-match; $(HELM) repo add incubator https://charts.helm.sh/incubator; $(HELM) repo add bitnami-full-index https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami;$(HELM) dependency update)
+	(cd $(REPOSITORY_ROOT)/install/helm/open-match; $(HELM) repo add incubator https://charts.helm.sh/incubator; $(HELM) repo add bitnami https://charts.bitnami.com/bitnami;$(HELM) dependency update)
 
 lint-chart: build/toolchain/bin/helm$(EXE_EXTENSION) build/toolchain/bin/ct$(EXE_EXTENSION)
 	(cd $(REPOSITORY_ROOT)/install/helm; $(HELM) lint $(OPEN_MATCH_HELM_NAME))

--- a/Makefile
+++ b/Makefile
@@ -758,8 +758,7 @@ endef
 ## # Run go tests
 ## make test
 ##
-test: go mod tidy \
-	$(ALL_PROTOS) tls-certs third_party/
+test: $(ALL_PROTOS) tls-certs third_party/
 	$(call test_folder,.)
 
 ## # Run go tests more quickly, but with worse flake and race detection

--- a/Makefile
+++ b/Makefile
@@ -758,7 +758,7 @@ endef
 ## # Run go tests
 ## make test
 ##
-test: GO111MODULE=on $(GO) mod tidy \
+test: go mod tidy \
 	$(ALL_PROTOS) tls-certs third_party/
 	$(call test_folder,.)
 

--- a/Makefile
+++ b/Makefile
@@ -758,7 +758,7 @@ endef
 ## # Run go tests
 ## make test
 ##
-test: $(GO) mod tidy \
+test: $(GO) mod tidy
     $(ALL_PROTOS) tls-certs third_party/
 	$(call test_folder,.)
 

--- a/Makefile
+++ b/Makefile
@@ -760,9 +760,9 @@ endef
 ## # Run go tests
 ## make test
 ##
-test: $(GO) mod tidy
-	$(ALL_PROTOS) tls-certs third_party/
+test: $(ALL_PROTOS) tls-certs third_party/
 	$(call test_folder,.)
+	$(GO) mod tidy
 
 ## # Run go tests more quickly, but with worse flake and race detection
 ## make fasttest

--- a/Makefile
+++ b/Makefile
@@ -758,7 +758,8 @@ endef
 ## # Run go tests
 ## make test
 ##
-test: $(ALL_PROTOS) tls-certs third_party/
+test: $(GO) mod tidy
+	$(ALL_PROTOS) tls-certs third_party/
 	$(call test_folder,.)
 
 ## # Run go tests more quickly, but with worse flake and race detection

--- a/Makefile
+++ b/Makefile
@@ -758,7 +758,7 @@ endef
 ## # Run go tests
 ## make test
 ##
-test: $(GO) mod tidy
+test: $(GO) mod tidy \
 	$(ALL_PROTOS) tls-certs third_party/
 	$(call test_folder,.)
 

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,9 @@ CHART_TESTING_VERSION = 2.4.0
 REDIS_DEV_PASSWORD = helloworld
 
 ENABLE_SECURITY_HARDENING = 0
-GO = GO111MODULE=on go
+# GO = GO111MODULE=on go
+export GO111MODULE=on
+GO=go
 # Defines the absolute local directory of the open-match project
 REPOSITORY_ROOT := $(patsubst %/,%,$(dir $(abspath $(MAKEFILE_LIST))))
 BUILD_DIR = $(REPOSITORY_ROOT)/build

--- a/Makefile
+++ b/Makefile
@@ -758,7 +758,7 @@ endef
 ## # Run go tests
 ## make test
 ##
-test: $(GO) mod tidy \
+test: GO111MODULE=on $(GO) mod tidy \
 	$(ALL_PROTOS) tls-certs third_party/
 	$(call test_folder,.)
 

--- a/Makefile
+++ b/Makefile
@@ -758,8 +758,7 @@ endef
 ## # Run go tests
 ## make test
 ##
-test: $(GO) mod tidy
-    $(ALL_PROTOS) tls-certs third_party/
+test: $(ALL_PROTOS) tls-certs third_party/
 	$(call test_folder,.)
 
 ## # Run go tests more quickly, but with worse flake and race detection

--- a/install/helm/open-match/Chart.yaml
+++ b/install/helm/open-match/Chart.yaml
@@ -18,8 +18,8 @@ version: 0.0.0-dev
 name: open-match
 dependencies:
   - name: redis
-    version: 16.3.1
-    repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
+    version: 17.7.3
+    repository: https://charts.bitnami.com/bitnami
     condition: open-match-core.redis.enabled
   - name: open-match-telemetry
     version: 0.0.0-dev

--- a/install/helm/open-match/templates/_helpers.tpl
+++ b/install/helm/open-match/templates/_helpers.tpl
@@ -112,7 +112,7 @@ resources:
 {{- if .Values.redis.auth.enabled	 }}
 - name: redis-password
   secret:
-    secretName: {{ include "call-nested" (list . "redis" "redis.fullname") }}
+    secretName: {{ include "call-nested" (list . "redis" "common.names.fullname") }}
 {{- end -}}
 {{- end -}}
 
@@ -240,7 +240,7 @@ http://{{ include "call-nested" (list . "open-match-telemetry.jaeger" "jaeger.co
 
 {{/*
 Call templates from sub-charts in a synthesized context, workaround for https://github.com/helm/helm/issues/3920
-Mainly useful for things like `{{ include "call-nested" (list . "redis" "redis.fullname") }}`
+Mainly useful for things like `{{ include "call-nested" (list . "redis" "common.names.fullname") }}`
 https://github.com/helm/helm/issues/4535#issuecomment-416022809
 https://github.com/helm/helm/issues/4535#issuecomment-477778391
 */}}

--- a/install/helm/open-match/templates/om-configmap-default.yaml
+++ b/install/helm/open-match/templates/om-configmap-default.yaml
@@ -95,12 +95,24 @@ data:
       sentinelPort: {{ .Values.redis.sentinel.port }}
       sentinelMaster: {{ .Values.redis.sentinel.masterSet }}
       sentinelHostname: {{ include "call-nested" (list . "redis" "common.names.fullname") }}
-      sentinelUsePassword: {{ .Values.redis.auth.sentinel }}
+      sentinelUsePassword: {{ .Values.redis.sentinel.usePassword }}
 {{- else}}
       # Open Match's default Redis setups
       hostname: {{ include "call-nested" (list . "redis" "common.names.fullname") }}-master.{{ .Release.Namespace }}.svc.cluster.local
+      {{- if .Values.redis.redisPort }}
+      # source value: redis.redisPort = {{ .Values.redis.redisPort }}
       port: {{ .Values.redis.redisPort }}
+      {{- else if index .Values "open-match-core" "redis" "port" }}
+      # source value: open-match-core.redis.port = {{ index .Values "open-match-core" "redis" "port"}}
+      port: {{    index .Values "open-match-core" "redis" "port" }}
+      {{- end }}
+      {{- if .Values.redis.user }}
+      # source value: redis.user = {{ .Values.redis.user }}
       user: {{ .Values.redis.user }}
+      {{- else if index .Values "open-match-core" "redis" "user" }}
+      # source value: open-match-core.redis.user = {{ index .Values "open-match-core" "redis" "user"}}
+      user: {{ index .Values "open-match-core" "redis" "user"}}
+      {{- end }}
 {{- end}}
 {{- else }}
       # BYO Redis setups

--- a/install/helm/open-match/values-production.yaml
+++ b/install/helm/open-match/values-production.yaml
@@ -106,19 +106,12 @@ configs:
 # https://hub.helm.sh/charts/stable/redis
 # https://github.com/helm/charts/tree/master/stable/redis
 redis:
-  redisPort: 6379
+  architecture: standalone
   auth:
     enabled: false
-    sentinel: false
-    usePasswordFiles: false
-  secretMountPath: /opt/bitnami/redis/secrets
   configmap: |
     maxclients 100000
     maxmemory 500000000
-  sentinel:
-    enabled: true
-    masterSet: om-redis-master
-    port: 26379
   master:
     disableCommands: [] # don't disable 'FLUSH-' commands
     resources:
@@ -132,20 +125,6 @@ redis:
       enabled: false
   metrics:
     enabled: true
-  serviceAccount:
-    create: true
-  replica:
-    disableCommands: [] # don't disable 'FLUSH-' commands
-    replicaCount: 3
-    persistence:
-      enabled: false
-    resources:
-      requests:
-        memory: 1Gi
-        cpu: 1
-      limits:
-        memory: 2Gi
-        cpu: 2
   sysctlImage:
     # Enable this setting in production if you are running Open Match under Linux environment
     enabled: true

--- a/install/helm/open-match/values.yaml
+++ b/install/helm/open-match/values.yaml
@@ -103,28 +103,18 @@ configs:
     configName: '{{ include "openmatch.configmap.override" . }}'
 
 # Override Redis settings
-# https://hub.helm.sh/charts/stable/redis
-# https://github.com/helm/charts/tree/master/stable/redis
+# https://github.com/bitnami/charts/tree/ba40e46ec6831e039f5bf213ab10e9748603ce6c/bitnami/redis
 redis:
-  redisPort: 6379
+  architecture: standalone
   auth:
     enabled: false
-    sentinel: false
-    usePasswordFiles: false
-  secretMountPath: /opt/bitnami/redis/secrets
-  configmap: |
+  commonConfiguration: |
     maxclients 100000
     maxmemory 300000000
-  sentinel:
-    enabled: true
-    masterSet: om-redis-master
-    port: 26379
-    resources:
-      requests:
-        memory: 300Mi
-        cpu: 0.5
   master:
     disableCommands: [] # don't disable 'FLUSH-' commands
+    persistence:
+      enabled: false
     resources:
       requests:
         memory: 300Mi
@@ -138,19 +128,13 @@ redis:
         cpu: 0.5
   metrics:
     enabled: true
-    resources:
-      requests:
-        memory: 300Mi
-        cpu: 0.5
-  serviceAccount:
-    create: true
   sysctlImage:
-    # Enable this setting in production if you are running Open Match under Linux environment
-    enabled: false
+    # Disable this setting in production if you are not running Redis in Linux
+    enabled: true 
     mountHostSys: true
     # Redis may require some changes in the kernel of the host machine to work as expected,
     # in particular increasing the somaxconn value and disabling transparent huge pages.
-    # https://github.com/helm/charts/tree/master/stable/redis#host-kernel-settings
+    # https://docs.bitnami.com/kubernetes/infrastructure/redis/administration/configure-kernel-settings/ 
     command:
       - /bin/sh
       - -c


### PR DESCRIPTION
Combining updates from https://github.com/googleforgames/open-match/issues/1573 and https://github.com/googleforgames/open-match/issues/1541 . This updates the chart to the latest version of Redis and updates values accordingly. Also includes a few other updates to make the ci/cd runnable with the updates.