### PR TITLE
Add feature flag to use Prometheus Operator Service Monitor

### DIFF
--- a/install/helm/open-match/templates/backend.yaml
+++ b/install/helm/open-match/templates/backend.yaml
@@ -101,3 +101,21 @@ spec:
         {{- include "openmatch.container.common" . | nindent 8 }}
         {{- include "kubernetes.probe" (dict "port" .Values.backend.httpPort "isHTTPS" .Values.global.tls.enabled) | nindent 8 }}
 {{- end }}
+{{- if and (index .Values "open-match-core" "enabled") (index .Values "global" "monitoring" "enabled")}} 
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "openmatch.backend.hostName" . }}-service-monitor
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "openmatch.name" . }}
+      component: backend
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+  - port: http
+{{- end }}

--- a/install/helm/open-match/templates/frontend.yaml
+++ b/install/helm/open-match/templates/frontend.yaml
@@ -101,3 +101,21 @@ spec:
         {{- include "openmatch.container.common" . | nindent 8 }}
         {{- include "kubernetes.probe" (dict "port" .Values.frontend.httpPort "isHTTPS" .Values.global.tls.enabled) | nindent 8 }}
 {{- end }}
+{{- if and (index .Values "open-match-core" "enabled") (index .Values "global" "monitoring" "enabled")}} 
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "openmatch.frontend.hostName" . }}-service-monitor
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "openmatch.name" . }}
+      component: frontend
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+  - port: http
+{{- end }}

--- a/install/helm/open-match/templates/query.yaml
+++ b/install/helm/open-match/templates/query.yaml
@@ -101,3 +101,21 @@ spec:
         {{- include "openmatch.container.common" . | nindent 8 }}
         {{- include "kubernetes.probe" (dict "port" .Values.query.httpPort "isHTTPS" .Values.global.tls.enabled) | nindent 8 }}
 {{- end }}
+{{- if and (index .Values "open-match-core" "enabled") (index .Values "global" "monitoring" "enabled")}} 
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "openmatch.query.hostName" . }}-service-monitor
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "openmatch.name" . }}
+      component: query
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+  - port: http
+{{- end }}

--- a/install/helm/open-match/templates/swaggerui.yaml
+++ b/install/helm/open-match/templates/swaggerui.yaml
@@ -76,3 +76,21 @@ spec:
         {{- include "openmatch.container.common" . | nindent 8 }}
         {{- include "kubernetes.probe" (dict "port" .Values.swaggerui.httpPort) | nindent 8 }}
 {{- end }}
+{{- if and (index .Values "open-match-core" "swaggerui" "enabled") (index .Values "global" "monitoring" "enabled")}} 
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "openmatch.swaggerui.hostName" . }}-service-monitor
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "openmatch.name" . }}
+      component: swaggerui
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+  - port: http
+{{- end }}

--- a/install/helm/open-match/templates/synchronizer.yaml
+++ b/install/helm/open-match/templates/synchronizer.yaml
@@ -85,3 +85,21 @@ spec:
         {{- include "openmatch.container.common" . | nindent 8 }}
         {{- include "kubernetes.probe" (dict "port" .Values.synchronizer.httpPort "isHTTPS" .Values.global.tls.enabled) | nindent 8 }}
 {{- end }}
+{{- if and (index .Values "open-match-core" "enabled") (index .Values "global" "monitoring" "enabled")}} 
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "openmatch.synchronizer.hostName" . }}-service-monitor
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "openmatch.name" . }}
+      component: synchronizer
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+  - port: http
+{{- end }}

--- a/install/helm/open-match/values-production.yaml
+++ b/install/helm/open-match/values-production.yaml
@@ -278,6 +278,10 @@ global:
     tag: 0.0.0-dev
     pullPolicy: Always
 
+  # Enable monitoring if you want to create Prometheus Operator Service Monitor for every service
+  monitoring:
+    enabled: false
+
   # Expose the telemetry configurations to all subcharts because prometheus, for example,
   # requires pod-level annotation to customize its scrape path.
   # See definitions in templates/_helpers.tpl - "prometheus.annotations" section for details

--- a/install/helm/open-match/values.yaml
+++ b/install/helm/open-match/values.yaml
@@ -283,7 +283,7 @@ global:
 
   # Enable monitoring if you want to create Prometheus Operator Service Monitor for every service
   monitoring:
-    enabled: true
+    enabled: false
 
   # Expose the telemetry configurations to all subcharts because prometheus, for example,
   # requires pod-level annotation to customize its scrape path.

--- a/install/helm/open-match/values.yaml
+++ b/install/helm/open-match/values.yaml
@@ -281,6 +281,10 @@ global:
     tag: 1.8.1
     pullPolicy: Always
 
+  # Enable monitoring if you want to create Prometheus Operator Service Monitor for every service
+  monitoring:
+    enabled: true
+
   # Expose the telemetry configurations to all subcharts because prometheus, for example,
   # requires pod-level annotation to customize its scrape path.
   # See definitions in templates/_helpers.tpl - "prometheus.annotations" section for details


### PR DESCRIPTION
**What this PR does / Why we need it**:
Add ability to use ServiceMonitor from Prometheus Operator.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #1245`.
-->

