### PR TITLE
Arm64 support for OpenMatch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,7 +200,8 @@ ALL_PROTOS = $(GOLANG_PROTOS) $(SWAGGER_JSON_DOCS)
 CMDS = $(notdir $(wildcard cmd/*))
 
 # Names of the individual images, ommiting the openmatch prefix.
-IMAGES = $(CMDS) mmf-go-soloduel mmf-go-backfill base-build
+#IMAGES = $(CMDS) mmf-go-soloduel mmf-go-backfill base-build
+IMAGES = backend base-build
 
 help:
 	@cat Makefile | grep ^\#\# | grep -v ^\#\#\# |cut -c 4-
@@ -246,6 +247,41 @@ build-mmf-go-soloduel-image: docker build-base-build-image
 
 build-mmf-go-backfill-image: docker build-base-build-image
 	docker build -f examples/functions/golang/backfill/Dockerfile -t $(REGISTRY)/openmatch-mmf-go-backfill:$(TAG) -t $(REGISTRY)/openmatch-mmf-go-backfill:$(ALTERNATE_TAG) .
+
+#######################################
+## # Pushes multiarch images to the container registry.
+## push-multiarch-images / push-multiarch-<image name>-image
+##
+PLATFORMS = linux/amd64,linux/arm64
+push-multiarch-images: $(foreach IMAGE,$(IMAGES),push-multiarch-$(IMAGE)-image)
+
+# Include all-protos here so that all dependencies are guaranteed to be downloaded after the base image is created.
+# This is important so that the repository does not have any mutations while building individual images.
+push-multiarch-base-build-image: docker $(ALL_PROTOS)
+	docker buildx build \
+		--platforms $(PLATFORMS) \
+		-f Dockerfile.base-build -t open-match-base-build -t $(REGISTRY)/openmatch-base-build:$(TAG) -t $(REGISTRY)/openmatch-base-build:$(ALTERNATE_TAG) .
+
+$(foreach CMD,$(CMDS),push-multiarch-$(CMD)-image): push-multiarch-%-image: docker push-multiarch-base-build-image
+	docker buildx build \
+		--platforms $(PLATFORMS) \
+		-f Dockerfile.cmd \
+		$(IMAGE_BUILD_ARGS) \
+		--build-arg=IMAGE_TITLE=$* \
+		-t $(REGISTRY)/openmatch-$*:$(TAG) \
+		-t $(REGISTRY)/openmatch-$*:$(ALTERNATE_TAG) \
+		.
+
+push-multiarch-mmf-go-soloduel-image: docker push-multiarch-base-build-image
+	docker buildx build \
+		--platforms $(PLATFORMS) \
+	 	-f examples/functions/golang/soloduel/Dockerfile -t $(REGISTRY)/openmatch-mmf-go-soloduel:$(TAG) -t $(REGISTRY)/openmatch-mmf-go-soloduel:$(ALTERNATE_TAG) .
+
+push-multiarch-mmf-go-backfill-image: docker push-multiarch-base-build-image
+	docker buildx build \
+		--platforms $(PLATFORMS) \
+		-f examples/functions/golang/backfill/Dockerfile -t $(REGISTRY)/openmatch-mmf-go-backfill:$(TAG) -t $(REGISTRY)/openmatch-mmf-go-backfill:$(ALTERNATE_TAG) .
+
 
 #######################################
 ## # Builds and pushes images to your container registry.

--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,9 @@ DASHBOARD_PORT = 9092
 # Open Match Cluster E2E Test Variables
 OPEN_MATCH_CI_LABEL = open-match-ci
 
+#New builder for buildx
+BUILDX_BUILDER = openmatch-builder
+
 # This flag is set when running in Continuous Integration.
 ifdef OPEN_MATCH_CI_MODE
 	export KUBECONFIG = $(HOME)/.kube/config
@@ -200,8 +203,7 @@ ALL_PROTOS = $(GOLANG_PROTOS) $(SWAGGER_JSON_DOCS)
 CMDS = $(notdir $(wildcard cmd/*))
 
 # Names of the individual images, ommiting the openmatch prefix.
-#IMAGES = $(CMDS) mmf-go-soloduel mmf-go-backfill base-build
-IMAGES = backend base-build
+IMAGES = $(CMDS) mmf-go-soloduel mmf-go-backfill base-build
 
 help:
 	@cat Makefile | grep ^\#\# | grep -v ^\#\#\# |cut -c 4-
@@ -252,6 +254,10 @@ build-mmf-go-backfill-image: docker build-base-build-image
 ## # Pushes multiarch images to the container registry.
 ## push-multiarch-images / push-multiarch-<image name>-image
 ##
+
+create-arm64-builder:
+	-docker buildx create --name $(BUILDX_BUILDER)
+
 PLATFORMS = linux/amd64,linux/arm64
 push-multiarch-images: $(foreach IMAGE,$(IMAGES),push-multiarch-$(IMAGE)-image)
 
@@ -259,27 +265,35 @@ push-multiarch-images: $(foreach IMAGE,$(IMAGES),push-multiarch-$(IMAGE)-image)
 # This is important so that the repository does not have any mutations while building individual images.
 push-multiarch-base-build-image: docker $(ALL_PROTOS)
 	docker buildx build \
-		--platforms $(PLATFORMS) \
+		--platform=$(PLATFORMS) \
+		--builder=$(BUILDX_BUILDER) \
+		--push \
 		-f Dockerfile.base-build -t open-match-base-build -t $(REGISTRY)/openmatch-base-build:$(TAG) -t $(REGISTRY)/openmatch-base-build:$(ALTERNATE_TAG) .
 
 $(foreach CMD,$(CMDS),push-multiarch-$(CMD)-image): push-multiarch-%-image: docker push-multiarch-base-build-image
 	docker buildx build \
-		--platforms $(PLATFORMS) \
+		--platform=$(PLATFORMS) \
+		--builder=$(BUILDX_BUILDER) \
 		-f Dockerfile.cmd \
 		$(IMAGE_BUILD_ARGS) \
 		--build-arg=IMAGE_TITLE=$* \
 		-t $(REGISTRY)/openmatch-$*:$(TAG) \
+		--push \
 		-t $(REGISTRY)/openmatch-$*:$(ALTERNATE_TAG) \
 		.
 
 push-multiarch-mmf-go-soloduel-image: docker push-multiarch-base-build-image
 	docker buildx build \
-		--platforms $(PLATFORMS) \
+		--platform=$(PLATFORMS) \
+		--builder=$(BUILDX_BUILDER) \
+		--push \
 	 	-f examples/functions/golang/soloduel/Dockerfile -t $(REGISTRY)/openmatch-mmf-go-soloduel:$(TAG) -t $(REGISTRY)/openmatch-mmf-go-soloduel:$(ALTERNATE_TAG) .
 
 push-multiarch-mmf-go-backfill-image: docker push-multiarch-base-build-image
 	docker buildx build \
-		--platforms $(PLATFORMS) \
+		--platform=$(PLATFORMS) \
+		--builder=$(BUILDX_BUILDER) \
+		--push \
 		-f examples/functions/golang/backfill/Dockerfile -t $(REGISTRY)/openmatch-mmf-go-backfill:$(TAG) -t $(REGISTRY)/openmatch-mmf-go-backfill:$(ALTERNATE_TAG) .
 
 

--- a/Makefile
+++ b/Makefile
@@ -255,7 +255,7 @@ build-mmf-go-backfill-image: docker build-base-build-image
 ## push-multiarch-images / push-multiarch-<image name>-image
 ##
 
-create-arm64-builder:
+create-buildx-builder:
 	-docker buildx create --name $(BUILDX_BUILDER)
 
 PLATFORMS = linux/amd64,linux/arm64

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -137,7 +137,7 @@ steps:
 
 - id: 'Build: Docker Images'
   name: 'gcr.io/$PROJECT_ID/open-match-build'
-  args: ['make', '_GCB_POST_SUBMIT=${_GCB_POST_SUBMIT}', '_GCB_LATEST_VERSION=${_GCB_LATEST_VERSION}', 'SHORT_SHA=${SHORT_SHA}', 'BRANCH_NAME=${BRANCH_NAME}', 'push-images', '-j8']
+  args: ['make', '_GCB_POST_SUBMIT=${_GCB_POST_SUBMIT}', '_GCB_LATEST_VERSION=${_GCB_LATEST_VERSION}', 'SHORT_SHA=${SHORT_SHA}', 'BRANCH_NAME=${BRANCH_NAME}', 'push-multiarch-images', '-j8']
   waitFor: ['Build: Assets']
 
 - id: 'Lint: Format, Vet, Charts'


### PR DESCRIPTION
**What this PR does / Why we need it**:
Pushes multi-arch images for openmatch. This is required for openmatch to work in linux/arm64 platform.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes https://github.com/googleforgames/open-match/issues/1771

**Special notes for your reviewer**:


