### PR TITLE
Enable annotations on frontend service

### DIFF
--- a/install/helm/open-match/templates/frontend.yaml
+++ b/install/helm/open-match/templates/frontend.yaml
@@ -18,7 +18,13 @@ apiVersion: v1
 metadata:
   name: {{ include "openmatch.frontend.hostName" . }}
   namespace: {{ .Release.Namespace }}
-  annotations: {{- include "openmatch.chartmeta" . | nindent 4 }}
+  annotations:
+    {{- include "openmatch.chartmeta" . | nindent 4 }}
+    {{- if .Values.frontend.service.annotations }}
+    {{- range $key, $value := .Values.frontend.service.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+    {{- end }}
   labels:
     app: {{ template "openmatch.name" . }}
     component: frontend

--- a/install/helm/open-match/values.yaml
+++ b/install/helm/open-match/values.yaml
@@ -63,6 +63,8 @@ frontend: &frontend
   portType: ClusterIP
   replicas: 3
   image: openmatch-frontend
+  service:
+    annotations: {}
 backend: &backend
   hostName:
   grpcPort: 50505
@@ -130,11 +132,11 @@ redis:
     enabled: true
   sysctlImage:
     # Disable this setting in production if you are not running Redis in Linux
-    enabled: true 
+    enabled: true
     mountHostSys: true
     # Redis may require some changes in the kernel of the host machine to work as expected,
     # in particular increasing the somaxconn value and disabling transparent huge pages.
-    # https://docs.bitnami.com/kubernetes/infrastructure/redis/administration/configure-kernel-settings/ 
+    # https://docs.bitnami.com/kubernetes/infrastructure/redis/administration/configure-kernel-settings/
     command:
       - /bin/sh
       - -c


### PR DESCRIPTION
**What this PR does / Why we need it**:
Enable users to add annotations to the frontend service when using the helm chart. With support for annotations, users can customize the service with configuration annotations for:
- [external-dns](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/annotations/annotations.md)
- Cloud load balancers e.g [GCP](https://cloud.google.com/kubernetes-engine/docs/concepts/service-load-balancer-parameters) 

Closes #1441

**Special notes for your reviewer**:
- This PR is effectively the same change proposed in https://github.com/googleforgames/open-match/pull/1487 but that PR was closed and never merged. The issue #1441 should not have been closed.

